### PR TITLE
Migrate 4 security analyzers from regex/tokenizer to AST

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ parameters:
     excludePaths:
         - tests/Fixtures/inspects-code/syntax_error.php
         - tests/Fixtures/inspects-code/sample_functions.php
+        - tests/Fixtures/inspects-code-config/syntax_error.php
     tmpDir: build/phpstan
     treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false

--- a/src/Analyzers/Security/CookieSecurityAnalyzer.php
+++ b/src/Analyzers/Security/CookieSecurityAnalyzer.php
@@ -7,14 +7,21 @@ namespace ShieldCI\Analyzers\Security;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Router;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeFinder;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\Concerns\AnalyzesMiddleware;
+use ShieldCI\Concerns\InspectsCode;
 
 /**
  * Validates cookie security configuration.
@@ -28,6 +35,7 @@ use ShieldCI\Concerns\AnalyzesMiddleware;
 class CookieSecurityAnalyzer extends AbstractFileAnalyzer
 {
     use AnalyzesMiddleware;
+    use InspectsCode;
 
     protected function metadata(): AnalyzerMetadata
     {
@@ -77,7 +85,7 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
-     * Check session configuration file.
+     * Check session configuration file using AST parsing.
      */
     private function checkSessionConfig(array &$issues): void
     {
@@ -87,70 +95,72 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
             return;
         }
 
