### PR TITLE
Fix empty 'At ' display when issue has no location

### DIFF
--- a/src/Support/Reporter.php
+++ b/src/Support/Reporter.php
@@ -123,11 +123,16 @@ class Reporter implements ReporterInterface
 
                         // Show issue locations
                         foreach (array_slice($issues, 0, $displayCount) as $issue) {
+                            // Show message for application-wide issues without location
+                            $displayText = $issue->location === null
+                                ? $issue->message
+                                : "At {$issue->location}";
+
                             // Highlight critical issues with background color
                             if (isset($issue->severity) && $issue->severity->value === 'critical') {
-                                $output[] = $this->color("At {$issue->location}", 'white', 'bg_red');
+                                $output[] = $this->color($displayText, 'white', 'bg_red');
                             } else {
-                                $output[] = $this->color("At {$issue->location}", 'magenta');
+                                $output[] = $this->color($displayText, 'magenta');
                             }
                         }
 
@@ -602,11 +607,16 @@ class Reporter implements ReporterInterface
 
                 // Show issue locations
                 foreach (array_slice($issues, 0, $displayCount) as $issue) {
+                    // Show message for application-wide issues without location
+                    $displayText = $issue->location === null
+                        ? $issue->message
+                        : "At {$issue->location}";
+
                     // Highlight critical issues with background color
                     if (isset($issue->severity) && $issue->severity->value === 'critical') {
-                        $output[] = $this->color("At {$issue->location}", 'white', 'bg_red');
+                        $output[] = $this->color($displayText, 'white', 'bg_red');
                     } else {
-                        $output[] = $this->color("At {$issue->location}", 'magenta');
+                        $output[] = $this->color($displayText, 'magenta');
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Fix awkward empty "At " display when an analyzer reports an issue without a location
- Display the issue message instead for application-wide issues that are not tied to a specific file
- Applied fix to both `toConsole()` and `streamResult()` methods in Reporter.php