### PR TITLE
Refactor LogicInBladeAnalyzer to hybrid regex + AST architecture

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
         "illuminate/http": "^9.0|^10.0|^11.0|^12.0",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/view": "^9.0|^10.0|^11.0|^12.0",
         "larastan/larastan": "^2.0",
         "phpstan/phpstan": "^1.10",
         "shieldci/analyzers-core": "^0.1"

--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -5,223 +5,46 @@ declare(strict_types=1);
 namespace ShieldCI\Analyzers\BestPractices;
 
 use Illuminate\Contracts\Config\Repository as Config;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Support\BladeCompilerFactory;
 
 /**
- * Detects business logic in Blade templates.
+ * Detects business logic in Blade templates using a hybrid regex + AST approach.
  *
- * Finds:
- * - Complex @php blocks (> configurable lines)
- * - Database queries in Blade files
- * - Complex calculations and transformations in views
- * - Business logic patterns in Blade directives
- * - API calls in templates
+ * Pass 1 (regex on raw Blade): Structural checks — @php block size, inline PHP, unclosed blocks.
+ * Pass 2 (AST on compiled PHP): Logic detection — DB queries, API calls, business logic,
+ *         complex calculations, expensive computation, nested @foreach, collection manipulation.
+ *
+ * The AST pass compiles Blade → PHP via BladeCompiler, then parses the compiled PHP with
+ * nikic/php-parser. This gives structural access to static calls, method chains, and function
+ * calls — eliminating multi-line scanning and string/comment false-positive logic entirely.
  */
 class LogicInBladeAnalyzer extends AbstractFileAnalyzer
 {
     public const DEFAULT_MAX_PHP_BLOCK_LINES = 10;
-
-    /** @var array<string> Patterns that are definitely database operations */
-    private const DEFINITE_DB_PATTERNS = [
-        '/\bDB::/',                    // DB facade - always database
-        '/->query\s*\(/',              // Query builder - always database
-    ];
-
-    /**
-     * @var array<string> Self-terminal patterns - the static call IS the final operation.
-     *
-     * These patterns don't need a chained terminal method because they ARE terminal.
-     * Example: User::all(), User::find(1), User::first()
-     * Skipped if class is in NON_ELOQUENT_CLASSES (e.g., Arr::first, Factory::create).
-     */
-    private const SELF_TERMINAL_DB_PATTERNS = [
-        '/::find\s*\(/',               // Model::find(1) - terminal
-        '/::all\s*\(/',                // Model::all() - terminal
-        '/::first\s*\(/',              // Model::first() - terminal (but also Arr::first)
-        '/::create\s*\(/',             // Model::create([]) - terminal (but also Factory/Carbon)
-        '/::update\s*\(/',             // Model::update([]) - terminal
-        '/::delete\s*\(/',             // Model::delete() - terminal
-        '/::insert\s*\(/',             // Model::insert([]) - terminal
-        '/::upsert\s*\(/',             // Model::upsert([]) - terminal
-    ];
-
-    /**
-     * @var array<string> Chain patterns - require terminal method OR FQCN to confirm DB query.
-     *
-     * These patterns start a query chain but don't execute it.
-     * Example: User::where('x', 'y') - needs ->get(), ->first(), etc. to execute
-     * Without terminal, we can't be sure if it's a DB query or a custom class.
-     */
-    private const CHAIN_DB_PATTERNS = [
-        '/::where\s*\(/',              // Could be Eloquent chain or Collection/Arr/custom class
-    ];
-
-    /** @var array<string> Terminal methods that confirm a DB query chain */
-    private const TERMINAL_DB_METHODS = [
-        '->get(',
-        '->first(',
-        '->find(',
-        '->count(',
-        '->exists(',
-        '->pluck(',
-        '->sum(',
-        '->avg(',
-        '->min(',
-        '->max(',
-        '->paginate(',
-    ];
-
-    /** @var array<string> Namespace indicators for Model classes */
-    private const MODEL_NAMESPACE_INDICATORS = [
-        '\\Models\\',
-        '\\Model\\',
-    ];
-
-    /** @var array<string> Variable name patterns that suggest collections, not models */
-    private const COLLECTION_VARIABLE_PATTERNS = [
-        'collection',
-        'items',
-        'list',
-        'array',
-        'data',
-        'results',
-        'rows',
-        'records',
-        'entries',
-    ];
-
-    /** @var array<string> */
-    private const BUSINESS_LOGIC_FUNCTIONS = [
-        'array_filter', 'array_map', 'array_reduce', 'array_walk',
-        'array_merge', 'array_combine', 'array_diff',
-    ];
-
-    /** @var array<string> Non-database get methods to exclude */
-    private const NON_DB_GET_METHODS = [
-        'config()',
-        'session()',
-        'cache()',
-        'request()',
-        'cookie()',
-    ];
-
-    /** @var array<string> Extended list of non-database save method variable names */
-    private const NON_DB_SAVE_VARIABLES = [
-        'file',
-        'upload',
-        'image',
-        'photo',
-        'document',
-        'attachment',
-        'pdf',
-        'excel',
-        'csv',
-        'export',
-        'cache',
-        'temp',
-        'storage',
-    ];
-
-    /** @var array<string> Additional collection methods that indicate business logic */
-    private const COLLECTION_MANIPULATION_METHODS = [
-        'pluck',
-        'unique',
-        'chunk',
-        'groupBy',
-        'keyBy',
-        'reverse',
-        'shuffle',
-        'values',
-        'keys',
-    ];
-
-    /** @var array<string> Expensive string processing functions */
-    private const EXPENSIVE_STRING_FUNCTIONS = [
-        'preg_match', 'preg_replace', 'preg_match_all', 'preg_split',
-        'str_replace', 'str_ireplace', 'substr_replace', 'mb_ereg_replace',
-    ];
-
-    /** @var array<string> Expensive collection methods on large datasets */
-    private const EXPENSIVE_COLLECTION_METHODS = [
-        '->toArray(', '->all(', '->toJson(', '->jsonSerialize(',
-    ];
-
-    /** @var array<string> Non-Eloquent classes with DB-like method names */
-    private const NON_ELOQUENT_CLASSES = [
-        'Collection',
-        'Arr',
-        'Carbon',
-        'CarbonImmutable',
-        'DateTime',
-        'DateTimeImmutable',
-        'Factory',
-        'Str',
-        'Validator',
-    ];
-
-    /**
-     * @var array<string> Class name suffixes that are NEVER Eloquent models.
-     *
-     * These suffixes indicate classes that definitively cannot be Eloquent models,
-     * so we skip them unconditionally.
-     */
-    private const DEFINITE_NON_MODEL_SUFFIXES = [
-        'Service',
-        'Repository',
-        'Helper',
-        'Handler',
-        'Provider',
-        'Facade',
-        'Controller',
-        'Middleware',
-        'Policy',
-        'Event',
-        'Listener',
-        'Job',
-        'Mail',
-        'Notification',
-        'Command',
-        'Request',
-        'Rule',
-        'Exception',
-        'Trait',
-        'Interface',
-        'Contract',
-        'Test',
-        'Seeder',
-        'Migration',
-        'Observer',
-        'Scope',
-        'Cast',
-        'Enum',
-        'Factory',
-        'Action',
-    ];
-
-    /**
-     * @var array<string> Class name suffixes that MIGHT be Eloquent models.
-     *
-     * These suffixes are ambiguous - they could be model names like "OrderResource"
-     * or non-model classes like "ApiResource". We only skip them if there's NO
-     * terminal method present. If a terminal method IS present, we flag it.
-     */
-    private const AMBIGUOUS_SUFFIXES = [
-        'Resource',
-        'Manager',
-        'Builder',
-    ];
 
     private int $maxPhpBlockLines;
 
     /** @var array<int, true> Track reported lines to avoid duplicates */
     private array $reportedLines = [];
 
-    public function __construct(private Config $config) {}
+    public function __construct(
+        private Config $config,
+        private AstParser $astParser = new AstParser,
+    ) {}
 
     protected function metadata(): AnalyzerMetadata
     {
@@ -288,6 +111,11 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
         return $files;
     }
 
+    /**
+     * Two-pass analysis: structural regex checks + AST logic detection.
+     *
+     * @param  array<int, array{message: string, filePath: string, lineNumber: int, severity: Severity, recommendation: string, code: string, metadata: array<string, mixed>}>  $issues
+     */
     private function analyzeBladeFile(string $file, array &$issues): void
     {
         $content = FileParser::readFile($file);
@@ -297,20 +125,32 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
 
         $lines = FileParser::getLines($file);
 
-        // Track PHP blocks
+        // Pass 1: Structural checks on raw Blade (PHP block size, inline PHP, unclosed blocks)
+        $this->analyzeBladeStructure($file, $lines, $issues);
+
+        // Pass 2: Logic detection via compiled PHP AST
+        $this->analyzeBladeLogic($file, $content, $issues);
+    }
+
+    /**
+     * Pass 1: Structural checks using regex on raw Blade source.
+     *
+     * Detects:
+     * - @php blocks exceeding max line threshold
+     * - Inline <?php tags
+     * - Unclosed @php blocks
+     *
+     * @param  array<int, string>  $lines
+     * @param  array<int, array{message: string, filePath: string, lineNumber: int, severity: Severity, recommendation: string, code: string, metadata: array<string, mixed>}>  $issues
+     */
+    private function analyzeBladeStructure(string $file, array $lines, array &$issues): void
+    {
         $inPhpBlock = false;
         $phpBlockStart = 0;
         $phpBlockLines = 0;
-        $foreachDepth = 0;
-        $inBlockComment = false;
 
         foreach ($lines as $lineNumber => $line) {
             $trimmed = trim($line);
-
-            // Skip if we've already reported an issue for this line
-            if (isset($this->reportedLines[$lineNumber])) {
-                continue;
-            }
 
             // Check for @php block start
             if (preg_match('/@php\b/', $trimmed)) {
@@ -318,13 +158,11 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
                 $phpBlockStart = $lineNumber + 1;
                 $phpBlockLines = 0;
 
-                // Don't count the @php line itself - continue to next line
                 continue;
             }
 
-            // Check for @php block end (before counting)
+            // Check for @php block end
             if (preg_match('/@endphp\b/', $trimmed)) {
-                // Don't count the @endphp line itself
                 if ($phpBlockLines > $this->maxPhpBlockLines) {
                     $this->reportedLines[$phpBlockStart - 1] = true;
 
@@ -351,37 +189,12 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
                 continue;
             }
 
-            // Count lines in PHP block (only lines between @php and @endphp)
+            // Count lines in PHP block
             if ($inPhpBlock) {
                 $phpBlockLines++;
             }
 
-            // Block comment tracking
-            if (! $inBlockComment && $this->lineOpensBlockComment($line)) {
-                $inBlockComment = true;
-                // Check if the same line also closes the block comment: /* ... */
-                if ($this->lineClosesBlockComment($line)) {
-                    $inBlockComment = false;
-                }
-
-                continue;
-            }
-            if ($inBlockComment) {
-                if ($this->lineClosesBlockComment($line)) {
-                    $inBlockComment = false;
-                }
-
-                continue; // Skip all detection inside block comments
-            }
-
-            // Track @foreach depth for nested loop detection
-            if (preg_match('/@foreach\b/', $trimmed)) {
-                $foreachDepth++;
-            }
-            if (preg_match('/@endforeach\b/', $trimmed)) {
-                $foreachDepth = max(0, $foreachDepth - 1);
-            }
-
+            // Detect inline <?php tags
             if (preg_match('/<\?php/', $line)) {
                 $this->reportedLines[$lineNumber] = true;
 
@@ -395,127 +208,9 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
                     metadata: ['line' => $lineNumber + 1]
                 );
             }
-
-            // Check for DB queries (highest priority)
-            if ($this->hasDbQuery($line)) {
-                $this->reportedLines[$lineNumber] = true;
-
-                $issues[] = $this->createIssueWithSnippet(
-                    message: 'Database query found in Blade template',
-                    filePath: $file,
-                    lineNumber: $lineNumber + 1,
-                    severity: Severity::Critical,
-                    recommendation: 'Never query the database from Blade templates. Load all required data in the controller and pass it to the view',
-                    code: 'blade-has-db-query',
-                    metadata: ['line' => $lineNumber + 1]
-                );
-
-                continue; // Don't check other patterns if we found a DB query
-            }
-
-            // Multi-line DB chain detection (e.g., User::where(...)\n    ->get())
-            $chainStartPos = $this->getChainStartPosition($line);
-            if ($chainStartPos >= 0 && $this->scanForwardForTerminal($lines, $lineNumber, $chainStartPos, $line)) {
-                $this->reportedLines[$lineNumber] = true;
-
-                $issues[] = $this->createIssueWithSnippet(
-                    message: 'Database query found in Blade template',
-                    filePath: $file,
-                    lineNumber: $lineNumber + 1,
-                    severity: Severity::Critical,
-                    recommendation: 'Never query the database from Blade templates. Load all required data in the controller and pass it to the view',
-                    code: 'blade-has-db-query',
-                    metadata: ['line' => $lineNumber + 1]
-                );
-
-                continue;
-            }
-
-            // Check for API calls
-            if ($this->hasApiCall($line)) {
-                $this->reportedLines[$lineNumber] = true;
-
-                $issues[] = $this->createIssueWithSnippet(
-                    message: 'API call found in Blade template',
-                    filePath: $file,
-                    lineNumber: $lineNumber + 1,
-                    severity: Severity::High,
-                    recommendation: 'Make API calls in controllers or services, not in views. Views should only display pre-fetched data',
-                    code: 'blade-has-api-call',
-                    metadata: ['line' => $lineNumber + 1]
-                );
-
-                continue;
-            }
-
-            // Check for expensive computation
-            if ($this->hasExpensiveComputation($line, $foreachDepth)) {
-                $this->reportedLines[$lineNumber] = true;
-
-                $issues[] = $this->createIssueWithSnippet(
-                    message: 'Expensive computation found in Blade template',
-                    filePath: $file,
-                    lineNumber: $lineNumber + 1,
-                    severity: Severity::Medium,
-                    recommendation: 'Move expensive operations to controllers or services. Use computed properties or view composers for complex transformations',
-                    code: 'blade-expensive-computation',
-                    metadata: ['line' => $lineNumber + 1]
-                );
-
-                continue;
-            }
-
-            // Check for nested @foreach
-            if ($foreachDepth >= 2 && preg_match('/@foreach\b/', $trimmed)) {
-                $this->reportedLines[$lineNumber] = true;
-
-                $issues[] = $this->createIssueWithSnippet(
-                    message: sprintf('Nested @foreach detected (depth: %d) - potential performance issue', $foreachDepth),
-                    filePath: $file,
-                    lineNumber: $lineNumber + 1,
-                    severity: Severity::Medium,
-                    recommendation: 'Flatten nested data in the controller using eager loading or collection methods. Deeply nested loops in Blade can cause O(n²) or worse rendering performance',
-                    code: 'blade-nested-foreach',
-                    metadata: ['line' => $lineNumber + 1, 'depth' => $foreachDepth]
-                );
-
-                continue;
-            }
-
-            // Check for business logic patterns in Blade directives
-            if ($this->hasBusinessLogicInDirective($line)) {
-                $this->reportedLines[$lineNumber] = true;
-
-                $issues[] = $this->createIssueWithSnippet(
-                    message: 'Business logic found in Blade directive',
-                    filePath: $file,
-                    lineNumber: $lineNumber + 1,
-                    severity: Severity::Medium,
-                    recommendation: 'Extract business logic to controllers or services. Use simple conditionals in views for presentation logic only',
-                    code: 'blade-has-business-logic',
-                    metadata: ['line' => $lineNumber + 1]
-                );
-
-                continue;
-            }
-
-            // Check for complex calculations (lowest priority)
-            if ($this->hasComplexCalculation($line)) {
-                $this->reportedLines[$lineNumber] = true;
-
-                $issues[] = $this->createIssueWithSnippet(
-                    message: 'Complex calculation found in Blade template',
-                    filePath: $file,
-                    lineNumber: $lineNumber + 1,
-                    severity: Severity::Low,
-                    recommendation: 'Move calculations to controller, view composer, or model accessor. Blade should only display pre-calculated values',
-                    code: 'blade-has-calculation',
-                    metadata: ['line' => $lineNumber + 1]
-                );
-            }
         }
 
-        // Check for unclosed PHP blocks
+        // Unclosed @php block
         if ($inPhpBlock) {
             $issues[] = $this->createIssueWithSnippet(
                 message: 'Unclosed @php block detected',
@@ -532,297 +227,687 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
         }
     }
 
-    private function hasDbQuery(string $line): bool
-    {
-        // Fast-path: skip if line has no static call or arrow operator
-        if (! str_contains($line, '::') && ! str_contains($line, '->')) {
-            return false;
-        }
-
-        // First, check if this is a non-database get method
-        foreach (self::NON_DB_GET_METHODS as $nonDbMethod) {
-            if (str_contains($line, $nonDbMethod) && str_contains($line, '->get(')) {
-                return false; // It's config/session/cache/request()->get(), not a DB query
-            }
-        }
-
-        // Check definite DB patterns first (always flag)
-        foreach (self::DEFINITE_DB_PATTERNS as $pattern) {
-            if (preg_match($pattern, $line, $matches, PREG_OFFSET_CAPTURE)) {
-                if ($this->isInsideStringOrComment($line, $matches[0][1])) {
-                    continue;
-                }
-
-                return true;
-            }
-        }
-
-        // Check self-terminal patterns (::all(), ::find(), ::first(), ::create(), etc.)
-        // These ARE terminal operations - they don't need a chained method
-        foreach (self::SELF_TERMINAL_DB_PATTERNS as $pattern) {
-            if (preg_match($pattern, $line, $matches, PREG_OFFSET_CAPTURE)) {
-                if ($this->isInsideStringOrComment($line, $matches[0][1])) {
-                    continue;
-                }
-
-                // Skip known non-Eloquent static calls (Arr::first, Carbon::create, Factory::create, etc.)
-                if ($this->isNonEloquentStaticCall($line, $matches[0][1])) {
-                    continue;
-                }
-
-                // Self-terminal patterns are flagged unless whitelisted
-                return true;
-            }
-        }
-
-        // Check chain patterns (::where() etc.) - require terminal method OR FQCN
-        foreach (self::CHAIN_DB_PATTERNS as $pattern) {
-            if (preg_match($pattern, $line, $matches, PREG_OFFSET_CAPTURE)) {
-                // Check if the match is inside a string or comment
-                if ($this->isInsideStringOrComment($line, $matches[0][1])) {
-                    continue;
-                }
-
-                // Skip known non-Eloquent static calls (Collection::where, Arr::where)
-                if ($this->isNonEloquentStaticCall($line, $matches[0][1])) {
-                    continue;
-                }
-
-                // Check if FQCN contains Models namespace - definitely a model
-                if ($this->isFromModelsNamespace($line, $matches[0][1])) {
-                    return true;
-                }
-
-                // For short class names, require terminal method to confirm it's a DB query
-                if ($this->hasTerminalMethod($line)) {
-                    return true;
-                }
-
-                // Uncertain case: short class name without terminal method
-                // Don't flag to avoid false positives (e.g., SomeQueryBuilder::where('x', 'y'))
-                continue;
-            }
-        }
-
-        // Check for model save (but exclude file uploads and other non-DB patterns)
-        if (preg_match('/\$(\w+)->save\s*\(/', $line, $matches, PREG_OFFSET_CAPTURE)) {
-            // Check if the match is inside a string or comment
-            if ($this->isInsideStringOrComment($line, $matches[0][1])) {
-                return false;
-            }
-
-            // Exclude common non-database save patterns
-            $variableName = $matches[1][0];
-            if (in_array($variableName, self::NON_DB_SAVE_VARIABLES, true)) {
-                return false;
-            }
-
-            return true; // Likely a model save
-        }
-
-        // Check for relationship queries with various terminal methods
-        if (preg_match('/\$(\w+)->(\w+)\(\)->(get|first|find|count|exists|pluck|sum|avg|min|max)\s*\(/', $line, $matches, PREG_OFFSET_CAPTURE)) {
-            // Check if the match is inside a string or comment
-            if ($this->isInsideStringOrComment($line, $matches[0][1])) {
-                return false;
-            }
-
-            // Check if variable name suggests a collection, not a model
-            $variableName = strtolower($matches[1][0]);
-            foreach (self::COLLECTION_VARIABLE_PATTERNS as $collectionPattern) {
-                if (str_contains($variableName, $collectionPattern)) {
-                    return false; // Likely a collection, not a model relationship
-                }
-            }
-
-            return true; // Likely $user->posts()->get(), $user->posts()->first(), etc.
-        }
-
-        return false;
-    }
-
     /**
-     * Check if the class in a static call comes from a Models namespace.
-     */
-    private function isFromModelsNamespace(string $line, int $matchPosition): bool
-    {
-        $beforeMatch = substr($line, 0, $matchPosition);
-
-        foreach (self::MODEL_NAMESPACE_INDICATORS as $indicator) {
-            if (str_contains($beforeMatch, $indicator)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Get the match position of a chain start pattern (::where() without terminal on same line).
+     * Pass 2: Logic detection via compiled PHP AST.
      *
-     * Returns -1 if no actionable chain start found.
-     */
-    private function getChainStartPosition(string $line): int
-    {
-        // Only check CHAIN_DB_PATTERNS (::where etc.)
-        foreach (self::CHAIN_DB_PATTERNS as $pattern) {
-            if (! preg_match($pattern, $line, $matches, PREG_OFFSET_CAPTURE)) {
-                continue;
-            }
-
-            $matchPos = $matches[0][1];
-
-            if ($this->isInsideStringOrComment($line, $matchPos)) {
-                continue;
-            }
-
-            // Skip definite non-Eloquent classes, but allow ambiguous suffixes through
-            // for forward scanning (terminal may be on the next line)
-            if ($this->isNonEloquentStaticCall($line, $matchPos)
-                && ! $this->hasAmbiguousSuffixClass($line, $matchPos)) {
-                continue;
-            }
-
-            // If terminal method is already on the same line, hasDbQuery() handles it
-            if ($this->hasTerminalMethod($line)) {
-                return -1;
-            }
-
-            // If FQCN with Models namespace, hasDbQuery() already handles it
-            if ($this->isFromModelsNamespace($line, $matchPos)) {
-                return -1;
-            }
-
-            return $matchPos;
-        }
-
-        return -1;
-    }
-
-    /**
-     * Forward-scan from a chain start line to find a terminal method on continuation lines.
+     * Compiles Blade → PHP, parses with nikic/php-parser, traverses the AST
+     * with BladeLogicVisitor to detect business logic patterns, then maps
+     * compiled-PHP line numbers back to original Blade lines.
      *
-     * @param  array<int, string>  $lines  All lines in the file (0-indexed keys)
-     * @param  int  $startLine  The 0-indexed line number of the chain start
-     * @param  int  $chainStartPos  The character position of the chain start on the start line
-     * @param  string  $startLineContent  The content of the start line
+     * @param  array<int, array{message: string, filePath: string, lineNumber: int, severity: Severity, recommendation: string, code: string, metadata: array<string, mixed>}>  $issues
      */
-    private function scanForwardForTerminal(array $lines, int $startLine, int $chainStartPos, string $startLineContent): bool
+    private function analyzeBladeLogic(string $file, string $content, array &$issues): void
     {
-        // If the starting line has a FQCN from \Models\ namespace — always a DB query
-        if ($this->isFromModelsNamespace($startLineContent, $chainStartPos)) {
-            return true;
+        $result = BladeCompilerFactory::compile($content);
+        if ($result === null) {
+            return;
         }
 
-        $lineKeys = array_keys($lines);
-        $startIndex = array_search($startLine, $lineKeys, true);
-        if ($startIndex === false) {
-            return false;
+        $ast = $this->astParser->parseCode($result['compiledPhp']);
+        if (empty($ast)) {
+            return;
         }
 
-        $maxLookahead = 20;
-        $scanned = 0;
+        $visitor = new BladeLogicVisitor;
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
 
-        for ($i = $startIndex + 1; $i < count($lineKeys) && $scanned < $maxLookahead; $i++, $scanned++) {
-            $nextLine = $lines[$lineKeys[$i]];
-            $trimmedNext = trim($nextLine);
+        $lineMap = $result['lineMap'];
 
-            // Stop at blank lines
-            if ($trimmedNext === '') {
-                return false;
+        foreach ($visitor->getIssues() as $astIssue) {
+            $compiledLine = $astIssue['line'];
+            $originalLine = $lineMap[$compiledLine] ?? null;
+
+            if ($originalLine === null) {
+                continue;
             }
 
-            // Stop at @endphp boundary
-            if (preg_match('/@endphp\b/', $trimmedNext)) {
-                return false;
+            // Use 0-indexed key for reportedLines (consistent with Pass 1)
+            $lineKey = $originalLine - 1;
+            if (isset($this->reportedLines[$lineKey])) {
+                continue;
             }
 
-            // Only chain continuation lines start with ->
-            if (! str_starts_with($trimmedNext, '->')) {
-                return false;
-            }
+            $this->reportedLines[$lineKey] = true;
 
-            // Check if this continuation line has a terminal method
-            if ($this->hasTerminalMethod($nextLine)) {
-                return true;
-            }
+            $metadata = array_merge(['line' => $originalLine], $astIssue['metadata'] ?? []);
 
-            // If the line ends with a semicolon, the chain ended without a terminal
-            if (str_ends_with($trimmedNext, ';')) {
-                return false;
-            }
+            $issues[] = $this->createIssueWithSnippet(
+                message: $astIssue['message'],
+                filePath: $file,
+                lineNumber: $originalLine,
+                severity: $astIssue['severity'],
+                recommendation: $astIssue['recommendation'],
+                code: $astIssue['code'],
+                metadata: $metadata
+            );
         }
-
-        return false;
     }
+}
+
+/**
+ * AST visitor that detects business logic patterns in compiled Blade PHP.
+ *
+ * Traverses the AST once, collecting issues for:
+ * - DB queries (static calls, method chains, model save)
+ * - API calls (Http facade, curl, file_get_contents)
+ * - Business logic functions (array_filter, array_map, etc.)
+ * - Complex @if conditions (4+ boolean operators)
+ * - Expensive computation (toArray, toJson, regex in loops)
+ * - Complex calculations (multiple arithmetic operators, compound assignment)
+ * - Nested @foreach loops
+ * - Collection manipulation in @foreach expressions
+ */
+class BladeLogicVisitor extends NodeVisitorAbstract
+{
+    private int $foreachDepth = 0;
+
+    /** @var list<array{message: string, severity: Severity, recommendation: string, code: string, line: int, metadata: array<string, mixed>}> */
+    private array $issues = [];
+
+    /** @var array<string> Non-Eloquent classes with DB-like method names */
+    private const NON_ELOQUENT_CLASSES = [
+        'Collection',
+        'Arr',
+        'Carbon',
+        'CarbonImmutable',
+        'DateTime',
+        'DateTimeImmutable',
+        'Factory',
+        'Str',
+        'Validator',
+    ];
+
+    /** @var array<string> Class name suffixes that are NEVER Eloquent models */
+    private const DEFINITE_NON_MODEL_SUFFIXES = [
+        'Service', 'Repository', 'Helper', 'Handler', 'Provider', 'Facade',
+        'Controller', 'Middleware', 'Policy', 'Event', 'Listener', 'Job',
+        'Mail', 'Notification', 'Command', 'Request', 'Rule', 'Exception',
+        'Trait', 'Interface', 'Contract', 'Test', 'Seeder', 'Migration',
+        'Observer', 'Scope', 'Cast', 'Enum', 'Factory', 'Action',
+    ];
+
+    /** @var array<string> Variable name patterns that suggest collections, not models */
+    private const COLLECTION_VARIABLE_PATTERNS = [
+        'collection', 'items', 'list', 'array', 'data',
+        'results', 'rows', 'records', 'entries',
+    ];
+
+    /** @var array<string> Variables whose ->save() is not a DB operation */
+    private const NON_DB_SAVE_VARIABLES = [
+        'file', 'upload', 'image', 'photo', 'document', 'attachment',
+        'pdf', 'excel', 'csv', 'export', 'cache', 'temp', 'storage',
+    ];
+
+    /** @var array<string> */
+    private const BUSINESS_LOGIC_FUNCTIONS = [
+        'array_filter', 'array_map', 'array_reduce', 'array_walk',
+        'array_merge', 'array_combine', 'array_diff',
+    ];
+
+    /** @var array<string> */
+    private const EXPENSIVE_STRING_FUNCTIONS = [
+        'preg_match', 'preg_replace', 'preg_match_all', 'preg_split',
+        'str_replace', 'str_ireplace', 'substr_replace', 'mb_ereg_replace',
+    ];
+
+    /** @var array<string> Expensive collection methods */
+    private const EXPENSIVE_COLLECTION_METHODS = [
+        'toArray', 'all', 'toJson', 'jsonSerialize',
+    ];
+
+    /** @var array<string> Terminal methods that confirm a DB query chain */
+    private const TERMINAL_QUERY_METHODS = [
+        'get', 'first', 'find', 'count', 'exists',
+        'pluck', 'sum', 'avg', 'min', 'max', 'paginate',
+    ];
+
+    /** @var array<string> Self-terminal static methods (the call IS the operation) */
+    private const SELF_TERMINAL_METHODS = [
+        'find', 'all', 'first', 'create', 'update',
+        'delete', 'insert', 'upsert',
+    ];
+
+    /** @var array<string> API-related function names */
+    private const API_FUNCTIONS = ['curl_init', 'curl_exec', 'file_get_contents'];
+
+    /** @var array<string> Collection manipulation methods flagged in @foreach */
+    private const COLLECTION_MANIPULATION_METHODS = [
+        'filter', 'map', 'transform', 'sortBy',
+        'pluck', 'unique', 'chunk', 'groupBy', 'keyBy',
+        'reverse', 'shuffle', 'values', 'keys',
+    ];
 
     /**
-     * Check if the line contains a terminal method that confirms a DB query.
+     * @return list<array{message: string, severity: Severity, recommendation: string, code: string, line: int, metadata: array<string, mixed>}>
      */
-    private function hasTerminalMethod(string $line): bool
+    public function getIssues(): array
     {
-        foreach (self::TERMINAL_DB_METHODS as $terminal) {
-            if (str_contains($line, $terminal)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->issues;
     }
 
-    /**
-     * Check if a static method call is from a non-Eloquent class.
-     *
-     * Classes like Collection, Arr, Carbon have methods (where, first, all, create)
-     * that look like Eloquent queries but are not database operations.
-     */
-    private function isNonEloquentStaticCall(string $line, int $matchPosition): bool
+    public function enterNode(Node $node): ?int
     {
-        $beforeMatch = substr($line, 0, $matchPosition);
-        $trimmed = rtrim($beforeMatch);
+        // Track foreach depth
+        if ($node instanceof Stmt\Foreach_) {
+            $this->foreachDepth++;
 
-        // Dynamic class resolution - uncertain, so don't flag
-        // e.g., ($foo ? Arr : Model)::where(), $class::where()
-        if (str_ends_with($trimmed, ')') || preg_match('/\$\w+$/', $trimmed)) {
-            return true;
-        }
-
-        // Extract class name from FQCN: \Illuminate\Support\Collection -> Collection
-        // Handles: Collection, \Collection, Some\Namespace\Collection
-        if (preg_match('/\\\\?(?:[A-Za-z_][A-Za-z0-9_]*\\\\)*([A-Za-z_][A-Za-z0-9_]*)$/', $trimmed, $matches)) {
-            $className = $matches[1];
-
-            // Check exact class name match
-            if (in_array($className, self::NON_ELOQUENT_CLASSES, true)) {
-                return true;
+            // Check for nested @foreach (depth >= 2)
+            if ($this->foreachDepth >= 2) {
+                $this->addIssue(
+                    line: $node->getStartLine(),
+                    message: sprintf('Nested @foreach detected (depth: %d) - potential performance issue', $this->foreachDepth),
+                    severity: Severity::Medium,
+                    recommendation: 'Flatten nested data in the controller using eager loading or collection methods. Deeply nested loops in Blade can cause O(n²) or worse rendering performance',
+                    code: 'blade-nested-foreach',
+                    metadata: ['depth' => $this->foreachDepth],
+                );
             }
 
-            // Check definite non-model suffixes (always skip)
-            foreach (self::DEFINITE_NON_MODEL_SUFFIXES as $suffix) {
-                if (str_ends_with($className, $suffix)) {
-                    return true;
+            // Check for collection manipulation in foreach expression
+            $this->checkForeachExpression($node);
+        }
+
+        // Detect $__currentLoopData = $expr->collectionMethod() pattern
+        // (Blade compiles @foreach($items->filter() as $item) to this)
+        if ($node instanceof Expr\Assign) {
+            $this->checkCurrentLoopDataAssignment($node);
+        }
+
+        // DB query detection — static calls
+        if ($node instanceof Expr\StaticCall) {
+            $this->checkDbStaticCall($node);
+            $this->checkApiStaticCall($node);
+        }
+
+        // DB query detection — method chains
+        if ($node instanceof Expr\MethodCall) {
+            $this->checkDbMethodChain($node);
+            $this->checkModelSave($node);
+            $this->checkExpensiveCollectionMethod($node);
+        }
+
+        // API call and business logic — function calls
+        if ($node instanceof Expr\FuncCall) {
+            $this->checkApiFuncCall($node);
+            $this->checkBusinessLogicFunction($node);
+            if ($this->foreachDepth >= 1) {
+                $this->checkExpensiveStringFunction($node);
+            }
+        }
+
+        // Complex @if conditions
+        if ($node instanceof Stmt\If_) {
+            $this->checkComplexCondition($node);
+        }
+
+        // Complex calculations — compound assignment operators
+        if ($node instanceof Expr\AssignOp) {
+            $this->checkCompoundAssignment($node);
+        }
+
+        // Complex calculations in echo expressions (Blade {{ }} compiles to echo e(...))
+        if ($node instanceof Stmt\Echo_) {
+            $this->checkEchoCalculation($node);
+        }
+
+        return null;
+    }
+
+    public function leaveNode(Node $node): ?int
+    {
+        if ($node instanceof Stmt\Foreach_) {
+            $this->foreachDepth = max(0, $this->foreachDepth - 1);
+        }
+
+        return null;
+    }
+
+    private function checkDbStaticCall(Expr\StaticCall $node): void
+    {
+        if (! $node->class instanceof Name || ! $node->name instanceof Identifier) {
+            return;
+        }
+
+        $fullClassName = $node->class->toString();
+        $shortName = $this->getShortClassName($fullClassName);
+        $methodName = $node->name->name;
+
+        // DB facade — always flag
+        if ($shortName === 'DB') {
+            $this->addDbIssue($node->getStartLine());
+
+            return;
+        }
+
+        // ->query() method — always flag
+        if ($methodName === 'query') {
+            $this->addDbIssue($node->getStartLine());
+
+            return;
+        }
+
+        // Skip known non-Eloquent classes
+        if (in_array($shortName, self::NON_ELOQUENT_CLASSES, true)) {
+            return;
+        }
+
+        // Skip definite non-model suffixes
+        if ($this->hasDefiniteNonModelSuffix($shortName)) {
+            return;
+        }
+
+        // Self-terminal methods (::find(), ::all(), ::first(), ::create(), etc.)
+        if (in_array($methodName, self::SELF_TERMINAL_METHODS, true)) {
+            $this->addDbIssue($node->getStartLine());
+
+            return;
+        }
+
+        // Chain-start methods (::where()) — need terminal or FQCN to confirm
+        if ($methodName === 'where') {
+            // FQCN with \Models\ → definitely a model
+            if (str_contains($fullClassName, '\\Models\\') || str_contains($fullClassName, '\\Model\\')) {
+                $this->addDbIssue($node->getStartLine());
+
+                return;
+            }
+
+            // Ambiguous suffix without terminal — skip
+            // Unknown class without terminal — skip (avoid false positives)
+            // Terminal detection is handled by checkDbMethodChain when it
+            // encounters the terminal MethodCall and walks down to this StaticCall root.
+        }
+    }
+
+    private function checkDbMethodChain(Expr\MethodCall $node): void
+    {
+        if (! $node->name instanceof Identifier) {
+            return;
+        }
+
+        $methodName = $node->name->name;
+
+        // Only check terminal methods
+        if (! in_array($methodName, self::TERMINAL_QUERY_METHODS, true)) {
+            return;
+        }
+
+        // Walk the chain down to the root
+        $root = $node->var;
+        while ($root instanceof Expr\MethodCall) {
+            $root = $root->var;
+        }
+
+        // Root is a static call — check if it's a DB query
+        if ($root instanceof Expr\StaticCall) {
+            if (! $root->class instanceof Name) {
+                return;
+            }
+
+            $fullClassName = $root->class->toString();
+            $shortName = $this->getShortClassName($fullClassName);
+
+            // DB facade
+            if ($shortName === 'DB') {
+                $this->addDbIssue($root->getStartLine());
+
+                return;
+            }
+
+            // Skip known non-Eloquent classes
+            if (in_array($shortName, self::NON_ELOQUENT_CLASSES, true)) {
+                return;
+            }
+
+            // Skip definite non-model suffixes
+            if ($this->hasDefiniteNonModelSuffix($shortName)) {
+                return;
+            }
+
+            // FQCN with Models namespace
+            if (str_contains($fullClassName, '\\Models\\') || str_contains($fullClassName, '\\Model\\')) {
+                $this->addDbIssue($root->getStartLine());
+
+                return;
+            }
+
+            // Has terminal method (we're here because it does) — flag it
+            $this->addDbIssue($root->getStartLine());
+
+            return;
+        }
+
+        // Root is a FuncCall (collect() helper) — not a DB call
+        if ($root instanceof Expr\FuncCall) {
+            return;
+        }
+
+        // Check for relationship pattern: $var->method()->terminal()
+        // The chain is: MethodCall(terminal) -> MethodCall(relationship) -> Variable
+        if ($node->var instanceof Expr\MethodCall
+            && $node->var->var instanceof Expr\Variable
+            && is_string($node->var->var->name)) {
+            $variableName = strtolower($node->var->var->name);
+
+            // Check if variable name suggests a collection
+            foreach (self::COLLECTION_VARIABLE_PATTERNS as $pattern) {
+                if (str_contains($variableName, $pattern)) {
+                    return;
                 }
             }
 
-            // Check ambiguous suffixes (only skip if NO terminal method present)
-            // e.g., OrderResource::where('x', 'y')->get() should be FLAGGED
-            // e.g., OrderResource::where('x', 'y') without terminal should NOT be flagged
-            foreach (self::AMBIGUOUS_SUFFIXES as $suffix) {
-                if (str_ends_with($className, $suffix)) {
-                    if ($this->hasTerminalMethod($line)) {
-                        return false; // Has terminal method = likely DB query, DO flag
+            // Likely a relationship query: $user->posts()->get()
+            $this->addDbIssue($node->getStartLine());
+        }
+    }
+
+    private function checkModelSave(Expr\MethodCall $node): void
+    {
+        if (! $node->name instanceof Identifier) {
+            return;
+        }
+
+        if ($node->name->name !== 'save') {
+            return;
+        }
+
+        if (! $node->var instanceof Expr\Variable || ! is_string($node->var->name)) {
+            return;
+        }
+
+        $variableName = $node->var->name;
+
+        // Exclude non-database save patterns
+        if (in_array($variableName, self::NON_DB_SAVE_VARIABLES, true)) {
+            return;
+        }
+
+        $this->addDbIssue($node->getStartLine());
+    }
+
+    private function checkApiStaticCall(Expr\StaticCall $node): void
+    {
+        if (! $node->class instanceof Name) {
+            return;
+        }
+
+        $className = $this->getShortClassName($node->class->toString());
+
+        if ($className === 'Http') {
+            $this->addIssue(
+                line: $node->getStartLine(),
+                message: 'API call found in Blade template',
+                severity: Severity::High,
+                recommendation: 'Make API calls in controllers or services, not in views. Views should only display pre-fetched data',
+                code: 'blade-has-api-call',
+            );
+        }
+    }
+
+    private function checkApiFuncCall(Expr\FuncCall $node): void
+    {
+        if (! $node->name instanceof Name) {
+            return;
+        }
+
+        $funcName = $node->name->toString();
+
+        if (in_array($funcName, self::API_FUNCTIONS, true)) {
+            $this->addIssue(
+                line: $node->getStartLine(),
+                message: 'API call found in Blade template',
+                severity: Severity::High,
+                recommendation: 'Make API calls in controllers or services, not in views. Views should only display pre-fetched data',
+                code: 'blade-has-api-call',
+            );
+        }
+    }
+
+    private function checkBusinessLogicFunction(Expr\FuncCall $node): void
+    {
+        if (! $node->name instanceof Name) {
+            return;
+        }
+
+        $funcName = $node->name->toString();
+
+        if (in_array($funcName, self::BUSINESS_LOGIC_FUNCTIONS, true)) {
+            $this->addIssue(
+                line: $node->getStartLine(),
+                message: 'Business logic found in Blade directive',
+                severity: Severity::Medium,
+                recommendation: 'Extract business logic to controllers or services. Use simple conditionals in views for presentation logic only',
+                code: 'blade-has-business-logic',
+            );
+        }
+    }
+
+    private function checkComplexCondition(Stmt\If_ $node): void
+    {
+        $booleanCount = $this->countBooleanOperators($node->cond);
+
+        if ($booleanCount >= 3) {
+            $this->addIssue(
+                line: $node->getStartLine(),
+                message: 'Business logic found in Blade directive',
+                severity: Severity::Medium,
+                recommendation: 'Extract business logic to controllers or services. Use simple conditionals in views for presentation logic only',
+                code: 'blade-has-business-logic',
+            );
+        }
+    }
+
+    private function countBooleanOperators(Node $node): int
+    {
+        $count = 0;
+
+        if ($node instanceof Expr\BinaryOp\BooleanAnd || $node instanceof Expr\BinaryOp\BooleanOr) {
+            $count = 1;
+            $count += $this->countBooleanOperators($node->left);
+            $count += $this->countBooleanOperators($node->right);
+        }
+
+        return $count;
+    }
+
+    private function checkExpensiveCollectionMethod(Expr\MethodCall $node): void
+    {
+        if (! $node->name instanceof Identifier) {
+            return;
+        }
+
+        if (in_array($node->name->name, self::EXPENSIVE_COLLECTION_METHODS, true)) {
+            // Skip if this is part of a DB chain (root is StaticCall) — handled elsewhere
+            $root = $node->var;
+            while ($root instanceof Expr\MethodCall) {
+                $root = $root->var;
+            }
+            if ($root instanceof Expr\StaticCall) {
+                return;
+            }
+
+            $this->addIssue(
+                line: $node->getStartLine(),
+                message: 'Expensive computation found in Blade template',
+                severity: Severity::Medium,
+                recommendation: 'Move expensive operations to controllers or services. Use computed properties or view composers for complex transformations',
+                code: 'blade-expensive-computation',
+            );
+        }
+    }
+
+    private function checkExpensiveStringFunction(Expr\FuncCall $node): void
+    {
+        if (! $node->name instanceof Name) {
+            return;
+        }
+
+        $funcName = $node->name->toString();
+
+        if (in_array($funcName, self::EXPENSIVE_STRING_FUNCTIONS, true)) {
+            $this->addIssue(
+                line: $node->getStartLine(),
+                message: 'Expensive computation found in Blade template',
+                severity: Severity::Medium,
+                recommendation: 'Move expensive operations to controllers or services. Use computed properties or view composers for complex transformations',
+                code: 'blade-expensive-computation',
+            );
+        }
+    }
+
+    private function checkForeachExpression(Stmt\Foreach_ $node): void
+    {
+        $expr = $node->expr;
+
+        if (! $expr instanceof Expr\MethodCall || ! $expr->name instanceof Identifier) {
+            return;
+        }
+
+        $methodName = $expr->name->name;
+
+        if (in_array($methodName, self::COLLECTION_MANIPULATION_METHODS, true)) {
+            $this->addIssue(
+                line: $node->getStartLine(),
+                message: 'Business logic found in Blade directive',
+                severity: Severity::Medium,
+                recommendation: 'Extract business logic to controllers or services. Use simple conditionals in views for presentation logic only',
+                code: 'blade-has-business-logic',
+            );
+        }
+    }
+
+    /**
+     * Detect collection manipulation in Blade's compiled @foreach pattern.
+     *
+     * Blade compiles @foreach($items->filter() as $item) to:
+     *   $__currentLoopData = $items->filter();
+     *   foreach($__currentLoopData as $item) { ... }
+     *
+     * The collection method is in the assignment, not the foreach expression.
+     */
+    private function checkCurrentLoopDataAssignment(Expr\Assign $node): void
+    {
+        // Check if LHS is $__currentLoopData
+        if (! $node->var instanceof Expr\Variable
+            || $node->var->name !== '__currentLoopData') {
+            return;
+        }
+
+        // Check if RHS is a method call with a collection manipulation method
+        $rhs = $node->expr;
+        if (! $rhs instanceof Expr\MethodCall || ! $rhs->name instanceof Identifier) {
+            return;
+        }
+
+        $methodName = $rhs->name->name;
+
+        if (in_array($methodName, self::COLLECTION_MANIPULATION_METHODS, true)) {
+            $this->addIssue(
+                line: $node->getStartLine(),
+                message: 'Business logic found in Blade directive',
+                severity: Severity::Medium,
+                recommendation: 'Extract business logic to controllers or services. Use simple conditionals in views for presentation logic only',
+                code: 'blade-has-business-logic',
+            );
+        }
+    }
+
+    /**
+     * Detect complex calculations in Blade echo expressions.
+     *
+     * Blade compiles {{ expr }} to echo e(expr). Flag when the expression
+     * contains 2+ arithmetic operators (e.g., {{ ($a * $b) + ($c * $d) }}).
+     */
+    private function checkEchoCalculation(Stmt\Echo_ $node): void
+    {
+        foreach ($node->exprs as $expr) {
+            // Unwrap e() call: echo e(innerExpr)
+            $inner = $expr;
+            if ($expr instanceof Expr\FuncCall
+                && $expr->name instanceof Name
+                && $expr->name->toString() === 'e'
+                && count($expr->args) >= 1) {
+                $inner = $expr->args[0]->value;
+            }
+
+            $arithmeticCount = $this->countArithmeticOperators($inner);
+            if ($arithmeticCount >= 2) {
+                $this->addIssue(
+                    line: $node->getStartLine(),
+                    message: 'Complex calculation found in Blade template',
+                    severity: Severity::Low,
+                    recommendation: 'Move calculations to controller, view composer, or model accessor. Blade should only display pre-calculated values',
+                    code: 'blade-has-calculation',
+                );
+            }
+        }
+    }
+
+    /**
+     * Recursively count arithmetic BinaryOp nodes in an expression tree.
+     */
+    private function countArithmeticOperators(Node $node): int
+    {
+        $count = 0;
+
+        if ($node instanceof Expr\BinaryOp\Plus
+            || $node instanceof Expr\BinaryOp\Minus
+            || $node instanceof Expr\BinaryOp\Mul
+            || $node instanceof Expr\BinaryOp\Div
+            || $node instanceof Expr\BinaryOp\Mod) {
+            $count = 1;
+        }
+
+        foreach ($node->getSubNodeNames() as $name) {
+            $subNode = $node->$name;
+            if ($subNode instanceof Node) {
+                $count += $this->countArithmeticOperators($subNode);
+            } elseif (is_array($subNode)) {
+                foreach ($subNode as $item) {
+                    if ($item instanceof Node) {
+                        $count += $this->countArithmeticOperators($item);
                     }
-
-                    return true; // No terminal = uncertain, skip to avoid false positive
                 }
             }
-
-            return false;
         }
 
-        // Fallback to original behavior
-        foreach (self::NON_ELOQUENT_CLASSES as $class) {
-            if (str_ends_with($beforeMatch, $class)) {
+        return $count;
+    }
+
+    /**
+     * Detect compound assignment operators ($x += $y, $x *= $y, etc.).
+     */
+    private function checkCompoundAssignment(Expr\AssignOp $node): void
+    {
+        // Any compound arithmetic assignment is a calculation in Blade
+        if ($node instanceof Expr\AssignOp\Plus
+            || $node instanceof Expr\AssignOp\Minus
+            || $node instanceof Expr\AssignOp\Mul
+            || $node instanceof Expr\AssignOp\Div
+            || $node instanceof Expr\AssignOp\Mod) {
+            $this->addIssue(
+                line: $node->getStartLine(),
+                message: 'Complex calculation found in Blade template',
+                severity: Severity::Low,
+                recommendation: 'Move calculations to controller, view composer, or model accessor. Blade should only display pre-calculated values',
+                code: 'blade-has-calculation',
+            );
+        }
+    }
+
+    private function getShortClassName(string $fullName): string
+    {
+        $parts = explode('\\', $fullName);
+
+        return end($parts);
+    }
+
+    private function hasDefiniteNonModelSuffix(string $className): bool
+    {
+        foreach (self::DEFINITE_NON_MODEL_SUFFIXES as $suffix) {
+            if (str_ends_with($className, $suffix)) {
                 return true;
             }
         }
@@ -830,291 +915,29 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
         return false;
     }
 
-    /**
-     * Check if the class in a static call has an ambiguous suffix (Resource, Manager, Builder).
-     */
-    private function hasAmbiguousSuffixClass(string $line, int $matchPosition): bool
+    private function addDbIssue(int $line): void
     {
-        $beforeMatch = substr($line, 0, $matchPosition);
-        $trimmed = rtrim($beforeMatch);
-
-        if (preg_match('/\\\\?(?:[A-Za-z_][A-Za-z0-9_]*\\\\)*([A-Za-z_][A-Za-z0-9_]*)$/', $trimmed, $matches)) {
-            $className = $matches[1];
-
-            foreach (self::AMBIGUOUS_SUFFIXES as $suffix) {
-                if (str_ends_with($className, $suffix)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        $this->addIssue(
+            line: $line,
+            message: 'Database query found in Blade template',
+            severity: Severity::Critical,
+            recommendation: 'Never query the database from Blade templates. Load all required data in the controller and pass it to the view',
+            code: 'blade-has-db-query',
+        );
     }
 
     /**
-     * Check if a match position is inside a string literal or comment.
+     * @param  array<string, mixed>  $metadata
      */
-    private function isInsideStringOrComment(string $line, int $matchPosition): bool
+    private function addIssue(int $line, string $message, Severity $severity, string $recommendation, string $code, array $metadata = []): void
     {
-        $beforeMatch = substr($line, 0, $matchPosition);
-
-        // Check for single-line comment before match position
-        $singleCommentPos = strpos($beforeMatch, '//');
-        if ($singleCommentPos !== false) {
-            return true;
-        }
-
-        // Check for block comment wrapping the match position: /* ... match ... */
-        $blockOpenPos = strrpos($beforeMatch, '/*');
-        if ($blockOpenPos !== false) {
-            // Is there a close (*/) between the open and match position?
-            $closeBeforeMatch = strpos($beforeMatch, '*/', $blockOpenPos + 2);
-            if ($closeBeforeMatch === false) {
-                // No close before match — we're inside an unclosed block comment
-                return true;
-            }
-        }
-
-        // Check if we're inside a string literal by counting quotes
-        $inSingleQuote = false;
-        $inDoubleQuote = false;
-
-        for ($i = 0; $i < $matchPosition; $i++) {
-            $char = $line[$i];
-            $prevChar = $i > 0 ? $line[$i - 1] : '';
-
-            // Skip escaped quotes
-            if ($prevChar === '\\') {
-                continue;
-            }
-
-            if ($char === "'" && ! $inDoubleQuote) {
-                $inSingleQuote = ! $inSingleQuote;
-            } elseif ($char === '"' && ! $inSingleQuote) {
-                $inDoubleQuote = ! $inDoubleQuote;
-            }
-        }
-
-        return $inSingleQuote || $inDoubleQuote;
-    }
-
-    /**
-     * Check if a line opens a block comment (/*) outside of a string literal.
-     */
-    private function lineOpensBlockComment(string $line): bool
-    {
-        $pos = strpos($line, '/*');
-        if ($pos === false) {
-            return false;
-        }
-
-        return ! $this->isInsideStringOrComment($line, $pos);
-    }
-
-    /**
-     * Check if a line closes a block comment (* /).
-     */
-    private function lineClosesBlockComment(string $line): bool
-    {
-        return str_contains($line, '*/');
-    }
-
-    private function hasApiCall(string $line): bool
-    {
-        // Fast-path: skip if line has none of the API call indicators
-        if (! str_contains($line, 'Http::')
-            && ! str_contains($line, 'Guzzle')
-            && ! str_contains($line, 'curl_')
-            && ! str_contains($line, 'file_get_contents')) {
-            return false;
-        }
-
-        $patterns = [
-            '/Http::/',                // Laravel HTTP client
-            '/\bGuzzle\b/',            // Guzzle client
-            '/\bcurl_/',               // cURL functions
-            '/file_get_contents\s*\(\s*[\'"]https?:\/\//', // file_get_contents with URL
+        $this->issues[] = [
+            'message' => $message,
+            'severity' => $severity,
+            'recommendation' => $recommendation,
+            'code' => $code,
+            'line' => $line,
+            'metadata' => $metadata,
         ];
-
-        foreach ($patterns as $pattern) {
-            if (preg_match($pattern, $line, $matches, PREG_OFFSET_CAPTURE)) {
-                // Check if the match is inside a string or comment
-                if ($this->isInsideStringOrComment($line, $matches[0][1])) {
-                    continue;
-                }
-
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function hasComplexCalculation(string $line): bool
-    {
-        // Fast-path: skip if line has no Blade output and no assignment operators
-        if (! str_contains($line, '{{') && ! str_contains($line, '+=')
-            && ! str_contains($line, '-=') && ! str_contains($line, '*=')
-            && ! str_contains($line, '/=') && ! str_contains($line, '%=')) {
-            return false;
-        }
-
-        // Skip simple variable outputs
-        if (preg_match('/^\{\{\s*\$\w+\s*\}\}$/', trim($line))) {
-            return false;
-        }
-
-        // Skip helper function calls (config, session, cache, etc.)
-        if (preg_match('/\{\{\s*(config|session|cache|request|cookie|auth)\s*\(\s*\)/', $line)) {
-            return false; // {{ config()->get() }} is acceptable
-        }
-
-        // Skip facade calls (Config::, Session::, Cache::, etc.)
-        if (preg_match('/\{\{\s*(Config|Session|Cache|Request|Cookie|Auth)::/', $line)) {
-            return false; // {{ Config::get() }} is acceptable
-        }
-
-        // Skip null coalescing operators ({{ $value ?? 0 }})
-        if (preg_match('/\{\{\s*\$\w+(?:->\w+)?\s*\?\?\s*(?:\d+|[\'"][^\'"]*[\'"]|null)\s*\}\}/', $line)) {
-            return false;
-        }
-
-        // Skip simple single operations including object properties (these are often acceptable)
-        // Matches: {{ $price * $quantity }}, {{ $item->price * $qty }}, {{ $a + $b->value }}
-        if (preg_match('/\{\{\s*\$\w+(?:->\w+)?\s*[\+\-\*\/]\s*\$\w+(?:->\w+)?\s*\}\}/', $line)) {
-            return false; // {{ $price * $quantity }} or {{ $item->price * $qty }} is acceptable
-        }
-
-        // Detect complex calculations (multiple operations)
-        if (preg_match('/\{\{.*[\+\-\*\/\%].*\}\}/', $line)) {
-            // Count operations
-            if (preg_match_all('/[\+\-\*\/\%]/', $line, $matches) && count($matches[0]) >= 2) {
-                return true; // Multiple operations = complex
-            }
-        }
-
-        // Detect calculations in @php blocks or inline PHP
-        if (preg_match('/\$[\w]+\s*[\+\-\*\/\%]=/', $line)) {
-            return true;
-        }
-
-        // Detect complex expressions with function calls and math
-        if (preg_match('/\{\{.*\(.*\).*[\+\*\/]/', $line)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Check for expensive computation patterns in Blade.
-     *
-     * Detects:
-     * - Regex/string processing inside foreach loops
-     * - Expensive collection methods (->toArray(), ->all()) anywhere
-     */
-    private function hasExpensiveComputation(string $line, int $foreachDepth): bool
-    {
-        // Fast-path: check if any expensive collection method substring is present
-        $hasExpensiveCollectionMethod = false;
-        foreach (self::EXPENSIVE_COLLECTION_METHODS as $method) {
-            if (str_contains($line, $method)) {
-                $hasExpensiveCollectionMethod = true;
-
-                break;
-            }
-        }
-
-        // If not in a loop and no expensive collection methods, nothing to check
-        if ($foreachDepth < 1 && ! $hasExpensiveCollectionMethod) {
-            return false;
-        }
-
-        // Check for expensive string functions inside loops
-        if ($foreachDepth >= 1) {
-            foreach (self::EXPENSIVE_STRING_FUNCTIONS as $func) {
-                if (preg_match('/\b'.preg_quote($func, '/').'\s*\(/', $line)) {
-                    return true;
-                }
-            }
-        }
-
-        // Check for expensive collection methods anywhere
-        foreach (self::EXPENSIVE_COLLECTION_METHODS as $method) {
-            if (str_contains($line, $method)) {
-                $methodPos = strpos($line, $method);
-                if ($methodPos !== false && ! $this->isInsideStringOrComment($line, $methodPos)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private function hasBusinessLogicInDirective(string $line): bool
-    {
-        // Fast-path: skip if line has no directives and no business logic functions
-        $hasDirective = str_contains($line, '@if') || str_contains($line, '@foreach');
-        if (! $hasDirective) {
-            $hasFunction = false;
-            foreach (self::BUSINESS_LOGIC_FUNCTIONS as $func) {
-                if (str_contains($line, $func)) {
-                    $hasFunction = true;
-
-                    break;
-                }
-            }
-            if (! $hasFunction) {
-                return false;
-            }
-        }
-
-        // Check for overly complex @if conditions (4+ conditions, not 3+)
-        if (preg_match('/@if\s*\(/', $line)) {
-            // Count && and || operators
-            $andCount = substr_count($line, '&&');
-            $orCount = substr_count($line, '||');
-            if ($andCount + $orCount >= 3) {
-                return true; // 4+ conditions indicates business logic
-            }
-        }
-
-        // Check for loops with transformations
-        if (preg_match('/@foreach\s*\(.*->filter\(/', $line)) {
-            return true; // Filtering in foreach
-        }
-
-        if (preg_match('/@foreach\s*\(.*->map\(/', $line)) {
-            return true; // Mapping in foreach
-        }
-
-        if (preg_match('/@foreach\s*\(.*->transform\(/', $line)) {
-            return true; // Transforming in foreach
-        }
-
-        if (preg_match('/@foreach\s*\(.*->sortBy\(/', $line)) {
-            return true; // Sorting in foreach
-        }
-
-        // Check for additional collection methods in foreach
-        $collectionMethods = implode('|', self::COLLECTION_MANIPULATION_METHODS);
-        if (preg_match('/@foreach\s*\(.*->('.$collectionMethods.')\(/', $line)) {
-            return true; // Collection manipulation in foreach
-        }
-
-        // Handle collect() helper with collection methods
-        if (preg_match('/@foreach\s*\(\s*collect\s*\(.*\)->(filter|map|transform|sortBy|'.$collectionMethods.')\(/', $line)) {
-            return true; // collect($items)->filter() in foreach
-        }
-
-        // Check for array_* functions (data manipulation) using word boundary regex
-        foreach (self::BUSINESS_LOGIC_FUNCTIONS as $func) {
-            if (preg_match('/\b'.preg_quote($func, '/').'\s*\(/', $line)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/Support/BladeCompilerFactory.php
+++ b/src/Support/BladeCompilerFactory.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+
+/**
+ * Standalone Blade-to-PHP compiler with original line number tracking.
+ *
+ * Injects __BLADE_LINE_N__ markers before each source line so that after
+ * BladeCompiler::compileString() transforms Blade syntax to PHP, we can
+ * map compiled-PHP line numbers back to original Blade line numbers.
+ */
+class BladeCompilerFactory
+{
+    /**
+     * Compile Blade source to PHP with line-number tracking.
+     *
+     * @return array{compiledPhp: string, lineMap: array<int, int>}|null
+     */
+    public static function compile(string $bladeSource): ?array
+    {
+        try {
+            $markedSource = self::injectLineMarkers($bladeSource);
+            $compiler = new BladeCompiler(new Filesystem, sys_get_temp_dir());
+            $compiler->withoutComponentTags();
+            $compiledPhp = $compiler->compileString($markedSource);
+            $lineMap = self::buildLineMap($compiledPhp);
+
+            return ['compiledPhp' => $compiledPhp, 'lineMap' => $lineMap];
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Inject __BLADE_LINE_N__ markers before each source line.
+     *
+     * Outside @php blocks: a self-contained PHP open/close tag wrapping a marker.
+     * Inside  @php blocks: a single-line // comment on its own line.
+     *
+     * Why dual-mode: @php compiles to a PHP open tag. Injecting another open tag
+     * inside would close the PHP mode prematurely, producing invalid PHP.
+     * Why // not block comments: block comments cannot nest in PHP, so user's own
+     * block comments would conflict with marker block comments.
+     */
+    private static function injectLineMarkers(string $bladeSource): string
+    {
+        $lines = explode("\n", $bladeSource);
+        $inPhpBlock = false;
+        $marked = [];
+
+        foreach ($lines as $index => $line) {
+            $lineNum = $index + 1;
+            $trimmed = trim($line);
+
+            if (! $inPhpBlock && preg_match('/@php\b/', $trimmed)
+                && ! str_contains($trimmed, '@endphp')) {
+                $inPhpBlock = true;
+                $marked[] = "<?php /* __BLADE_LINE_{$lineNum}__ */ ?>".$line;
+            } elseif ($inPhpBlock && str_contains($trimmed, '@endphp')) {
+                $marked[] = "// __BLADE_LINE_{$lineNum}__";
+                $marked[] = $line;
+                $inPhpBlock = false;
+            } elseif ($inPhpBlock) {
+                $marked[] = "// __BLADE_LINE_{$lineNum}__";
+                $marked[] = $line;
+            } else {
+                $marked[] = "<?php /* __BLADE_LINE_{$lineNum}__ */ ?>".$line;
+            }
+        }
+
+        return implode("\n", $marked);
+    }
+
+    /**
+     * Build compiled-line → original-blade-line mapping.
+     *
+     * Scans compiled PHP for __BLADE_LINE_N__ markers. Each compiled line
+     * maps to the most recently seen marker's original line number.
+     *
+     * @return array<int, int> Keys = compiled PHP line (1-indexed), values = original Blade line
+     */
+    private static function buildLineMap(string $compiledPhp): array
+    {
+        $map = [];
+        $lines = explode("\n", $compiledPhp);
+        $currentBladeLine = 1;
+
+        foreach ($lines as $compiledIdx => $line) {
+            if (preg_match('/__BLADE_LINE_(\d+)__/', $line, $m)) {
+                $currentBladeLine = (int) $m[1];
+            }
+            $map[$compiledIdx + 1] = $currentBladeLine;
+        }
+
+        return $map;
+    }
+}

--- a/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
@@ -2641,8 +2641,9 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        // Blank line breaks the chain — should NOT be flagged as multi-line DB query
-        $this->assertPassed($result);
+        // AST correctly detects the chain across blank lines (blank lines don't break PHP expressions)
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('Database query', $result);
     }
 
     public function test_multi_line_chain_stops_at_endphp(): void

--- a/tests/Unit/Support/BladeCompilerFactoryTest.php
+++ b/tests/Unit/Support/BladeCompilerFactoryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use PHPUnit\Framework\TestCase;
+use ShieldCI\Support\BladeCompilerFactory;
+
+class BladeCompilerFactoryTest extends TestCase
+{
+    public function test_compiles_simple_blade_to_php(): void
+    {
+        $result = BladeCompilerFactory::compile('<div>{{ $name }}</div>');
+
+        $this->assertNotNull($result);
+        $this->assertArrayHasKey('compiledPhp', $result);
+        $this->assertArrayHasKey('lineMap', $result);
+        $this->assertStringContainsString('<?php echo', $result['compiledPhp']);
+    }
+
+    public function test_line_map_maps_back_to_original_lines(): void
+    {
+        $blade = "<div>\n    {{ \$name }}\n</div>";
+
+        $result = BladeCompilerFactory::compile($blade);
+
+        $this->assertNotNull($result);
+        $lineMap = $result['lineMap'];
+
+        // Line map should be 1-indexed
+        $this->assertArrayHasKey(1, $lineMap);
+
+        // Should contain mappings back to original blade lines (1, 2, 3)
+        $this->assertContains(1, $lineMap);
+        $this->assertContains(2, $lineMap);
+        $this->assertContains(3, $lineMap);
+    }
+
+    public function test_compiles_php_block_with_line_tracking(): void
+    {
+        $blade = "<div>\n    @php\n        \$x = 1;\n    @endphp\n</div>";
+
+        $result = BladeCompilerFactory::compile($blade);
+
+        $this->assertNotNull($result);
+
+        // Compiled PHP should be parseable
+        $ast = (new \ShieldCI\AnalyzersCore\Support\AstParser)->parseCode($result['compiledPhp']);
+        $this->assertNotEmpty($ast);
+    }
+
+    public function test_handles_block_comments_inside_php_blocks(): void
+    {
+        $blade = "<div>\n    @php\n        /*\n         * A comment\n         */\n        \$users = User::all();\n    @endphp\n</div>";
+
+        $result = BladeCompilerFactory::compile($blade);
+
+        $this->assertNotNull($result);
+
+        // Compiled PHP should be parseable even with block comments
+        $ast = (new \ShieldCI\AnalyzersCore\Support\AstParser)->parseCode($result['compiledPhp']);
+        $this->assertNotEmpty($ast);
+    }
+
+    public function test_markers_use_line_comments_inside_php_blocks(): void
+    {
+        $blade = "<div>\n    @php\n        \$x = 1;\n    @endphp\n</div>";
+
+        $result = BladeCompilerFactory::compile($blade);
+
+        $this->assertNotNull($result);
+        // Inside @php blocks, markers should use // comments (not /* */ which would conflict)
+        $this->assertStringContainsString('// __BLADE_LINE_', $result['compiledPhp']);
+    }
+
+    public function test_markers_use_php_tags_outside_php_blocks(): void
+    {
+        $result = BladeCompilerFactory::compile('<div>{{ $name }}</div>');
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('__BLADE_LINE_1__', $result['compiledPhp']);
+    }
+
+    public function test_line_map_is_monotonically_non_decreasing(): void
+    {
+        $blade = "<h1>Title</h1>\n<p>{{ \$body }}</p>\n<footer>End</footer>";
+
+        $result = BladeCompilerFactory::compile($blade);
+
+        $this->assertNotNull($result);
+
+        $prev = 0;
+        foreach ($result['lineMap'] as $originalLine) {
+            $this->assertGreaterThanOrEqual($prev, $originalLine);
+            $prev = $originalLine;
+        }
+    }
+
+    public function test_empty_blade_returns_result(): void
+    {
+        $result = BladeCompilerFactory::compile('');
+
+        $this->assertNotNull($result);
+        $this->assertArrayHasKey('compiledPhp', $result);
+        $this->assertArrayHasKey('lineMap', $result);
+    }
+
+    public function test_blade_directives_compile_correctly(): void
+    {
+        $blade = "@if(\$show)\n    <p>Hello</p>\n@endif";
+
+        $result = BladeCompilerFactory::compile($blade);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('<?php if', $result['compiledPhp']);
+    }
+
+    public function test_foreach_compiles_with_loop_data(): void
+    {
+        $blade = "@foreach(\$items as \$item)\n    <p>{{ \$item }}</p>\n@endforeach";
+
+        $result = BladeCompilerFactory::compile($blade);
+
+        $this->assertNotNull($result);
+        // Blade compiles @foreach to $__currentLoopData assignment
+        $this->assertStringContainsString('__currentLoopData', $result['compiledPhp']);
+    }
+
+    public function test_multiline_php_block_preserves_line_mapping(): void
+    {
+        $blade = "<div>\n    @php\n        \$a = 1;\n        \$b = 2;\n        \$c = \$a + \$b;\n    @endphp\n</div>";
+
+        $result = BladeCompilerFactory::compile($blade);
+
+        $this->assertNotNull($result);
+
+        $lineMap = $result['lineMap'];
+
+        // The line map should contain references to lines 3, 4, 5 (inside @php block)
+        $this->assertContains(3, $lineMap);
+        $this->assertContains(4, $lineMap);
+        $this->assertContains(5, $lineMap);
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces ~1100-line regex-only `LogicInBladeAnalyzer` with a two-pass hybrid approach: regex for Blade-structural checks + AST for PHP logic detection
- Adds `BladeCompilerFactory` — standalone Blade-to-PHP compiler with dual-mode line markers for accurate line-number mapping back to original Blade source
- Adds `BladeLogicVisitor` — single-pass AST visitor that detects DB queries, API calls, business logic, calculations, expensive computation, nested `@foreach`, and collection manipulation
- Eliminates multi-line chain scanning, string/comment false-positive logic, and ~25 regex constant arrays — the AST naturally handles all of these structurally