### PR TITLE
Improve PHPStan recommendation for Eloquent scope methods

### DIFF
--- a/src/Analyzers/Reliability/PHPStanAnalyzer.php
+++ b/src/Analyzers/Reliability/PHPStanAnalyzer.php
@@ -413,6 +413,7 @@ class PHPStanAnalyzer extends AbstractFileAnalyzer
                 'not found' => 'Fix the import - the class, interface, or trait does not exist. Check for typos in the import statement or ensure the file exists.',
             ],
             'invalid-method-calls' => [
+                'Eloquent\Builder' => 'Fix the method call - if this is an Eloquent local scope, narrow the Builder type with an inline @var annotation: /** @var \Illuminate\Database\Eloquent\Builder<\App\Models\YourModel> $query */. This is the simplest fix when calling scopes inside closures. Alternatively, add a @method annotation to the model: /** @method static \Illuminate\Database\Eloquent\Builder<static> sent() */. ShieldCI includes Larastan which recognizes most scopes automatically, but scopes inside closures, traits, or parent models may need these annotations.',
                 'undefined method' => 'Fix the method call - the method does not exist on this class. Check for typos in the method name or ensure the method is defined.',
                 'Parameter' => 'Fix the method parameters - they do not match the method signature. Check the parameter types, order, and count.',
                 'private' => 'Fix the method visibility - you are calling a private/protected method outside its scope.',


### PR DESCRIPTION
## Summary
- Added Eloquent scope-specific recommendation to `invalid-method-calls` category in PHPStanAnalyzer
- When PHPStan reports undefined methods on `Eloquent\Builder`, the recommendation now suggests:
  1. Inline `@var` annotation to narrow the Builder type (simplest fix for closures)
  2. `@method` annotation on the model as an alternative
- Added test validating the scope-specific recommendation is returned for Builder method call errors

Follows the same keyword-priority pattern established in #70 for Eloquent Attribute accessor recommendations.