### PR TITLE
Deduplicate code, standardize config naming, centralize inline suppression

### DIFF
--- a/config/shieldci.php
+++ b/config/shieldci.php
@@ -33,6 +33,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Guest URL
+    |--------------------------------------------------------------------------
+    |
+    | Override the guest/login URL used by authentication-related analyzers.
+    | By default, the analyzers auto-detect common login routes.
+    |
+    */
+
+    'guest_url' => env('SHIELDCI_GUEST_URL'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Security Advisories
+    |--------------------------------------------------------------------------
+    |
+    | Configure the source for PHP security advisory data.
+    |
+    */
+
+    'security_advisories' => [
+        'source' => env('SHIELDCI_ADVISORY_SOURCE', 'https://api.osv.dev/v1/querybatch'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | CI Mode Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -15,6 +15,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\ClassifiesFiles;
 
 /**
  * Detects multiple database write operations without transactions.
@@ -26,6 +27,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
 {
+    use ClassifiesFiles;
+
     /**
      * Minimum number of writes that require full transactional atomicity.
      */
@@ -103,28 +106,6 @@ class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
             sprintf('Found %d method(s) with multiple writes missing transaction protection', count($issues)),
             $issues
         );
-    }
-
-    /**
-     * Check if file is a test file.
-     */
-    private function isTestFile(string $file): bool
-    {
-        return str_contains($file, '/tests/') ||
-               str_contains($file, '/Tests/') ||
-               str_ends_with($file, 'Test.php');
-    }
-
-    /**
-     * Check if file is a development helper file.
-     */
-    private function isDevelopmentFile(string $file): bool
-    {
-        return str_contains($file, '/database/seeders/') ||
-               str_contains($file, '/database/factories/') ||
-               str_contains($file, '/database/migrations/') ||
-               str_ends_with($file, 'Seeder.php') ||
-               str_ends_with($file, 'Factory.php');
     }
 }
 

