### PR TITLE
Prevent env variable values from leaking in code snippets

### DIFF
--- a/src/Analyzers/Reliability/EnvVariableAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvVariableAnalyzer.php
@@ -10,6 +10,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
 /**
  * Checks that all environment variables from .env.example are defined in .env.
@@ -50,10 +51,9 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
         if (! file_exists($envPath)) {
             return $this->failed(
                 '.env file not found',
-                [$this->createIssueWithSnippet(
+                [$this->createIssue(
                     message: '.env file is missing',
-                    filePath: $envPath,
-                    lineNumber: null,
+                    location: new Location($this->getRelativePath($envPath)),
                     severity: Severity::Critical,
                     recommendation: $this->buildMissingEnvFileRecommendation(),
                     code: 'missing-env',
@@ -70,10 +70,9 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
         if ($exampleResult['error'] !== null) {
             return $this->failed(
                 'Failed to parse .env.example file',
-                [$this->createIssueWithSnippet(
+                [$this->createIssue(
                     message: 'Unable to parse .env.example file',
-                    filePath: $envExamplePath,
-                    lineNumber: null,
+                    location: new Location($this->getRelativePath($envExamplePath)),
                     severity: Severity::Critical,
                     recommendation: sprintf(
                         "The .env.example file could not be parsed. Error: %s\n\nEnsure the file is readable and properly formatted.",
@@ -88,10 +87,9 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
         if ($actualResult['error'] !== null) {
             return $this->failed(
                 'Failed to parse .env file',
-                [$this->createIssueWithSnippet(
+                [$this->createIssue(
                     message: 'Unable to parse .env file',
-                    filePath: $envPath,
-                    lineNumber: null,
+                    location: new Location($this->getRelativePath($envPath)),
                     severity: Severity::High,
                     recommendation: sprintf(
                         "The .env file could not be parsed. Error: %s\n\nEnsure the file is readable and properly formatted.",
@@ -137,10 +135,9 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
         if (empty($missingVars) && ! empty($commentedOnlyVars)) {
             return $this->warning(
                 sprintf('Found %d commented environment variable(s)', count($commentedOnlyVars)),
-                [$this->createIssueWithSnippet(
+                [$this->createIssue(
                     message: 'Environment variables are commented out',
-                    filePath: $envPath,
-                    lineNumber: null,
+                    location: new Location($this->getRelativePath($envPath)),
                     severity: Severity::Low,
                     recommendation: $this->buildCommentedVariablesRecommendation($commentedOnlyVars),
                     code: 'commented-variables',
@@ -156,10 +153,9 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
         $issues = [];
 
         if (! empty($missingVars)) {
-            $issues[] = $this->createIssueWithSnippet(
+            $issues[] = $this->createIssue(
                 message: 'Missing environment variables',
-                filePath: $envPath,
-                lineNumber: null,
+                location: new Location($this->getRelativePath($envPath)),
                 severity: Severity::High,
                 recommendation: $this->buildMissingVariablesRecommendation($missingVars),
                 code: 'missing-variables',
@@ -171,10 +167,9 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
         }
 
         if (! empty($commentedOnlyVars)) {
-            $issues[] = $this->createIssueWithSnippet(
+            $issues[] = $this->createIssue(
                 message: 'Environment variables are commented out',
-                filePath: $envPath,
-                lineNumber: null,
+                location: new Location($this->getRelativePath($envPath)),
                 severity: Severity::Low,
                 recommendation: $this->buildCommentedVariablesRecommendation($commentedOnlyVars),
                 code: 'commented-variables',

--- a/src/Analyzers/Security/DebugModeAnalyzer.php
+++ b/src/Analyzers/Security/DebugModeAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
 /**
  * Detects debug mode and debugging-related security issues.
@@ -133,10 +134,9 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
             }
 
             // Create issue only once for the line where APP_DEBUG is actually set
-            $issues[] = $this->createIssueWithSnippet(
+            $issues[] = $this->createIssue(
                 message: 'Debug mode is enabled (APP_DEBUG=true) in '.($appEnv ?: 'unknown').' environment',
-                filePath: $envFile,
-                lineNumber: $debugLineNumber ?? 1, // Fallback to line 1 if not found (shouldn't happen)
+                location: new Location($this->getRelativePath($envFile), $debugLineNumber ?? 1),
                 severity: Severity::Critical,
                 recommendation: 'Set APP_DEBUG=false in production/staging environments to prevent information disclosure',
                 metadata: [

--- a/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
+++ b/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
@@ -216,10 +216,9 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
                     // If it looks like a real value (long enough and not a placeholder)
                     if (! $isPlaceholder && strlen($value) > 20 && ! str_starts_with($value, 'base64:')) {
-                        $issues[] = $this->createIssueWithSnippet(
+                        $issues[] = $this->createIssue(
                             message: sprintf('Sensitive key "%s" may contain real credentials in .env.example', $key),
-                            filePath: $envExample,
-                            lineNumber: $lineNumber + 1,
+                            location: new Location($this->getRelativePath($envExample), $lineNumber + 1),
                             severity: Severity::High,
                             recommendation: 'Replace with placeholder value. .env.example should not contain real credentials',
                             code: $key,
@@ -254,10 +253,9 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
         // Check if .env is ignored
         $ignored = preg_match('/^\s*(?:\.env|\*\.env)\s*$/m', $content) === 1;
         if (! $ignored) {
-            $issues[] = $this->createIssueWithSnippet(
+            $issues[] = $this->createIssue(
                 message: '.env file is not excluded in .gitignore',
-                filePath: $gitignorePath,
-                lineNumber: null,
+                location: new Location($this->getRelativePath($gitignorePath)),
                 severity: Severity::Critical,
                 recommendation: 'Add ".env" to .gitignore to prevent accidentally committing secrets to version control',
                 code: '.env',
@@ -312,10 +310,9 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
         // Return code 0 means file is tracked by git
         if ($returnCode === 0 && is_string($output) && str_contains($output, '.env')) {
-            $issues[] = $this->createIssueWithSnippet(
+            $issues[] = $this->createIssue(
                 message: '.env file is committed to git repository',
-                filePath: $envPath,
-                lineNumber: null,
+                location: new Location($this->getRelativePath($envPath)),
                 severity: Severity::Critical,
                 recommendation: 'Remove .env from git: "git rm --cached .env" and ensure it\'s in .gitignore',
                 code: 'git-tracked',
@@ -347,10 +344,9 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
         // Check if file is world-readable or world-writable (Critical)
         if (($perms & self::WORLD_READABLE) || ($perms & self::WORLD_WRITABLE)) {
-            $issues[] = $this->createIssueWithSnippet(
+            $issues[] = $this->createIssue(
                 message: sprintf('.env file has insecure permissions (%s)', $octal),
-                filePath: $envPath,
-                lineNumber: null,
+                location: new Location($this->getRelativePath($envPath)),
                 severity: Severity::Critical,
                 recommendation: 'Restrict .env permissions: chmod 600 .env',
                 code: 'permissions',
@@ -366,10 +362,9 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
         // Check if file is group-readable or group-writable (Medium)
         if (($perms & self::GROUP_READABLE) || ($perms & self::GROUP_WRITABLE)) {
-            $issues[] = $this->createIssueWithSnippet(
+            $issues[] = $this->createIssue(
                 message: sprintf('.env file has overly permissive permissions (%s)', $octal),
-                filePath: $envPath,
-                lineNumber: null,
+                location: new Location($this->getRelativePath($envPath)),
                 severity: Severity::Medium,
                 recommendation: 'Consider restricting .env permissions: chmod 600 .env (readable only by owner)',
                 code: 'permissions',


### PR DESCRIPTION
 ## Summary                                                                                                                                          
                                                                                                                                                      
  - Replace `createIssueWithSnippet()` with `createIssue()` for all `.env` and `.env.example` file issues                                             
  - Prevents sensitive values (secrets, API keys, passwords) from being exposed in issue reports sent to the platform API                             
  - Updated test to verify code snippets are NOT attached to env file issues                                                                          
                                                                                                                                                      
  ## Affected Analyzers                                                                                                                               
                                                                                                                                                      
  | Analyzer | File | Changes |                                                                                                                       
  |----------|------|---------|                                                                                                                       
  | EnvVariableAnalyzer | `Reliability/EnvVariableAnalyzer.php` | 6 occurrences |                                                                     
  | AppKeyAnalyzer | `Security/AppKeyAnalyzer.php` | 5 occurrences |                                                                                  
  | DebugModeAnalyzer | `Security/DebugModeAnalyzer.php` | 1 occurrence |                                                                             
  | EnvFileSecurityAnalyzer | `Security/EnvFileSecurityAnalyzer.php` | 5 occurrences |                                                                