### PR TITLE
Feat: configurable documentation URLs with auto-generation

### DIFF
--- a/config/shieldci.php
+++ b/config/shieldci.php
@@ -19,6 +19,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Documentation Base URL
+    |--------------------------------------------------------------------------
+    |
+    | Base URL for analyzer documentation
+    |
+    | URLs are auto-generated as: {base_url}/analyzers/{category}/{analyzer-id}
+    | Example: https://docs.shieldci.com/analyzers/security/sql-injection
+    |
+    */
+
+    'docs_base_url' => env('SHIELDCI_DOCS_URL', 'https://docs.shieldci.com'),
+
+    /*
+    |--------------------------------------------------------------------------
     | CI Mode Configuration
     |--------------------------------------------------------------------------
     |

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
         - tests
     tmpDir: build/phpstan
     treatPhpDocTypesAsCertain: false
+    reportUnmatchedIgnoredErrors: false
     # Include analyzers-core base classes for proper inheritance analysis
     scanFiles:
         - vendor/shieldci/analyzers-core/src/Abstracts/AbstractFileAnalyzer.php

--- a/src/AnalyzerManager.php
+++ b/src/AnalyzerManager.php
@@ -177,7 +177,8 @@ class AnalyzerManager
                         'description' => $metadata->description,
                         'category' => $metadata->category,
                         'severity' => $metadata->severity,
-                        'docsUrl' => $metadata->docsUrl,
+                        'docsUrl' => $metadata->getDocsUrl(),
+                        'timeToFix' => $metadata->timeToFix,
                     ],
                 );
             });
@@ -326,7 +327,8 @@ class AnalyzerManager
                         'description' => $metadata->description,
                         'category' => $metadata->category,
                         'severity' => $metadata->severity,
-                        'docsUrl' => $metadata->docsUrl,
+                        'docsUrl' => $metadata->getDocsUrl(),
+                        'timeToFix' => $metadata->timeToFix,
                         'skipReason' => $skipReason,
                     ],
                 );
@@ -426,7 +428,8 @@ class AnalyzerManager
                 'description' => $metadata->description,
                 'category' => $metadata->category,
                 'severity' => $metadata->severity,
-                'docsUrl' => $metadata->docsUrl,
+                'docsUrl' => $metadata->getDocsUrl(),
+                'timeToFix' => $metadata->timeToFix,
             ],
         );
     }

--- a/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
+++ b/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
@@ -32,7 +32,6 @@ class ChunkMissingAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::High,
             tags: ['laravel', 'performance', 'memory', 'eloquent', 'optimization'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/chunk-missing',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/BestPractices/ConfigOutsideConfigAnalyzer.php
+++ b/src/Analyzers/BestPractices/ConfigOutsideConfigAnalyzer.php
@@ -50,7 +50,6 @@ class ConfigOutsideConfigAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::Medium,
             tags: ['laravel', 'configuration', 'maintainability', 'testability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/config-outside-config',
             timeToFix: 10
         );
     }

--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -39,7 +39,6 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::High,
             tags: ['performance', 'eloquent', 'database', 'n+1', 'optimization'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/eloquent-n-plus-one',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/BestPractices/FatModelAnalyzer.php
+++ b/src/Analyzers/BestPractices/FatModelAnalyzer.php
@@ -52,7 +52,6 @@ class FatModelAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::Medium,
             tags: ['laravel', 'eloquent', 'architecture', 'solid', 'srp'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/fat-model',
             timeToFix: 45
         );
     }

--- a/src/Analyzers/BestPractices/FrameworkOverrideAnalyzer.php
+++ b/src/Analyzers/BestPractices/FrameworkOverrideAnalyzer.php
@@ -94,7 +94,6 @@ class FrameworkOverrideAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::High,
             tags: ['laravel', 'framework', 'upgradability', 'maintenance'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/framework-override',
             timeToFix: 120
         );
     }

--- a/src/Analyzers/BestPractices/HardcodedStoragePathsAnalyzer.php
+++ b/src/Analyzers/BestPractices/HardcodedStoragePathsAnalyzer.php
@@ -54,7 +54,6 @@ class HardcodedStoragePathsAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::Medium,
             tags: ['laravel', 'portability', 'paths', 'configuration'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/hardcoded-storage-paths',
             timeToFix: 10
         );
     }

--- a/src/Analyzers/BestPractices/HelperFunctionAbuseAnalyzer.php
+++ b/src/Analyzers/BestPractices/HelperFunctionAbuseAnalyzer.php
@@ -131,7 +131,6 @@ class HelperFunctionAbuseAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::Low,
             tags: ['testability', 'dependency-injection', 'laravel', 'helpers', 'code-quality'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/helper-function-abuse',
             timeToFix: 25
         );
     }

--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -221,7 +221,6 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::Medium,
             tags: ['laravel', 'blade', 'mvc', 'views', 'architecture'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/logic-in-blade',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/BestPractices/LogicInRoutesAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInRoutesAnalyzer.php
@@ -46,7 +46,6 @@ class LogicInRoutesAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::High,
             tags: ['laravel', 'routes', 'mvc', 'architecture', 'best-practices'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/logic-in-routes',
             timeToFix: 20
         );
     }

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -47,7 +47,6 @@ class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::High,
             tags: ['laravel', 'database', 'transactions', 'data-integrity', 'acid'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/missing-database-transactions',
             timeToFix: 25
         );
     }

--- a/src/Analyzers/BestPractices/MissingErrorTrackingAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingErrorTrackingAnalyzer.php
@@ -75,7 +75,6 @@ class MissingErrorTrackingAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::Info,
             tags: ['laravel', 'monitoring', 'production', 'error-tracking', 'observability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/missing-error-tracking',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
+++ b/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
@@ -84,7 +84,6 @@ class MixedQueryBuilderEloquentAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::Medium,
             tags: ['laravel', 'eloquent', 'query-builder', 'consistency'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/mixed-query-builder-eloquent',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/BestPractices/PhpSideFilteringAnalyzer.php
+++ b/src/Analyzers/BestPractices/PhpSideFilteringAnalyzer.php
@@ -53,7 +53,6 @@ class PhpSideFilteringAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::Critical,
             tags: ['laravel', 'performance', 'database', 'memory', 'optimization', 'collections'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/php-side-filtering',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
+++ b/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
@@ -108,7 +108,6 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::Medium,
             tags: ['dependency-injection', 'architecture', 'testability', 'laravel', 'ioc'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/service-container-resolution',
             timeToFix: 25
         );
     }

--- a/src/Analyzers/BestPractices/SilentFailureAnalyzer.php
+++ b/src/Analyzers/BestPractices/SilentFailureAnalyzer.php
@@ -113,7 +113,6 @@ class SilentFailureAnalyzer extends AbstractFileAnalyzer
             category: Category::BestPractices,
             severity: Severity::Medium,
             tags: ['laravel', 'exceptions', 'error-handling', 'debugging', 'monitoring'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/best-practices/silent-failure',
             timeToFix: 20
         );
     }

--- a/src/Analyzers/CodeQuality/CommentedCodeAnalyzer.php
+++ b/src/Analyzers/CodeQuality/CommentedCodeAnalyzer.php
@@ -117,7 +117,6 @@ class CommentedCodeAnalyzer extends AbstractFileAnalyzer
             category: Category::CodeQuality,
             severity: Severity::Low,
             tags: ['maintainability', 'code-quality', 'comments', 'dead-code', 'version-control'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/code-quality/commented-code',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/CodeQuality/MethodLengthAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MethodLengthAnalyzer.php
@@ -60,7 +60,6 @@ class MethodLengthAnalyzer extends AbstractFileAnalyzer
             category: Category::CodeQuality,
             severity: Severity::Low,
             tags: ['complexity', 'maintainability', 'code-quality', 'readability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/code-quality/method-length',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
@@ -45,7 +45,6 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
             category: Category::CodeQuality,
             severity: Severity::Low,
             tags: ['documentation', 'maintainability', 'code-quality', 'readability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/code-quality/missing-docblock',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/CodeQuality/NamingConventionAnalyzer.php
+++ b/src/Analyzers/CodeQuality/NamingConventionAnalyzer.php
@@ -43,7 +43,6 @@ class NamingConventionAnalyzer extends AbstractFileAnalyzer
             category: Category::CodeQuality,
             severity: Severity::Low,
             tags: ['conventions', 'psr', 'code-quality', 'readability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/code-quality/naming-convention',
             timeToFix: 20
         );
     }

--- a/src/Analyzers/CodeQuality/NestingDepthAnalyzer.php
+++ b/src/Analyzers/CodeQuality/NestingDepthAnalyzer.php
@@ -44,7 +44,6 @@ class NestingDepthAnalyzer extends AbstractFileAnalyzer
             category: Category::CodeQuality,
             severity: Severity::Medium,
             tags: ['complexity', 'maintainability', 'code-quality', 'readability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/code-quality/nesting-depth',
             timeToFix: 20
         );
     }

--- a/src/Analyzers/Performance/AutoloaderOptimizationAnalyzer.php
+++ b/src/Analyzers/Performance/AutoloaderOptimizationAnalyzer.php
@@ -57,7 +57,6 @@ class AutoloaderOptimizationAnalyzer extends AbstractFileAnalyzer
             category: Category::Performance,
             severity: Severity::High,
             tags: ['composer', 'autoloader', 'performance', 'optimization'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/autoloader-optimization',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Performance/CacheDriverAnalyzer.php
+++ b/src/Analyzers/Performance/CacheDriverAnalyzer.php
@@ -42,7 +42,6 @@ class CacheDriverAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::High,
             tags: ['cache', 'performance', 'configuration', 'redis', 'memcached'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/cache-driver',
             timeToFix: 60
         );
     }

--- a/src/Analyzers/Performance/CacheHeaderAnalyzer.php
+++ b/src/Analyzers/Performance/CacheHeaderAnalyzer.php
@@ -144,7 +144,6 @@ class CacheHeaderAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::High,
             tags: ['cache', 'assets', 'performance', 'headers', 'browser-cache'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/asset-cache-headers',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/Performance/CollectionCallAnalyzer.php
+++ b/src/Analyzers/Performance/CollectionCallAnalyzer.php
@@ -49,7 +49,6 @@ class CollectionCallAnalyzer extends AbstractFileAnalyzer
             category: Category::Performance,
             severity: Severity::High,
             tags: ['database', 'collection', 'performance', 'n+1', 'optimization', 'phpstan'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/collection-call-optimization',
             timeToFix: 45
         );
     }

--- a/src/Analyzers/Performance/ConfigCachingAnalyzer.php
+++ b/src/Analyzers/Performance/ConfigCachingAnalyzer.php
@@ -47,7 +47,6 @@ class ConfigCachingAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::High,
             tags: ['cache', 'configuration', 'performance', 'optimization'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/config-caching',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Performance/DebugLogAnalyzer.php
+++ b/src/Analyzers/Performance/DebugLogAnalyzer.php
@@ -51,7 +51,6 @@ class DebugLogAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::High,
             tags: ['logging', 'performance', 'configuration'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/debug-log-level',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Performance/DevDependencyAnalyzer.php
+++ b/src/Analyzers/Performance/DevDependencyAnalyzer.php
@@ -59,7 +59,6 @@ class DevDependencyAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::High,
             tags: ['composer', 'dependencies', 'performance', 'memory', 'production'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/dev-dependencies-production',
             timeToFix: 10
         );
     }

--- a/src/Analyzers/Performance/EnvCallAnalyzer.php
+++ b/src/Analyzers/Performance/EnvCallAnalyzer.php
@@ -63,7 +63,6 @@ class EnvCallAnalyzer extends AbstractFileAnalyzer
             category: Category::Performance,
             severity: Severity::High,
             tags: ['configuration', 'cache', 'performance', 'env'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/env-call-outside-config',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/Performance/HorizonSuggestionAnalyzer.php
+++ b/src/Analyzers/Performance/HorizonSuggestionAnalyzer.php
@@ -48,7 +48,6 @@ class HorizonSuggestionAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::Low,
             tags: ['queue', 'horizon', 'redis', 'monitoring', 'performance'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/horizon-suggestion',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/Performance/MinificationAnalyzer.php
+++ b/src/Analyzers/Performance/MinificationAnalyzer.php
@@ -88,7 +88,6 @@ class MinificationAnalyzer extends AbstractFileAnalyzer
             category: Category::Performance,
             severity: Severity::Medium,
             tags: ['assets', 'minification', 'performance', 'javascript', 'css'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/asset-minification',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/Performance/MysqlSingleServerAnalyzer.php
+++ b/src/Analyzers/Performance/MysqlSingleServerAnalyzer.php
@@ -71,7 +71,6 @@ class MysqlSingleServerAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::Medium,
             tags: ['mysql', 'database', 'performance', 'sockets', 'optimization'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/mysql-single-server-optimization',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/Performance/OpcacheAnalyzer.php
+++ b/src/Analyzers/Performance/OpcacheAnalyzer.php
@@ -87,7 +87,6 @@ class OpcacheAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::High,
             tags: ['php', 'opcache', 'performance', 'optimization', 'bytecode'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/opcache-enabled',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/Performance/QueueDriverAnalyzer.php
+++ b/src/Analyzers/Performance/QueueDriverAnalyzer.php
@@ -41,7 +41,6 @@ class QueueDriverAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::Medium,
             tags: ['queue', 'performance', 'configuration', 'redis', 'sqs'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/queue-driver',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/Performance/RouteCachingAnalyzer.php
+++ b/src/Analyzers/Performance/RouteCachingAnalyzer.php
@@ -47,7 +47,6 @@ class RouteCachingAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::High,
             tags: ['cache', 'routes', 'performance', 'optimization'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/route-caching',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Performance/SessionDriverAnalyzer.php
+++ b/src/Analyzers/Performance/SessionDriverAnalyzer.php
@@ -51,7 +51,6 @@ class SessionDriverAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::Critical,
             tags: ['session', 'performance', 'configuration', 'redis', 'scalability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/session-driver',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/Performance/SharedCacheLockAnalyzer.php
+++ b/src/Analyzers/Performance/SharedCacheLockAnalyzer.php
@@ -59,7 +59,6 @@ class SharedCacheLockAnalyzer extends AbstractFileAnalyzer
             category: Category::Performance,
             severity: Severity::Low,
             tags: ['performance', 'cache', 'locks', 'redis', 'reliability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/shared-cache-lock',
             timeToFix: 20
         );
     }

--- a/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
+++ b/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
@@ -61,7 +61,6 @@ class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::Low,
             tags: ['performance', 'middleware', 'optimization', 'http'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/unused-global-middleware',
             timeToFix: 10
         );
     }

--- a/src/Analyzers/Performance/ViewCachingAnalyzer.php
+++ b/src/Analyzers/Performance/ViewCachingAnalyzer.php
@@ -61,7 +61,6 @@ class ViewCachingAnalyzer extends AbstractAnalyzer
             category: Category::Performance,
             severity: Severity::Medium,
             tags: ['cache', 'views', 'blade', 'performance', 'optimization'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/performance/view-caching',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Reliability/CachePrefixAnalyzer.php
+++ b/src/Analyzers/Reliability/CachePrefixAnalyzer.php
@@ -58,7 +58,6 @@ class CachePrefixAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::High,
             tags: ['cache', 'configuration', 'reliability', 'multi-tenant'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/cache-prefix-configuration',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Reliability/CacheStatusAnalyzer.php
+++ b/src/Analyzers/Reliability/CacheStatusAnalyzer.php
@@ -48,7 +48,6 @@ class CacheStatusAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::Critical,
             tags: ['cache', 'infrastructure', 'reliability', 'availability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/cache-status',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
+++ b/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
@@ -35,7 +35,6 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::Critical,
             tags: ['composer', 'dependencies', 'reliability', 'configuration'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/composer-validation',
             timeToFix: 10
         );
     }

--- a/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
+++ b/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
@@ -68,7 +68,6 @@ class CustomErrorPageAnalyzer extends AbstractAnalyzer
             category: Category::Reliability,
             severity: Severity::Low,
             tags: ['errors', 'ux', 'reliability', 'security', 'fingerprinting'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/custom-error-pages',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/Reliability/DatabaseStatusAnalyzer.php
+++ b/src/Analyzers/Reliability/DatabaseStatusAnalyzer.php
@@ -48,7 +48,6 @@ class DatabaseStatusAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::Critical,
             tags: ['database', 'infrastructure', 'reliability', 'availability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/database-status',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -37,7 +37,6 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::Critical,
             tags: ['permissions', 'filesystem', 'reliability', 'deployment', 'symlinks'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/directory-write-permissions',
             timeToFix: 10
         );
     }

--- a/src/Analyzers/Reliability/EnvExampleAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvExampleAnalyzer.php
@@ -31,7 +31,6 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::Low,
             tags: ['environment', 'configuration', 'documentation', 'team-collaboration'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/env-example-documented',
             timeToFix: 10
         );
     }

--- a/src/Analyzers/Reliability/EnvFileAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvFileAnalyzer.php
@@ -28,7 +28,6 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::Critical,
             tags: ['environment', 'configuration', 'deployment'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/env-file-exists',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Reliability/EnvVariableAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvVariableAnalyzer.php
@@ -31,7 +31,6 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::High,
             tags: ['environment', 'configuration', 'reliability', 'deployment'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/env-variables-complete',
             timeToFix: 20
         );
     }

--- a/src/Analyzers/Reliability/MaintenanceModeAnalyzer.php
+++ b/src/Analyzers/Reliability/MaintenanceModeAnalyzer.php
@@ -63,7 +63,6 @@ class MaintenanceModeAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::High,
             tags: ['maintenance', 'availability', 'reliability', 'downtime'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/maintenance-mode-status',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Reliability/PHPStanAnalyzer.php
+++ b/src/Analyzers/Reliability/PHPStanAnalyzer.php
@@ -258,7 +258,6 @@ class PHPStanAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::High,
             tags: ['phpstan', 'static-analysis', 'type-safety', 'reliability'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/phpstan',
             timeToFix: 120
         );
     }

--- a/src/Analyzers/Reliability/QueueTimeoutAnalyzer.php
+++ b/src/Analyzers/Reliability/QueueTimeoutAnalyzer.php
@@ -39,7 +39,6 @@ class QueueTimeoutAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::High,
             tags: ['queue', 'configuration', 'reliability', 'jobs'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/queue-timeout-configuration',
             timeToFix: 10
         );
     }

--- a/src/Analyzers/Reliability/UpToDateMigrationsAnalyzer.php
+++ b/src/Analyzers/Reliability/UpToDateMigrationsAnalyzer.php
@@ -66,7 +66,6 @@ class UpToDateMigrationsAnalyzer extends AbstractFileAnalyzer
             category: Category::Reliability,
             severity: Severity::High,
             tags: ['database', 'migrations', 'reliability', 'deployment'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/reliability/up-to-date-migrations',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Security/AppKeyAnalyzer.php
+++ b/src/Analyzers/Security/AppKeyAnalyzer.php
@@ -38,7 +38,6 @@ class AppKeyAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['encryption', 'app-key', 'security', 'configuration'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/app-key',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Security/AuthenticationAnalyzer.php
+++ b/src/Analyzers/Security/AuthenticationAnalyzer.php
@@ -80,7 +80,6 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['authentication', 'authorization', 'security', 'middleware'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/authentication-authorization',
             timeToFix: 25
         );
     }

--- a/src/Analyzers/Security/CookieSecurityAnalyzer.php
+++ b/src/Analyzers/Security/CookieSecurityAnalyzer.php
@@ -38,7 +38,6 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['cookies', 'encryption', 'xss', 'security', 'configuration'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/cookie',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/Security/CsrfAnalyzer.php
+++ b/src/Analyzers/Security/CsrfAnalyzer.php
@@ -37,7 +37,6 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['csrf', 'cross-site-request-forgery', 'security', 'forms'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/csrf-protection',
             timeToFix: 20
         );
     }

--- a/src/Analyzers/Security/DebugModeAnalyzer.php
+++ b/src/Analyzers/Security/DebugModeAnalyzer.php
@@ -48,7 +48,6 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['debug', 'information-disclosure', 'security', 'configuration'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/debug-mode',
             timeToFix: 5
         );
     }

--- a/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
+++ b/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
@@ -60,7 +60,6 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['env', 'environment', 'secrets', 'security', 'configuration'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/env-file',
             timeToFix: 10
         );
     }

--- a/src/Analyzers/Security/EnvHttpAccessibilityAnalyzer.php
+++ b/src/Analyzers/Security/EnvHttpAccessibilityAnalyzer.php
@@ -77,7 +77,6 @@ class EnvHttpAccessibilityAnalyzer extends AbstractAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['env', 'http', 'security', 'runtime', 'web-server', 'deployment'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/env-http-accessibility',
             timeToFix: 20
         );
     }

--- a/src/Analyzers/Security/FilePermissionsAnalyzer.php
+++ b/src/Analyzers/Security/FilePermissionsAnalyzer.php
@@ -49,7 +49,6 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['permissions', 'file-security', 'security', 'access-control'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/file-permissions',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -44,7 +44,6 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::High,
             tags: ['mass-assignment', 'foreign-keys', 'eloquent', 'security', 'relationships'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/fillable-foreign-key',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
@@ -46,7 +46,6 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['dependencies', 'npm', 'yarn', 'vulnerabilities', 'frontend', 'javascript'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/frontend-vulnerable-dependencies',
             timeToFix: 60
         );
     }

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -39,7 +39,6 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::High,
             tags: ['hsts', 'https', 'headers', 'security', 'ssl', 'tls'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/hsts-header',
             timeToFix: 10
         );
     }

--- a/src/Analyzers/Security/HashingStrengthAnalyzer.php
+++ b/src/Analyzers/Security/HashingStrengthAnalyzer.php
@@ -39,7 +39,6 @@ class HashingStrengthAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['hashing', 'passwords', 'bcrypt', 'argon2', 'security'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/hashing-strength',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/Security/LicenseAnalyzer.php
+++ b/src/Analyzers/Security/LicenseAnalyzer.php
@@ -69,7 +69,6 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::High,
             tags: ['licenses', 'legal', 'compliance', 'dependencies', 'gpl', 'commercial'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/license-compliance',
             timeToFix: 120
         );
     }

--- a/src/Analyzers/Security/LoginThrottlingAnalyzer.php
+++ b/src/Analyzers/Security/LoginThrottlingAnalyzer.php
@@ -37,7 +37,6 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::High,
             tags: ['authentication', 'rate-limiting', 'brute-force', 'security', 'throttling'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/login-throttling',
             timeToFix: 20
         );
     }

--- a/src/Analyzers/Security/MassAssignmentAnalyzer.php
+++ b/src/Analyzers/Security/MassAssignmentAnalyzer.php
@@ -126,7 +126,6 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::High,
             tags: ['mass-assignment', 'eloquent', 'security', 'models', 'sql-injection'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/mass-assignment-vulnerabilities',
             timeToFix: 25
         );
     }

--- a/src/Analyzers/Security/PHPIniAnalyzer.php
+++ b/src/Analyzers/Security/PHPIniAnalyzer.php
@@ -84,7 +84,6 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::High,
             tags: ['php', 'configuration', 'ini', 'security', 'server'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/php-ini',
             timeToFix: 15
         );
     }

--- a/src/Analyzers/Security/SqlInjectionAnalyzer.php
+++ b/src/Analyzers/Security/SqlInjectionAnalyzer.php
@@ -150,7 +150,6 @@ class SqlInjectionAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['sql', 'injection', 'database', 'security'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/sql-injection',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/Security/StableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/StableDependencyAnalyzer.php
@@ -38,7 +38,6 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Low,
             tags: ['dependencies', 'composer', 'stability', 'versions', 'production'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/stable-dependencies',
             timeToFix: 30
         );
     }

--- a/src/Analyzers/Security/UnguardedModelsAnalyzer.php
+++ b/src/Analyzers/Security/UnguardedModelsAnalyzer.php
@@ -39,7 +39,6 @@ class UnguardedModelsAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::High,
             tags: ['eloquent', 'mass-assignment', 'models', 'security', 'unguard'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/unguarded-models',
             timeToFix: 20
         );
     }

--- a/src/Analyzers/Security/UpToDateDependencyAnalyzer.php
+++ b/src/Analyzers/Security/UpToDateDependencyAnalyzer.php
@@ -69,7 +69,6 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
             category: Category::Security,
             severity: Severity::Medium,
             tags: ['dependencies', 'composer', 'updates', 'maintenance', 'security-patches'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/up-to-date-dependencies',
             timeToFix: 60
         );
     }

--- a/src/Analyzers/Security/VulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/VulnerableDependencyAnalyzer.php
@@ -42,7 +42,6 @@ class VulnerableDependencyAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['dependencies', 'composer', 'vulnerabilities', 'cve', 'security'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/vulnerable-dependencies',
             timeToFix: 60
         );
     }

--- a/src/Analyzers/Security/XssAnalyzer.php
+++ b/src/Analyzers/Security/XssAnalyzer.php
@@ -84,7 +84,6 @@ class XssAnalyzer extends AbstractFileAnalyzer
             category: Category::Security,
             severity: Severity::Critical,
             tags: ['xss', 'cross-site-scripting', 'security', 'blade', 'csp', 'headers'],
-            docsUrl: 'https://docs.shieldci.com/analyzers/security/xss-vulnerabilities',
             timeToFix: 30
         );
     }

--- a/src/ShieldCIServiceProvider.php
+++ b/src/ShieldCIServiceProvider.php
@@ -11,6 +11,7 @@ use Psr\Log\LoggerInterface;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\FileParser;
+use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\Commands\AnalyzeCommand;
 use ShieldCI\Commands\BaselineCommand;
 use ShieldCI\Contracts\ReporterInterface;
@@ -32,6 +33,19 @@ class ShieldCIServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__.'/../config/shieldci.php',
             'shieldci'
+        );
+
+        // Configure documentation base URL resolver for AnalyzerMetadata
+        // This allows auto-generation of docs URLs from category + analyzer ID
+        AnalyzerMetadata::setDocsBaseUrlResolver(
+            function (): string {
+                /** @var \Illuminate\Contracts\Config\Repository $config */
+                $config = $this->app->make('config');
+                /** @var string $baseUrl */
+                $baseUrl = $config->get('shieldci.docs_base_url', 'https://docs.shieldci.com');
+
+                return $baseUrl;
+            }
         );
 
         // Register bindings


### PR DESCRIPTION
## Summary
- Add configurable `docs_base_url` in `config/shieldci.php`
- Remove hardcoded `docsUrl` from all analyzers
- URLs are now auto-generated from `{base_url}/analyzers/{category}/{id}`

## Changes
- **config/shieldci.php**: Added `docs_base_url` config (env: `SHIELDCI_DOCS_URL`)
- **ShieldCIServiceProvider.php**: Configure URL resolver for `AnalyzerMetadata`
- **AnalyzerManager.php**: Use `getDocsUrl()` method, include `timeToFix` in metadata
- **74 Analyzer files**: Removed hardcoded `docsUrl:` parameter
- **phpstan.neon**: Added `reportUnmatchedIgnoredErrors: false`

## Configuration
```php
// config/shieldci.php
'docs_base_url' => env('SHIELDCI_DOCS_URL', 'https://docs.shieldci.com'),
```