-        $content = FileParser::readFile($sessionConfig);
-        if ($content === null) {
+        $config = $this->parseConfigArray($sessionConfig);
+
+        if ($config === []) {
             return;
         }
 
-        $lines = FileParser::getLines($sessionConfig);
+        // Check HttpOnly flag
+        if (isset($config['http_only'])) {
+            $entry = $config['http_only'];
 
-        foreach ($lines as $lineNumber => $line) {
-            if (! is_string($line)) {
-                continue;
-            }
-
-            // Skip commented lines
-            if (preg_match('/^\s*\/\//', $line)) {
-                continue;
-            }
-
-            // Check HttpOnly flag
-            if (preg_match('/["\']http_only["\']\s*=>\s*(false|0)/i', $line, $matches)) {
+            if ($entry['value'] === false || $entry['value'] === 0) {
                 $issues[] = $this->createIssueWithSnippet(
                     message: 'Session cookies are not secured with HttpOnly flag',
                     filePath: $sessionConfig,
-                    lineNumber: $lineNumber + 1,
+                    lineNumber: $entry['line'],
                     severity: Severity::Critical,
                     recommendation: 'Set "http_only" => true in config/session.php to protect against XSS attacks',
                     code: 'http_only',
                     metadata: [
                         'file' => 'session.php',
                         'config_key' => 'http_only',
-                        'current_value' => $matches[1],
+                        'current_value' => $this->configValueToString($entry['value']),
                     ]
                 );
             }
+        }
 
-            // Check Secure flag (should be true for HTTPS sites)
-            if (preg_match('/["\']secure["\']\s*=>\s*(false|0)/i', $line, $matches)) {
+        // Check Secure flag (should be true for HTTPS sites)
+        if (isset($config['secure'])) {
+            $entry = $config['secure'];
+
+            if ($entry['value'] === false || $entry['value'] === 0) {
                 $issues[] = $this->createIssueWithSnippet(
                     message: 'Session cookies are not restricted to HTTPS (secure flag disabled)',
                     filePath: $sessionConfig,
-                    lineNumber: $lineNumber + 1,
+                    lineNumber: $entry['line'],
                     severity: Severity::High,
                     recommendation: 'Set "secure" => env("SESSION_SECURE_COOKIE", true) for HTTPS-only applications',
                     code: 'secure',
                     metadata: [
                         'file' => 'session.php',
                         'config_key' => 'secure',
-                        'current_value' => $matches[1],
+                        'current_value' => $this->configValueToString($entry['value']),
                     ]
                 );
             }
+        }
 
-            // Check SameSite attribute
-            if (preg_match('/["\']same_site["\']\s*=>\s*["\']?(null|none)["\']?/i', $line, $matches)) {
+        // Check SameSite attribute
+        if (isset($config['same_site'])) {
+            $entry = $config['same_site'];
+            $isWeak = $entry['value'] === null
+                || (is_string($entry['value']) && in_array(strtolower($entry['value']), ['null', 'none'], true));
+
+            if ($isWeak) {
                 $issues[] = $this->createIssueWithSnippet(
                     message: 'Session cookies have weak SameSite protection',
                     filePath: $sessionConfig,
-                    lineNumber: $lineNumber + 1,
+                    lineNumber: $entry['line'],
                     severity: Severity::Medium,
                     recommendation: 'Use "same_site" => "lax" or "strict" to protect against CSRF attacks',
                     code: 'same_site',
                     metadata: [
                         'file' => 'session.php',
                         'config_key' => 'same_site',
-                        'current_value' => $matches[1],
+                        'current_value' => $this->configValueToString($entry['value']),
                     ]
                 );
             }
@@ -347,22 +357,59 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
-     * Check bootstrap/app.php for Laravel 11+ applications.
+     * Check bootstrap/app.php for Laravel 11+ applications using AST.
      * This is a fallback when runtime checks aren't available.
      */
     private function checkBootstrapApp(string $file, array &$issues): void
     {
-        $content = FileParser::readFile($file);
-        if ($content === null || ! is_string($content)) {
+        $astParser = new AstParser;
+        $ast = $astParser->parseFile($file);
+
+        if ($ast === []) {
             return;
         }
 
-        // Check for various ways EncryptCookies might be registered in Laravel 11+
-        $hasEncryptCookies = str_contains($content, 'EncryptCookies') ||
-                             str_contains($content, 'encryptCookies') ||
-                             str_contains($content, 'EncryptCookies::class') ||
-                             preg_match('/->withMiddleware\s*\([^)]*EncryptCookies/i', $content) ||
-                             preg_match('/->withMiddleware\s*\([^)]*encryptCookies/i', $content);
+        $nodeFinder = new NodeFinder;
+        $hasEncryptCookies = false;
+
+        // Look for method calls named encryptCookies/EncryptCookies (e.g. $middleware->encryptCookies())
+        /** @var MethodCall[] $methodCalls */
+        $methodCalls = $nodeFinder->findInstanceOf($ast, MethodCall::class);
+
+        foreach ($methodCalls as $call) {
+            if ($call->name instanceof Identifier
+                && strtolower($call->name->name) === 'encryptcookies'
+            ) {
+                $hasEncryptCookies = true;
+                break;
+            }
+        }
+
+        // Look for EncryptCookies class name references (e.g. EncryptCookies::class)
+        if (! $hasEncryptCookies) {
+            /** @var Name[] $names */
+            $names = $nodeFinder->findInstanceOf($ast, Name::class);
+
+            foreach ($names as $name) {
+                if (str_contains($name->toString(), 'EncryptCookies')) {
+                    $hasEncryptCookies = true;
+                    break;
+                }
+            }
+        }
+
+        // Look for string references to EncryptCookies (e.g. 'EncryptCookies' as argument)
+        if (! $hasEncryptCookies) {
+            /** @var String_[] $strings */
+            $strings = $nodeFinder->findInstanceOf($ast, String_::class);
+
+            foreach ($strings as $string) {
+                if (str_contains($string->value, 'EncryptCookies') || str_contains($string->value, 'encryptCookies')) {
+                    $hasEncryptCookies = true;
+                    break;
+                }
+            }
+        }
 
         if (! $hasEncryptCookies) {
             $issues[] = $this->createIssueWithSnippet(
@@ -380,5 +427,29 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
                 ]
             );
         }
+    }
+
+    /**
+     * Convert a config value to its string representation for metadata.
+     */
+    private function configValueToString(mixed $value): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+
+        if ($value === true) {
+            return 'true';
+        }
+
+        if ($value === false) {
+            return 'false';
+        }
+
+        if (is_int($value) || is_float($value) || is_string($value)) {
+            return (string) $value;
+        }
+
+        return 'unknown';
     }
 }

--- a/tests/Fixtures/inspects-code-config/config_mixed_keys.php
+++ b/tests/Fixtures/inspects-code-config/config_mixed_keys.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'named_key' => 'value1',
+    'another' => true,
+    0 => 'indexed_value',
+    'last' => 'final',
+];

--- a/tests/Fixtures/inspects-code-config/config_no_return.php
+++ b/tests/Fixtures/inspects-code-config/config_no_return.php
@@ -1,0 +1,5 @@
+<?php
+
+$config = [
+    'name' => 'MyApp',
+];

--- a/tests/Fixtures/inspects-code-config/config_standard.php
+++ b/tests/Fixtures/inspects-code-config/config_standard.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'name' => 'MyApp',
+    'debug' => false,
+    'port' => 8080,
+    'rate' => 1.5,
+    'key' => env('APP_KEY'),
+    'debug_env' => env('APP_DEBUG', false),
+    'url' => env('APP_URL', 'http://localhost'),
+    'nullable' => null,
+    'complex' => strtoupper('hello'),
+];

--- a/tests/Fixtures/inspects-code-config/config_with_spread.php
+++ b/tests/Fixtures/inspects-code-config/config_with_spread.php
@@ -1,0 +1,9 @@
+<?php
+
+$defaults = ['timeout' => 30];
+
+return [
+    'name' => 'MyApp',
+    ...$defaults,
+    'debug' => true,
+];

--- a/tests/Fixtures/inspects-code-config/syntax_error.php
+++ b/tests/Fixtures/inspects-code-config/syntax_error.php
@@ -1,0 +1,4 @@
+<?php
+
+// Intentionally invalid PHP: missing function name causes parser to throw
+function { return null; }


### PR DESCRIPTION
## Summary

- **InspectsCode trait**: Added shared `parseConfigArray()` helper for AST-based PHP config file parsing, used by CookieSecurityAnalyzer and HSTSHeaderAnalyzer
- **DebugModeAnalyzer**: Replaced `token_get_all()` + manual token context helpers with `FuncCall`/`Exit_` AST nodes, eliminating false positives from method calls, static calls, and function definitions
- **CookieSecurityAnalyzer**: Replaced regex config checks with `parseConfigArray()` for type-safe value comparison; replaced string matching in `bootstrap/app.php` with AST node searching (`MethodCall`, `Name`, `String_`)
- **HSTSHeaderAnalyzer**: Replaced fragile 3-step comment-stripping regex pipeline with AST `findStaticCalls()` for `URL::forceScheme('https')` / `URL::forceHttps()` detection; replaced regex config checks with `parseConfigArray()`
- **XssAnalyzer**: Added `analyzePhpFileWithAst()` for non-Blade PHP files (Echo_ nodes with superglobals/request calls, Response::make with user input) while preserving existing regex analysis for Blade templates