### PR TITLE
Improve PHPStan recommendation for undefined Eloquent Attribute properties

### DIFF
--- a/src/Analyzers/Reliability/PHPStanAnalyzer.php
+++ b/src/Analyzers/Reliability/PHPStanAnalyzer.php
@@ -428,6 +428,7 @@ class PHPStanAnalyzer extends AbstractFileAnalyzer
                 'might not exist' => 'Fix the offset access - the offset might not exist. Add an isset() check before accessing the offset.',
             ],
             'invalid-property-access' => [
+                'Access to an undefined property' => 'Fix the property access - the property does not exist on this class. If this is an Eloquent Attribute accessor, add a generic return type PHPDoc: /** @return Attribute<string, never> */. Larastan requires generic Attribute<TGet, TSet> annotations to recognize accessor-defined properties.',
                 'undefined property' => 'Fix the property access - the property does not exist on this class. Check for typos in the property name or ensure the property is defined.',
                 'private' => 'Fix the property visibility - you are accessing a private/protected property outside its scope.',
                 'protected' => 'Fix the property visibility - you are accessing a private/protected property outside its scope.',


### PR DESCRIPTION
## Summary

- Adds a specific recommendation for `Access to an undefined property` errors in the `invalid-property-access` category
- Guides users to add `@return Attribute<TGet, TSet>` generic PHPDoc annotations on Eloquent Attribute accessors, which Larastan requires to recognize accessor-defined properties
- Places the more specific keyword before the broader `undefined property` entry to ensure correct `str_contains()` matching order