### PR TITLE
Remove unnecessary Larastan detection check from CollectionCallAnalyzer

### DIFF
--- a/src/Analyzers/Performance/CollectionCallAnalyzer.php
+++ b/src/Analyzers/Performance/CollectionCallAnalyzer.php
@@ -54,17 +54,6 @@ class CollectionCallAnalyzer extends AbstractFileAnalyzer
         );
     }
 
-    public function shouldRun(): bool
-    {
-        // Check if PHPStan and Larastan are available
-        return $this->hasLarastan();
-    }
-
-    public function getSkipReason(): string
-    {
-        return 'Larastan package not installed (required for collection call analysis)';
-    }
-
     protected function runAnalysis(): ResultInterface
     {
         $issues = [];
@@ -136,46 +125,5 @@ class CollectionCallAnalyzer extends AbstractFileAnalyzer
             sprintf('Found %d inefficient collection operation(s) that should be database queries', count($issues)),
             $issues
         );
-    }
-
-    /**
-     * Check if Larastan is installed using capability-based detection.
-     *
-     * This approach is more reliable than checking file paths because it:
-     * - Works regardless of vendor directory structure
-     * - Detects Larastan even if loaded via custom neon config
-     * - Handles different installation methods (Composer, custom autoloading)
-     */
-    protected function hasLarastan(): bool
-    {
-        // For testing: check if PHPStan is mocked
-        if ($this->isMockedPHPStan()) {
-            return true; // Assume Larastan is available when using mocked PHPStan
-        }
-
-        // Primary detection: Check if Larastan classes exist
-        // This works regardless of how Larastan is installed or configured
-        return class_exists('Larastan\\Larastan\\ApplicationServiceProvider')
-            || class_exists('NunoMaduro\\Larastan\\ApplicationServiceProvider');
-    }
-
-    /**
-     * Check if PHPStan instance is a mock (for testing).
-     */
-    private function isMockedPHPStan(): bool
-    {
-        // Check for Mockery mock
-        if (interface_exists('Mockery\MockInterface') && $this->phpStan instanceof \Mockery\MockInterface) {
-            return true;
-        }
-
-        // Check for PHPUnit mock (starts with "Mock_")
-        $className = get_class($this->phpStan);
-        if (str_starts_with($className, 'Mock_')) {
-            return true;
-        }
-
-        // Fallback: check class name for common mock patterns
-        return str_contains($className, 'Mockery') || str_contains($className, 'PHPUnit');
     }
 }

--- a/tests/Unit/Analyzers/Performance/CollectionCallAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/CollectionCallAnalyzerTest.php
@@ -39,21 +39,6 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         return new CollectionCallAnalyzer($phpStan);
     }
 
-    public function test_skips_when_larastan_not_installed(): void
-    {
-        // Create analyzer with real PHPStan instance (not mocked)
-        // This will check for actual Larastan installation
-        $phpStan = new PHPStan;
-        $analyzer = new CollectionCallAnalyzer($phpStan);
-
-        // In test environment, Larastan won't be installed by default
-        $this->assertFalse($analyzer->shouldRun());
-
-        if (method_exists($analyzer, 'getSkipReason')) {
-            $this->assertStringContainsString('Larastan', $analyzer->getSkipReason());
-        }
-    }
-
     public function test_passes_when_no_collection_issues_found(): void
     {
         // Mock PHPStan to return no issues
@@ -577,33 +562,6 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         $this->assertStringContainsString('performance', strtolower($recommendation));
     }
 
-    public function test_skip_reason_mentions_larastan(): void
-    {
-        // Use real PHPStan (not mocked) so it checks for actual Larastan
-        $phpStan = new PHPStan;
-        $analyzer = new CollectionCallAnalyzer($phpStan);
-
-        if (! $analyzer->shouldRun()) {
-            $skipReason = $analyzer->getSkipReason();
-            $this->assertStringContainsString('Larastan', $skipReason);
-            $this->assertStringContainsString('required', $skipReason);
-        } else {
-            // If Larastan is actually installed, test passes
-            $this->assertTrue(true);
-        }
-    }
-
-    public function test_mock_detection_works_for_mockery(): void
-    {
-        /** @var PHPStan&\Mockery\MockInterface $phpStan */
-        $phpStan = Mockery::mock(PHPStan::class);
-
-        $analyzer = new CollectionCallAnalyzer($phpStan);
-
-        // Should detect Mockery mock and return true for hasLarastan
-        $this->assertTrue($analyzer->shouldRun());
-    }
-
     public function test_different_collection_methods_detected(): void
     {
         $phpstanResult = [
@@ -691,22 +649,6 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         $issues = $result->getIssues();
         // All 4 message variations should be detected
         $this->assertCount(4, $issues);
-    }
-
-    public function test_capability_based_detection_works_with_mocked_phpstan(): void
-    {
-        // Test that capability-based detection (via mocked PHPStan) works
-        // regardless of vendor directory structure or file paths
-        /** @var PHPStan&\Mockery\MockInterface $phpStan */
-        $phpStan = Mockery::mock(PHPStan::class);
-
-        $analyzer = new CollectionCallAnalyzer($phpStan);
-
-        // Mock detection should return true (assumes Larastan is available in tests)
-        $this->assertTrue($analyzer->shouldRun());
-
-        // This test proves we don't rely on file paths - only on class existence or mocks
-        // No need to check vendor/larastan/larastan/extension.neon or similar paths
     }
 
     public function test_uses_config_paths_when_paths_not_set(): void


### PR DESCRIPTION
- Removed broken hasLarastan() check that looked for non-existent Larastan classes                                                                  
- Removed shouldRun() and getSkipReason() methods                                                                                                   
- Removed isMockedPHPStan() helper method                                                                                                           
- Removed 4 related tests                                                                                                                           
- All 2328 tests pass, PHPStan Level 9 passes with 0 errors 