--- a/src/Analyzers/Performance/CacheDriverAnalyzer.php
+++ b/src/Analyzers/Performance/CacheDriverAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Performance;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
@@ -28,7 +28,7 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
 class CacheDriverAnalyzer extends AbstractAnalyzer
 {
     public function __construct(
-        private ConfigRepository $config
+        private Config $config
     ) {
         $this->configRepository = $config;
     }

--- a/src/Analyzers/Performance/ConfigCachingAnalyzer.php
+++ b/src/Analyzers/Performance/ConfigCachingAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Performance;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Foundation\CachesConfiguration;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
@@ -33,7 +33,7 @@ class ConfigCachingAnalyzer extends AbstractAnalyzer
 
     public function __construct(
         private Application $app,
-        ConfigRepository $config
+        Config $config
     ) {
         $this->configRepository = $config;
     }

--- a/src/Analyzers/Performance/DebugLogAnalyzer.php
+++ b/src/Analyzers/Performance/DebugLogAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Performance;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
@@ -21,7 +21,7 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
  * - Expose sensitive debugging information
  *
  * Skips local/development/testing environments where debug logging is acceptable for development.
- * Uses Laravel's ConfigRepository for proper configuration checking.
+ * Uses Laravel's Config for proper configuration checking.
  */
 class DebugLogAnalyzer extends AbstractAnalyzer
 {
@@ -37,7 +37,7 @@ class DebugLogAnalyzer extends AbstractAnalyzer
     protected ?array $relevantEnvironments = ['production', 'staging'];
 
     public function __construct(
-        private ConfigRepository $config
+        private Config $config
     ) {
         $this->configRepository = $config;
     }

--- a/src/Analyzers/Performance/HorizonSuggestionAnalyzer.php
+++ b/src/Analyzers/Performance/HorizonSuggestionAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Performance;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
@@ -34,7 +34,7 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 class HorizonSuggestionAnalyzer extends AbstractAnalyzer
 {
     public function __construct(
-        private ConfigRepository $config
+        private Config $config
     ) {
         $this->configRepository = $config;
     }

--- a/src/Analyzers/Performance/MinificationAnalyzer.php
+++ b/src/Analyzers/Performance/MinificationAnalyzer.php
@@ -114,7 +114,7 @@ class MinificationAnalyzer extends AbstractFileAnalyzer
             return "Not relevant in '{$currentEnv}' environment (only relevant in: {$relevantEnvs})";
         }
 
-        return 'Build directory not found (configure via shieldci.build_path or SHIELDCI_BUILD_PATH)';
+        return 'Build directory not found (configure via shieldci.analyzers.performance.asset-minification.build_path or SHIELDCI_BUILD_PATH)';
     }
 
     protected function runAnalysis(): ResultInterface
@@ -425,7 +425,7 @@ class MinificationAnalyzer extends AbstractFileAnalyzer
         $basePath = ! empty($this->basePath) ? $this->basePath : $this->getBasePath();
 
         try {
-            $configPath = config('shieldci.build_path');
+            $configPath = config('shieldci.analyzers.performance.asset-minification.build_path');
 
             if ($configPath && is_string($configPath)) {
                 $resolved = str_starts_with($configPath, DIRECTORY_SEPARATOR)

--- a/src/Analyzers/Performance/MysqlSingleServerAnalyzer.php
+++ b/src/Analyzers/Performance/MysqlSingleServerAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Performance;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
@@ -21,7 +21,7 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  * - Performance improvements from using Unix sockets
  * - Single-server optimization recommendations
  *
- * Uses Laravel's ConfigRepository for proper configuration access.
+ * Uses Laravel's Config for proper configuration access.
  *
  * Environment Relevance:
  * - Production/Staging: Important (Unix sockets provide measurable performance improvement)
@@ -47,7 +47,7 @@ class MysqlSingleServerAnalyzer extends AbstractAnalyzer
     protected ?array $relevantEnvironments = ['production', 'staging'];
 
     public function __construct(
-        private ConfigRepository $config
+        private Config $config
     ) {
         $this->configRepository = $config;
     }

--- a/src/Analyzers/Performance/QueueDriverAnalyzer.php
+++ b/src/Analyzers/Performance/QueueDriverAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Performance;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
@@ -22,12 +22,12 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  * - Database queue driver performance considerations
  * - Recommends Redis/SQS for production
  *
- * Uses Laravel's ConfigRepository for proper configuration access.
+ * Uses Laravel's Config for proper configuration access.
  */
 class QueueDriverAnalyzer extends AbstractAnalyzer
 {
     public function __construct(
-        private ConfigRepository $config
+        private Config $config
     ) {
         $this->configRepository = $config;
     }

--- a/src/Analyzers/Performance/RouteCachingAnalyzer.php
+++ b/src/Analyzers/Performance/RouteCachingAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Performance;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Foundation\CachesRoutes;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
@@ -33,7 +33,7 @@ class RouteCachingAnalyzer extends AbstractAnalyzer
 
     public function __construct(
         private Application $app,
-        ConfigRepository $config
+        Config $config
     ) {
         $this->configRepository = $config;
     }

--- a/src/Analyzers/Performance/SessionDriverAnalyzer.php
+++ b/src/Analyzers/Performance/SessionDriverAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Performance;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Router;
 use Illuminate\Session\Middleware\StartSession;
@@ -35,7 +35,7 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
 class SessionDriverAnalyzer extends AbstractAnalyzer
 {
     public function __construct(
-        private ConfigRepository $config,
+        private Config $config,
         private Router $router,
         private Kernel $kernel
     ) {

--- a/src/Analyzers/Performance/SharedCacheLockAnalyzer.php
+++ b/src/Analyzers/Performance/SharedCacheLockAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Performance;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
@@ -47,7 +47,7 @@ class SharedCacheLockAnalyzer extends AbstractFileAnalyzer
 
     public function __construct(
         private ParserInterface $parser,
-        private ConfigRepository $config
+        private Config $config
     ) {}
 
     protected function metadata(): AnalyzerMetadata

--- a/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
+++ b/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
@@ -6,7 +6,7 @@ namespace ShieldCI\Analyzers\Performance;
 
 use Fideloper\Proxy\TrustProxies as FideloperTrustProxies;
 use Fruitcake\Cors\HandleCors as FruitcakeHandleCors;
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Middleware\HandleCors;
@@ -44,7 +44,7 @@ class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
 
     public function __construct(
         private Application $app,
-        private ConfigRepository $config,
+        private Config $config,
         Router $router,
         Kernel $kernel
     ) {

--- a/src/Analyzers/Performance/ViewCachingAnalyzer.php
+++ b/src/Analyzers/Performance/ViewCachingAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Performance;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Filesystem\Filesystem;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
@@ -47,7 +47,7 @@ class ViewCachingAnalyzer extends AbstractAnalyzer
 
     public function __construct(
         private Filesystem $files,
-        private ConfigRepository $config
+        private Config $config
     ) {
         $this->configRepository = $config;
     }

--- a/src/Analyzers/Reliability/DatabaseStatusAnalyzer.php
+++ b/src/Analyzers/Reliability/DatabaseStatusAnalyzer.php
@@ -107,7 +107,7 @@ class DatabaseStatusAnalyzer extends AbstractFileAnalyzer
      */
     private function getConnectionsToCheck(string $defaultConnection): array
     {
-        $configured = config('shieldci.database.connections', []);
+        $configured = config('shieldci.analyzers.reliability.database-status.connections', []);
 
         if (is_string($configured)) {
             $configured = array_filter(array_map('trim', explode(',', $configured)));

--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -89,7 +89,7 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
     private function getDirectoriesToCheck(string $basePath): array
     {
         $directoriesToCheck = $this->safeExecute(
-            fn () => config('shieldci.writable_directories'),
+            fn () => config('shieldci.analyzers.reliability.directory-write-permissions.writable_directories'),
             null
         );
 
@@ -367,7 +367,7 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
     private function isSymlinkCheckEnabled(): bool
     {
         $enabled = $this->safeExecute(
-            fn () => config('shieldci.check_symlinks', true),
+            fn () => config('shieldci.analyzers.reliability.directory-write-permissions.check_symlinks', true),
             true
         );
 

--- a/src/Analyzers/Security/DebugModeAnalyzer.php
+++ b/src/Analyzers/Security/DebugModeAnalyzer.php
@@ -17,6 +17,7 @@ use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\ClassifiesFiles;
 
 /**
  * Detects debug mode and debugging-related security issues.
@@ -30,6 +31,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class DebugModeAnalyzer extends AbstractFileAnalyzer
 {
+    use ClassifiesFiles;
+
     private const HIGH_SEVERITY_FUNCTIONS = ['dd', 'dump', 'var_dump', 'print_r'];
 
     private array $debugFunctions = [
@@ -483,36 +486,5 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
                 );
             }
         }
-    }
-
-    /**
-     * Check if file is a test file.
-     */
-    private function isTestFile(string $file): bool
-    {
-        return str_contains($file, '/tests/') ||
-               str_contains($file, '/Tests/') ||
-               str_ends_with($file, 'Test.php');
-    }
-
-    /**
-     * Check if file is a development helper file.
-     */
-    private function isDevelopmentFile(string $file): bool
-    {
-        return str_contains($file, '/database/seeders/') ||
-               str_contains($file, '/database/factories/') ||
-               str_contains($file, 'Seeder.php') ||
-               str_contains($file, 'Factory.php');
-    }
-
-    /**
-     * Check if file is a Console Command (where exit codes are legitimate).
-     */
-    private function isConsoleCommand(string $file): bool
-    {
-        return str_contains($file, '/Console/Commands/') ||
-               str_contains($file, '/app/Console/Commands/') ||
-               str_contains($file, '\\Console\\Commands\\');
     }
 }

--- a/src/Analyzers/Security/FilePermissionsAnalyzer.php
+++ b/src/Analyzers/Security/FilePermissionsAnalyzer.php
@@ -141,7 +141,7 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
 
         // Allow configuration override
         /** @var array<string, array{type: string, max: int, recommended: int, critical?: bool, executable?: bool}> $config */
-        $config = function_exists('config') ? config('shieldci.file_permissions', []) : [];
+        $config = function_exists('config') ? config('shieldci.analyzers.security.file-permissions', []) : [];
 
         return array_merge($defaults, $config);
     }

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -410,7 +410,7 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
     private function getConfiguration(): array
     {
         /** @var array<string, mixed> $config */
-        $config = config('shieldci.hsts_header', []);
+        $config = config('shieldci.analyzers.security.hsts-header', []);
 
         return array_merge([
             'min_max_age' => 15768000,  // 6 months in seconds

--- a/src/Analyzers/Security/LicenseAnalyzer.php
+++ b/src/Analyzers/Security/LicenseAnalyzer.php
@@ -390,7 +390,7 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
     private function getConfiguration(): array
     {
         /** @var array<string, mixed> $config */
-        $config = config('shieldci.license_compliance', []);
+        $config = config('shieldci.analyzers.security.license-compliance', []);
 
         return array_merge([
             'whitelisted_licenses' => $this->whitelistedLicenses,

--- a/src/Analyzers/Security/PHPIniAnalyzer.php
+++ b/src/Analyzers/Security/PHPIniAnalyzer.php
@@ -272,7 +272,7 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
         ];
 
         if (function_exists('config')) {
-            $config = config('shieldci.php_configuration', []);
+            $config = config('shieldci.analyzers.security.php-ini.php_configuration', []);
             if (is_array($config)) {
                 /** @var array{ini_path?: string|null, secure_settings?: array<string, bool>} $config */
                 $merged = array_replace_recursive($defaults, $config);
@@ -298,7 +298,7 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
 
         $configPath = null;
         if (function_exists('config')) {
-            $configPath = config('shieldci.php_configuration.ini_path');
+            $configPath = config('shieldci.analyzers.security.php-ini.ini_path');
         }
 
         if (is_string($configPath) && $configPath !== '') {

--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -1353,7 +1353,7 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
          *    password_confirmation_max_timeout?: int
          * } $config
          */
-        $config = config('shieldci.password_security', []);
+        $config = config('shieldci.analyzers.security.password-security', []);
 
         return [
             'bcrypt_min_rounds' => ($config['bcrypt_min_rounds'] ?? 12),

--- a/src/Analyzers/Security/SqlInjectionAnalyzer.php
+++ b/src/Analyzers/Security/SqlInjectionAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Security;
 
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository as Config;
 use PhpParser\Node;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
@@ -138,7 +138,7 @@ class SqlInjectionAnalyzer extends AbstractFileAnalyzer
 
     public function __construct(
         private ParserInterface $parser,
-        private ?ConfigRepository $config = null
+        private Config $config,
     ) {}
 
     protected function metadata(): AnalyzerMetadata
@@ -423,11 +423,9 @@ class SqlInjectionAnalyzer extends AbstractFileAnalyzer
      */
     private function getNativeMysqliFunctions(): array
     {
-        if ($this->config) {
-            $custom = $this->config->get('shieldci.analyzers.security.sql-injection.mysqli_functions');
-            if (is_array($custom) && ! empty($custom)) {
-                return $custom;
-            }
+        $custom = $this->config->get('shieldci.analyzers.security.sql-injection.mysqli_functions');
+        if (is_array($custom) && ! empty($custom)) {
+            return $custom;
         }
 
         return $this->nativeMysqliFunctions;
@@ -440,11 +438,9 @@ class SqlInjectionAnalyzer extends AbstractFileAnalyzer
      */
     private function getNativePostgresFunctions(): array
     {
-        if ($this->config) {
-            $custom = $this->config->get('shieldci.analyzers.security.sql-injection.postgres_functions');
-            if (is_array($custom) && ! empty($custom)) {
-                return $custom;
-            }
+        $custom = $this->config->get('shieldci.analyzers.security.sql-injection.postgres_functions');
+        if (is_array($custom) && ! empty($custom)) {
+            return $custom;
         }
 
         return $this->nativePostgresFunctions;

--- a/src/Concerns/ClassifiesFiles.php
+++ b/src/Concerns/ClassifiesFiles.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Concerns;
+
+/**
+ * Trait for classifying files by their role in a Laravel project.
+ *
+ * Provides helper methods to identify test files, development-only files,
+ * and console commands — allowing analyzers to skip files that shouldn't
+ * trigger production-focused checks.
+ */
+trait ClassifiesFiles
+{
+    /**
+     * Check if file is a test file.
+     */
+    private function isTestFile(string $file): bool
+    {
+        return str_contains($file, '/tests/') ||
+               str_contains($file, '/Tests/') ||
+               str_ends_with($file, 'Test.php');
+    }
+
+    /**
+     * Check if file is a development helper file.
+     */
+    private function isDevelopmentFile(string $file): bool
+    {
+        return str_contains($file, '/database/seeders/') ||
+               str_contains($file, '/database/factories/') ||
+               str_contains($file, '/database/migrations/') ||
+               str_ends_with($file, 'Seeder.php') ||
+               str_ends_with($file, 'Factory.php');
+    }
+
+    /**
+     * Check if file is a Console Command.
+     */
+    private function isConsoleCommand(string $file): bool
+    {
+        return str_contains($file, '/Console/Commands/') ||
+               str_contains($file, '/app/Console/Commands/') ||
+               str_contains($file, '\\Console\\Commands\\');
+    }
+}

--- a/src/Support/InlineSuppressionParser.php
+++ b/src/Support/InlineSuppressionParser.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+/**
+ * Parses @shieldci-ignore inline comments from source files.
+ *
+ * Supports two placement styles (matching PHPStan conventions):
+ *   - Previous line: `// @shieldci-ignore [analyzer-id,...]`
+ *   - Same line:     `$code; // @shieldci-ignore [analyzer-id,...]`
+ *
+ * When no analyzer IDs are specified, the suppression applies to all analyzers.
+ * Multiple IDs can be comma-separated: `@shieldci-ignore sql-injection,xss-detection`
+ */
+class InlineSuppressionParser
+{
+    /**
+     * Cached file lines keyed by absolute file path.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private array $fileCache = [];
+
+    /**
+     * Determine if an issue at the given file and line is suppressed for an analyzer.
+     *
+     * Checks the issue line itself and the line immediately above it for
+     * a @shieldci-ignore comment that either targets all analyzers (bare)
+     * or specifically names the given analyzer ID.
+     */
+    public function isLineSuppressed(string $filePath, int $line, string $analyzerId): bool
+    {
+        if ($line < 1) {
+            return false;
+        }
+
+        $lines = $this->getFileLines($filePath);
+
+        if ($lines === []) {
+            return false;
+        }
+
+        // Check same line and previous line (1-based to 0-based index)
+        foreach ([$line - 1, $line - 2] as $index) {
+            if ($index < 0 || ! isset($lines[$index])) {
+                continue;
+            }
+
+            if ($this->lineHasSuppression($lines[$index], $analyzerId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a single line of text contains a matching @shieldci-ignore comment.
+     */
+    private function lineHasSuppression(string $lineContent, string $analyzerId): bool
+    {
+        // Match @shieldci-ignore optionally followed by comma-separated analyzer IDs
+        if (! preg_match('/@shieldci-ignore(?:\s+([\w,-]+))?/i', $lineContent, $matches)) {
+            return false;
+        }
+
+        // Bare @shieldci-ignore — suppresses all analyzers
+        if (! isset($matches[1])) {
+            return true;
+        }
+
+        // Specific analyzer IDs — check if our analyzer is listed
+        $ids = array_map('trim', explode(',', $matches[1]));
+
+        return in_array($analyzerId, $ids, true);
+    }
+
+    /**
+     * Read and cache file lines for a given path.
+     *
+     * @return array<int, string>
+     */
+    private function getFileLines(string $filePath): array
+    {
+        if (isset($this->fileCache[$filePath])) {
+            return $this->fileCache[$filePath];
+        }
+
+        if (! is_file($filePath) || ! is_readable($filePath)) {
+            $this->fileCache[$filePath] = [];
+
+            return [];
+        }
+
+        $content = file_get_contents($filePath);
+
+        if ($content === false) {
+            $this->fileCache[$filePath] = [];
+
+            return [];
+        }
+
+        $this->fileCache[$filePath] = explode("\n", $content);
+
+        return $this->fileCache[$filePath];
+    }
+}

--- a/src/Support/PHPStan.php
+++ b/src/Support/PHPStan.php
@@ -224,7 +224,7 @@ class PHPStan
         $result = [];
 
         /** @var array<string, string|bool> */
-        $configs = config('shieldci.phpstan', [
+        $configs = config('shieldci.analyzers.reliability.phpstan.options', [
             '--error-format' => 'json',
             '--no-progress' => true,
         ]);

--- a/tests/Unit/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzerTest.php
@@ -403,44 +403,6 @@ PHP;
         $this->assertHasIssueContaining('both Eloquent and Query Builder', $result);
     }
 
-    public function test_respects_suppression_comments(): void
-    {
-        $code = <<<'PHP'
-<?php
-
-namespace App\Repositories;
-
-use App\Models\User;
-use Illuminate\Support\Facades\DB;
-
-/**
- * @shieldci-ignore mixed-query-builder-eloquent
- */
-class UserRepository
-{
-    public function findActive()
-    {
-        return User::where('active', true)->get();
-    }
-
-    public function getUserCount()
-    {
-        return DB::table('users')->count();
-    }
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory(['Repositories/UserRepository.php' => $code]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['.']);
-
-        $result = $analyzer->analyze();
-
-        $this->assertPassed($result);
-    }
-
     public function test_detects_extended_eloquent_methods(): void
     {
         $code = <<<'PHP'
@@ -530,44 +492,6 @@ PHP;
         $this->assertNotNull($sameTableIssue, 'Should find same-table mixing issue');
         $this->assertEquals('High', $sameTableIssue->severity->name);
         $this->assertStringContainsString('may bypass global scopes', $sameTableIssue->recommendation);
-    }
-
-    public function test_general_suppression_comment_works(): void
-    {
-        $code = <<<'PHP'
-<?php
-
-namespace App\Repositories;
-
-use App\Models\User;
-use Illuminate\Support\Facades\DB;
-
-/**
- * @shieldci-ignore
- */
-class UserRepository
-{
-    public function findActive()
-    {
-        return User::where('active', true)->get();
-    }
-
-    public function getUserCount()
-    {
-        return DB::table('users')->count();
-    }
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory(['Repositories/UserRepository.php' => $code]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['.']);
-
-        $result = $analyzer->analyze();
-
-        $this->assertPassed($result);
     }
 
     public function test_detects_query_builder_via_model_tobase(): void

--- a/tests/Unit/Analyzers/Performance/MinificationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/MinificationAnalyzerTest.php
@@ -286,7 +286,7 @@ JS;
             'custom_build/css/app.css' => $unminifiedCss,
         ]);
 
-        config(['shieldci.build_path' => 'custom_build']);
+        config(['shieldci.analyzers.performance.asset-minification.build_path' => 'custom_build']);
 
         $analyzer = $this->createAnalyzer();
         $analyzer->setBasePath($tempDir);
@@ -368,7 +368,7 @@ JS;
         ]);
 
         // Set config to use temp directory's public path (which doesn't exist)
-        config(['shieldci.build_path' => $tempDir.'/public']);
+        config(['shieldci.analyzers.performance.asset-minification.build_path' => $tempDir.'/public']);
 
         /** @var MinificationAnalyzer $analyzer */
         $analyzer = $this->createAnalyzer();
@@ -1214,7 +1214,7 @@ JS;
         ]);
 
         $absolutePath = $tempDir.DIRECTORY_SEPARATOR.'custom';
-        config(['shieldci.build_path' => $absolutePath]);
+        config(['shieldci.analyzers.performance.asset-minification.build_path' => $absolutePath]);
 
         $analyzer = $this->createAnalyzer();
         $analyzer->setBasePath($tempDir);
@@ -1233,7 +1233,7 @@ JS;
             'public/css/app.css' => str_repeat("body {\n    color: red;\n}\n", 10),
         ]);
 
-        config(['shieldci.build_path' => '/completely/different/path']);
+        config(['shieldci.analyzers.performance.asset-minification.build_path' => '/completely/different/path']);
 
         $analyzer = $this->createAnalyzer();
         $analyzer->setBasePath($tempDir);

--- a/tests/Unit/Analyzers/Reliability/DatabaseStatusAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/DatabaseStatusAnalyzerTest.php
@@ -20,7 +20,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         Mockery::close();
         /** @var Config $config */
         $config = $this->app?->make('config') ?? app('config');
-        $config->set('shieldci.database.connections', []);
+        $config->set('shieldci.analyzers.reliability.database-status.connections', []);
 
         parent::tearDown();
     }
@@ -161,7 +161,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $this->applyDatabaseConfig($connections);
         /** @var Config $config */
         $config = $this->app?->make('config') ?? app('config');
-        $config->set('shieldci.database.connections', ['sqlite']);
+        $config->set('shieldci.analyzers.reliability.database-status.connections', ['sqlite']);
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
 
@@ -201,7 +201,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $this->applyDatabaseConfig();
         /** @var Config $config */
         $config = $this->app?->make('config') ?? app('config');
-        $config->set('shieldci.database.connections', 'mysql,sqlite');
+        $config->set('shieldci.analyzers.reliability.database-status.connections', 'mysql,sqlite');
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
         /** @phpstan-ignore-next-line */
@@ -226,7 +226,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $this->applyDatabaseConfig();
         /** @var Config $config */
         $config = $this->app?->make('config') ?? app('config');
-        $config->set('shieldci.database.connections', ['mysql', null, 123, '', 'valid']);
+        $config->set('shieldci.analyzers.reliability.database-status.connections', ['mysql', null, 123, '', 'valid']);
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
         /** @phpstan-ignore-next-line */
@@ -251,7 +251,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $this->applyDatabaseConfig();
         /** @var Config $config */
         $config = $this->app?->make('config') ?? app('config');
-        $config->set('shieldci.database.connections', 'mysql , sqlite ');
+        $config->set('shieldci.analyzers.reliability.database-status.connections', 'mysql , sqlite ');
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
         /** @phpstan-ignore-next-line */
@@ -480,7 +480,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         // Default is 'mysql', and we configure 'mysql' again
         /** @var Config $config */
         $config = $this->app?->make('config') ?? app('config');
-        $config->set('shieldci.database.connections', ['mysql']);
+        $config->set('shieldci.analyzers.reliability.database-status.connections', ['mysql']);
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
         // Should only be called once for mysql (deduplicated)
@@ -868,7 +868,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $this->applyDatabaseConfig($connections);
         /** @var Config $config */
         $config = $this->app?->make('config') ?? app('config');
-        $config->set('shieldci.database.connections', ['sqlite']);
+        $config->set('shieldci.analyzers.reliability.database-status.connections', ['sqlite']);
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
         /** @phpstan-ignore-next-line */
@@ -907,7 +907,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $this->applyDatabaseConfig($connections);
         /** @var Config $config */
         $config = $this->app?->make('config') ?? app('config');
-        $config->set('shieldci.database.connections', ['sqlite']);
+        $config->set('shieldci.analyzers.reliability.database-status.connections', ['sqlite']);
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
         /** @phpstan-ignore-next-line */

--- a/tests/Unit/Analyzers/Reliability/DirectoryWritePermissionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/DirectoryWritePermissionsAnalyzerTest.php
@@ -34,11 +34,11 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
 
         // Configure to check these specific directories (disable symlink check for this test)
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -57,11 +57,11 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
 
         // Configure to check non-existent directories
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -84,10 +84,10 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         chmod($tempDir.'/storage', 0555);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -107,12 +107,12 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         $tempDir = $this->createTempDirectory([]);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
                 $tempDir.'/custom/cache',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -144,10 +144,10 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         ]);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/custom/path',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -166,8 +166,8 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         ]);
 
         config([
-            'shieldci.writable_directories' => [],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [],
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -188,8 +188,8 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
 
         // Set invalid config (not an array)
         config([
-            'shieldci.writable_directories' => 'not-an-array',
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => 'not-an-array',
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -208,14 +208,14 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         ]);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 null,
                 123,
                 '',
                 ['nested' => 'array'],
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -237,12 +237,12 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
 
         // Use relative paths like in the real config
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 'storage',
                 'bootstrap/cache',
                 'custom/dir',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -263,11 +263,11 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
 
         // Mix of absolute and relative paths
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage', // Absolute
                 'cache',              // Relative
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -288,10 +288,10 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         $tempDir = $this->createTempDirectory([]);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -314,11 +314,11 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         $tempDir = $this->createTempDirectory([]);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -342,10 +342,10 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         $tempDir = $this->createTempDirectory([]);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -379,11 +379,11 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         chmod($tempDir.'/storage', 0555);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',        // exists but not writable
                 $tempDir.'/bootstrap/cache', // missing
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -418,10 +418,10 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         $tempDir = $this->createTempDirectory([]);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -448,10 +448,10 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         chmod($tempDir.'/storage', 0555);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -480,11 +480,11 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         chmod($tempDir.'/storage', 0555);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/cache',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -513,11 +513,11 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         chmod($tempDir.'/storage', 0555);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/cache',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -550,10 +550,10 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         }
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $symlinkPath,
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -571,8 +571,8 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         $analyzer->setBasePath('');
 
         config([
-            'shieldci.writable_directories' => null,
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => null,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $result = $analyzer->analyze();
@@ -600,14 +600,14 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         }
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
             'filesystems.links' => [
                 $tempDir.'/public/storage' => $tempDir.'/storage/app/public',
             ],
-            'shieldci.check_symlinks' => true,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -631,14 +631,14 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         // Don't create the symlink
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
             'filesystems.links' => [
                 $tempDir.'/public/storage' => $tempDir.'/storage/app/public',
             ],
-            'shieldci.check_symlinks' => true,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -678,14 +678,14 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         // Note: storage/app/public doesn't exist, so symlink is broken
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
             'filesystems.links' => [
                 $tempDir.'/public/storage' => $tempDir.'/storage/app/public',
             ],
-            'shieldci.check_symlinks' => true,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -722,14 +722,14 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         }
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
             'filesystems.links' => [
                 $tempDir.'/public/storage' => $tempDir.'/storage/app/public',
             ],
-            'shieldci.check_symlinks' => true,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -763,12 +763,12 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         // Should use default public/storage -> storage/app/public
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
             'filesystems.links' => null,
-            'shieldci.check_symlinks' => true,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -799,7 +799,7 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         }
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
@@ -807,7 +807,7 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
                 $tempDir.'/public/storage' => $tempDir.'/storage/app/public',
                 $tempDir.'/public/uploads' => $tempDir.'/storage/app/uploads',
             ],
-            'shieldci.check_symlinks' => true,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -829,14 +829,14 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         // No symlink created, but check is disabled
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
             'filesystems.links' => [
                 $tempDir.'/public/storage' => $tempDir.'/storage/app/public',
             ],
-            'shieldci.check_symlinks' => false,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => false,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -857,14 +857,14 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         ]);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
             'filesystems.links' => [
                 $tempDir.'/public/storage' => $tempDir.'/storage/app/public',
             ],
-            'shieldci.check_symlinks' => true,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -895,7 +895,7 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         ]);
 
         config([
-            'shieldci.writable_directories' => [
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
                 $tempDir.'/storage',
                 $tempDir.'/bootstrap/cache',
             ],
@@ -903,7 +903,7 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
                 $tempDir.'/public/storage' => $tempDir.'/storage/app/public',
                 $tempDir.'/public/uploads' => $tempDir.'/storage/app/uploads',
             ],
-            'shieldci.check_symlinks' => true,
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
         $analyzer = $this->createAnalyzer();

--- a/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
@@ -3049,87 +3049,8 @@ PHP;
     // ==========================================
     // Suppression Comment Tests (@shieldci-ignore)
     // ==========================================
-
-    public function test_suppresses_route_with_shieldci_ignore_comment(): void
-    {
-        $routes = <<<'PHP'
-<?php
-
-// @shieldci-ignore authentication
-Route::post('/public-webhook', [WebhookController::class, 'handle']);
-PHP;
-
-        $tempDir = $this->createTempDirectory([
-            'routes/web.php' => $routes,
-        ]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-
-        $result = $analyzer->analyze();
-
-        // Should pass because route is suppressed
-        $this->assertPassed($result);
-    }
-
-    public function test_suppresses_controller_method_with_shieldci_ignore_docblock(): void
-    {
-        $controller = <<<'PHP'
-<?php
-
-namespace App\Http\Controllers;
-
-class WebhookController extends Controller
-{
-    /**
-     * Public webhook endpoint for external systems
-     * @shieldci-ignore authentication
-     */
-    public function store()
-    {
-        // Public webhook logic
-    }
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory([
-            'app/Http/Controllers/WebhookController.php' => $controller,
-        ]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['app']);
-
-        $result = $analyzer->analyze();
-
-        // Should pass because method is suppressed
-        $this->assertPassed($result);
-    }
-
-    public function test_suppresses_route_group_with_shieldci_ignore_comment(): void
-    {
-        $routes = <<<'PHP'
-<?php
-
-// @shieldci-ignore
-Route::group(['prefix' => 'webhooks'], function () {
-    Route::post('/stripe', [WebhookController::class, 'stripe']);
-    Route::post('/paypal', [WebhookController::class, 'paypal']);
-});
-PHP;
-
-        $tempDir = $this->createTempDirectory([
-            'routes/web.php' => $routes,
-        ]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-
-        $result = $analyzer->analyze();
-
-        // Should pass because route group is suppressed
-        $this->assertPassed($result);
-    }
+    // Note: @shieldci-ignore is now handled centrally by AnalyzeCommand.
+    // See tests/Unit/Support/InlineSuppressionParserTest.php for suppression tests.
 
     public function test_does_not_suppress_without_specific_tag(): void
     {

--- a/tests/Unit/Analyzers/Security/HSTSHeaderAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/HSTSHeaderAnalyzerTest.php
@@ -648,7 +648,7 @@ PHP;
 
     public function test_warns_about_missing_preload_when_configured(): void
     {
-        config(['shieldci.hsts_header.require_preload' => true]);
+        config(['shieldci.analyzers.security.hsts-header.require_preload' => true]);
 
         $sessionConfig = <<<'PHP'
 <?php
@@ -690,7 +690,7 @@ PHP;
 
     public function test_passes_with_preload_when_configured(): void
     {
-        config(['shieldci.hsts_header.require_preload' => true]);
+        config(['shieldci.analyzers.security.hsts-header.require_preload' => true]);
 
         $sessionConfig = <<<'PHP'
 <?php
@@ -966,7 +966,7 @@ PHP;
 
     public function test_skips_session_check_when_disabled_in_config(): void
     {
-        config(['shieldci.hsts_header.check_session_secure' => false]);
+        config(['shieldci.analyzers.security.hsts-header.check_session_secure' => false]);
 
         $sessionConfig = <<<'PHP'
 <?php
@@ -1017,7 +1017,7 @@ PHP;
 
     public function test_respects_custom_min_max_age(): void
     {
-        config(['shieldci.hsts_header.min_max_age' => 31536000]); // 1 year
+        config(['shieldci.analyzers.security.hsts-header.min_max_age' => 31536000]); // 1 year
 
         $sessionConfig = <<<'PHP'
 <?php
@@ -1059,7 +1059,7 @@ PHP;
 
     public function test_respects_disabled_include_subdomains_requirement(): void
     {
-        config(['shieldci.hsts_header.require_include_subdomains' => false]);
+        config(['shieldci.analyzers.security.hsts-header.require_include_subdomains' => false]);
 
         $sessionConfig = <<<'PHP'
 <?php
@@ -1100,7 +1100,7 @@ PHP;
 
     public function test_respects_ignored_middleware(): void
     {
-        config(['shieldci.hsts_header.ignored_middleware' => ['TestMiddleware']]);
+        config(['shieldci.analyzers.security.hsts-header.ignored_middleware' => ['TestMiddleware']]);
 
         $sessionConfig = <<<'PHP'
 <?php
@@ -1147,7 +1147,7 @@ PHP;
 
     public function test_reports_multiple_issues(): void
     {
-        config(['shieldci.hsts_header.require_preload' => true]);
+        config(['shieldci.analyzers.security.hsts-header.require_preload' => true]);
 
         $sessionConfig = <<<'PHP'
 <?php

--- a/tests/Unit/Analyzers/Security/PHPIniAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/PHPIniAnalyzerTest.php
@@ -173,7 +173,7 @@ class PHPIniAnalyzerTest extends AnalyzerTestCase
         ]);
 
         config([
-            'shieldci.php_configuration.secure_settings' => [
+            'shieldci.analyzers.security.php-ini.php_configuration.secure_settings' => [
                 'custom_setting' => false,
             ],
         ]);

--- a/tests/Unit/Analyzers/Security/PasswordSecurityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/PasswordSecurityAnalyzerTest.php
@@ -1493,7 +1493,7 @@ PHP;
         $analyzer = $this->createAnalyzer();
         $analyzer->setBasePath($tempDir);
 
-        $this->app['config']->set('shieldci.password_security.password_confirmation_max_timeout', 3600);
+        $this->app['config']->set('shieldci.analyzers.security.password-security.password_confirmation_max_timeout', 3600);
 
         $result = $analyzer->analyze();
 

--- a/tests/Unit/Analyzers/Security/SqlInjectionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/SqlInjectionAnalyzerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ShieldCI\Tests\Unit\Analyzers\Security;
 
+use Illuminate\Contracts\Config\Repository as Config;
+use Mockery;
 use ShieldCI\Analyzers\Security\SqlInjectionAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
 use ShieldCI\Tests\AnalyzerTestCase;
@@ -12,7 +14,13 @@ class SqlInjectionAnalyzerTest extends AnalyzerTestCase
 {
     protected function createAnalyzer(): AnalyzerInterface
     {
-        return new SqlInjectionAnalyzer($this->parser);
+        /** @var Config&\Mockery\MockInterface $config */
+        $config = Mockery::mock(Config::class);
+
+        /** @phpstan-ignore-next-line */
+        $config->shouldReceive('get')->andReturn(null);
+
+        return new SqlInjectionAnalyzer($this->parser, $config);
     }
 
     public function test_passes_with_safe_query_builder(): void

--- a/tests/Unit/Support/InlineSuppressionParserTest.php
+++ b/tests/Unit/Support/InlineSuppressionParserTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use PHPUnit\Framework\Attributes\Test;
+use ShieldCI\Support\InlineSuppressionParser;
+use ShieldCI\Tests\TestCase;
+
+class InlineSuppressionParserTest extends TestCase
+{
+    private InlineSuppressionParser $parser;
+
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new InlineSuppressionParser;
+        $this->tempDir = sys_get_temp_dir().'/shieldci-suppression-test-'.uniqid();
+        mkdir($this->tempDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up temp files
+        $files = glob($this->tempDir.'/*');
+        if ($files !== false) {
+            array_map('unlink', $files);
+        }
+        if (is_dir($this->tempDir)) {
+            rmdir($this->tempDir);
+        }
+        parent::tearDown();
+    }
+
+    private function createTempFile(string $content): string
+    {
+        $path = $this->tempDir.'/test_'.uniqid().'.php';
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
+    // ==========================================
+    // Bare @shieldci-ignore (suppress all analyzers)
+    // ==========================================
+
+    #[Test]
+    public function bare_ignore_on_previous_line_suppresses_any_analyzer(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+// @shieldci-ignore
+Route::post('/webhook', [WebhookController::class, 'handle']);
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'authentication-authorization'));
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'sql-injection'));
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'any-analyzer'));
+    }
+
+    #[Test]
+    public function bare_ignore_on_same_line_suppresses_any_analyzer(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+$result = DB::select("SELECT * FROM users"); // @shieldci-ignore
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 2, 'sql-injection'));
+        $this->assertTrue($this->parser->isLineSuppressed($file, 2, 'xss-detection'));
+    }
+
+    // ==========================================
+    // Specific analyzer ID suppression
+    // ==========================================
+
+    #[Test]
+    public function specific_analyzer_id_on_previous_line_suppresses_only_that_analyzer(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+// @shieldci-ignore sql-injection
+$result = DB::select("SELECT * FROM users WHERE id = $id");
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'sql-injection'));
+        $this->assertFalse($this->parser->isLineSuppressed($file, 3, 'xss-detection'));
+    }
+
+    #[Test]
+    public function specific_analyzer_id_on_same_line_suppresses_only_that_analyzer(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+echo $userInput; // @shieldci-ignore xss-detection
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 2, 'xss-detection'));
+        $this->assertFalse($this->parser->isLineSuppressed($file, 2, 'sql-injection'));
+    }
+
+    // ==========================================
+    // Comma-separated multiple analyzer IDs
+    // ==========================================
+
+    #[Test]
+    public function comma_separated_ids_suppress_all_listed_analyzers(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+// @shieldci-ignore sql-injection,xss-detection
+echo DB::select("SELECT * FROM users WHERE name = '$name'");
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'sql-injection'));
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'xss-detection'));
+        $this->assertFalse($this->parser->isLineSuppressed($file, 3, 'authentication-authorization'));
+    }
+
+    // ==========================================
+    // No suppression
+    // ==========================================
+
+    #[Test]
+    public function line_without_suppression_comment_is_not_suppressed(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+// This is a normal comment
+$result = DB::select("SELECT * FROM users");
+PHP);
+
+        $this->assertFalse($this->parser->isLineSuppressed($file, 3, 'sql-injection'));
+    }
+
+    #[Test]
+    public function suppression_on_unrelated_line_does_not_affect_other_lines(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+// @shieldci-ignore sql-injection
+$safe = DB::select("SELECT 1");
+
+$unsafe = DB::select("SELECT * FROM users WHERE id = $id");
+PHP);
+
+        // Line 3 is suppressed (line 2 is the comment)
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'sql-injection'));
+
+        // Line 5 is NOT suppressed (the comment on line 2 only covers line 2 and 3)
+        $this->assertFalse($this->parser->isLineSuppressed($file, 5, 'sql-injection'));
+    }
+
+    // ==========================================
+    // Edge cases
+    // ==========================================
+
+    #[Test]
+    public function nonexistent_file_returns_not_suppressed(): void
+    {
+        $this->assertFalse($this->parser->isLineSuppressed('/nonexistent/path.php', 1, 'sql-injection'));
+    }
+
+    #[Test]
+    public function line_zero_returns_not_suppressed(): void
+    {
+        $file = $this->createTempFile("<?php\n// @shieldci-ignore\n\$x = 1;");
+
+        $this->assertFalse($this->parser->isLineSuppressed($file, 0, 'sql-injection'));
+    }
+
+    #[Test]
+    public function negative_line_returns_not_suppressed(): void
+    {
+        $file = $this->createTempFile("<?php\n// @shieldci-ignore\n\$x = 1;");
+
+        $this->assertFalse($this->parser->isLineSuppressed($file, -1, 'sql-injection'));
+    }
+
+    #[Test]
+    public function first_line_of_file_can_be_suppressed(): void
+    {
+        $file = $this->createTempFile('<?php // @shieldci-ignore');
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 1, 'any-analyzer'));
+    }
+
+    #[Test]
+    public function case_insensitive_matching(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+// @SHIELDCI-IGNORE sql-injection
+$result = DB::select("SELECT 1");
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'sql-injection'));
+    }
+
+    #[Test]
+    public function file_reads_are_cached(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+// @shieldci-ignore
+$a = 1;
+$b = 2;
+PHP);
+
+        // First call reads the file
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'x'));
+
+        // Second call should use cache (same parser instance)
+        $this->assertFalse($this->parser->isLineSuppressed($file, 4, 'x'));
+    }
+
+    // ==========================================
+    // Comment styles
+    // ==========================================
+
+    #[Test]
+    public function hash_comment_style_works(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+# @shieldci-ignore sql-injection
+$result = DB::select("SELECT 1");
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'sql-injection'));
+    }
+
+    #[Test]
+    public function block_comment_style_works(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+/* @shieldci-ignore sql-injection */
+$result = DB::select("SELECT 1");
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'sql-injection'));
+    }
+
+    #[Test]
+    public function docblock_comment_style_works(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+/** @shieldci-ignore sql-injection */
+$result = DB::select("SELECT 1");
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'sql-injection'));
+    }
+}


### PR DESCRIPTION
## Summary
- **Code deduplication**: Extract `ClassifiesFiles` trait from duplicated `isTestFile()`/`isDevelopmentFile()` methods in `DebugModeAnalyzer` and `MissingDatabaseTransactionsAnalyzer`
- **Centralized `@shieldci-ignore`**: Create `InlineSuppressionParser` and integrate into `AnalyzeCommand` so inline suppression works for **all** analyzers automatically. Remove per-analyzer implementations from `AuthenticationAnalyzer` and `MixedQueryBuilderEloquentAnalyzer`
- **Config naming consistency**: Standardize `ConfigRepository` → `Config` alias across 12 analyzers. Make `SqlInjectionAnalyzer` config required (was nullable) to match all other analyzers