### PR TITLE
Rewrite PasswordSecurityAnalyzer: AST-based detection, false-positive fixes, new checks

### DIFF
--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -588,6 +588,12 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
             return true;
         }
 
+        if ($node instanceof Node\Expr\PropertyFetch
+            && $node->name instanceof Node\Identifier
+            && $node->name->name === 'password') {
+            return true;
+        }
+
         if ($node instanceof Node\Expr\ArrayDimFetch
             && $node->dim instanceof Node\Scalar\String_
             && $node->dim->value === 'password') {

--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -387,7 +387,20 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
         array $config,
         array &$issues
     ): void {
-        $isBcrypt = in_array($algoName, ['PASSWORD_DEFAULT', 'PASSWORD_BCRYPT'], true);
+        if ($algoName === 'PASSWORD_DEFAULT') {
+            $issues[] = $this->createIssueWithSnippet(
+                message: 'password_hash() uses PASSWORD_DEFAULT with an explicit options array; options are algorithm-specific and may become invalid if PHP changes the default algorithm',
+                filePath: $file,
+                lineNumber: $call->getStartLine(),
+                severity: Severity::Info,
+                recommendation: 'Use an explicit algorithm constant (PASSWORD_BCRYPT or PASSWORD_ARGON2ID) when passing algorithm-specific options',
+                metadata: ['issue_type' => 'password_default_with_options']
+            );
+
+            return;
+        }
+
+        $isBcrypt = $algoName === 'PASSWORD_BCRYPT';
         $isArgon = in_array($algoName, ['PASSWORD_ARGON2I', 'PASSWORD_ARGON2ID'], true);
 
         foreach ($optionsArray->items as $item) {

--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -1355,20 +1355,6 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
          */
         $config = config('shieldci.password_security', []);
 
-        if (empty($config)) {
-            /** @var array{
-             *    bcrypt_min_rounds?: int,
-             *    argon2_min_memory?: int,
-             *    argon2_min_time?: int,
-             *    argon2_min_threads?: int,
-             *    ignored_paths?: array<int, string>,
-             *    allowed_weak_hash_patterns?: array<int, string>,
-             *    password_confirmation_max_timeout?: int
-             * } $config
-             */
-            $config = config('shieldci.hashing_strength', []);
-        }
-
         return [
             'bcrypt_min_rounds' => ($config['bcrypt_min_rounds'] ?? 12),
             'argon2_min_memory' => ($config['argon2_min_memory'] ?? 65536),

--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -483,14 +483,10 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
     /**
      * Extract a string key from an array item key node.
      */
-    private function extractPasswordHashArrayKey(Node\Expr|Node\Identifier|null $keyNode): ?string
+    private function extractPasswordHashArrayKey(?Node\Expr $keyNode): ?string
     {
         if ($keyNode === null) {
             return null;
-        }
-
-        if ($keyNode instanceof Node\Identifier) {
-            return $keyNode->toString();
         }
 
         if ($keyNode instanceof Node\Scalar\String_) {

--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -697,6 +697,17 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
             }
         }
 
+        if ($node instanceof Node\Expr\MethodCall
+            && $node->name instanceof Node\Identifier
+            && $node->name->name === 'make'
+            && $node->var instanceof Node\Expr\StaticCall
+            && $node->var->class instanceof Node\Name
+            && $node->var->class->toString() === 'Hash'
+            && $node->var->name instanceof Node\Identifier
+            && $node->var->name->name === 'driver') {
+            return true;
+        }
+
         return false;
     }
 

--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -1201,11 +1201,15 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
         }
 
         if ($rehashOnLogin === false) {
-            $lineMap = $this->mapConfigKeyLines($hashingConfigPath);
+            $lineNumber = 1;
+            if (file_exists($hashingConfigPath)) {
+                $lineMap = $this->mapConfigKeyLines($hashingConfigPath);
+                $lineNumber = $lineMap['rehash_on_login'] ?? 1;
+            }
             $issues[] = $this->createIssueWithSnippet(
                 message: 'Password rehashing on login is disabled (rehash_on_login is false)',
                 filePath: $hashingConfigPath,
-                lineNumber: $lineMap['rehash_on_login'] ?? 1,
+                lineNumber: $lineNumber,
                 severity: Severity::Medium,
                 recommendation: "Set 'rehash_on_login' => true in config/hashing.php so passwords are automatically rehashed when algorithm options change",
                 metadata: ['issue_type' => 'rehash_on_login_disabled']


### PR DESCRIPTION
## Summary

Comprehensive rewrite of the `PasswordSecurityAnalyzer` from regex-based to AST-based detection, fixing false positives, eliminating false negatives, and adding several new check areas.

### AST migration & detection engine
- Migrate all weak-hash detection from regex to `nikic/php-parser` AST traversal
- Detect `md5()`, `sha1()`, `hash('sha256', ...)` on password-related arguments only
- Detect `password_hash()` with weak/unknown algorithm constants
- Validate `password_hash()` options arrays (bcrypt cost, Argon2 memory/time/threads)
- Recognise safe hashing patterns: `Hash::make()`, `bcrypt()`, `password_hash()`, `Hash::driver()->make()`, variable-based hashers, wrapped expressions (casts, ternaries, function calls)

### Plain-text password storage detection (new)
- Detect direct property assignments: `$user->password = $request->password`
- Detect inline arrays in Eloquent/DB calls: `User::create(['password' => $request->password])`
- Detect indirect variable passing: `$data = ['password' => ...]; User::create($data)`
- Track hasher variables (`$hasher = Hash::driver()`) to avoid false positives on `$hasher->make()`

### Password rehash detection (new)
- Check `rehash_on_login` config key in `config/hashing.php` (Laravel 11+)
- Flag `rehash_on_login => false` as explicit disable
- Scan for `Hash::needsRehash()` / `password_needs_rehash()` in login flows
- Detect login flows via `Auth::attempt()`, `Auth::login()`, `Fortify::authenticateUsing()`, and `auth()->attempt()`

### False-positive fixes
- Add word-boundary matching to prevent flagging `$passwordResetToken`, `$passwordField`, etc.
- Exclude `database/seeders/` and `database/factories/` from code scanning
- Scan all providers in `app/Providers/` + `bootstrap/app.php` for `Password::defaults()`
- Properly parse `Password::defaults()` closure body via AST (not regex bracket-counting)
- Remove dead `PASSWORD_MD5/SHA1/SHA256` constant checks

### Config key cleanup
- Remove legacy `shieldci.hashing_strength` config fallback — use `shieldci.password_security` exclusively

### Test coverage
- Expanded from 46 to **143 tests** with 184 assertions
- Full suite passes, PHPStan Level 9 clean