### PR TITLE
Show human-readable analyzer names in CLI output

### DIFF
--- a/src/Analyzers/Reliability/PHPStanAnalyzer.php
+++ b/src/Analyzers/Reliability/PHPStanAnalyzer.php
@@ -253,7 +253,7 @@ class PHPStanAnalyzer extends AbstractFileAnalyzer
     {
         return new AnalyzerMetadata(
             id: 'phpstan',
-            name: 'PHPStan Static Analysis',
+            name: 'PHPStan Static Analyzer',
             description: 'Comprehensive static analysis using PHPStan to detect type errors, undefined references, and code quality issues',
             category: Category::Reliability,
             severity: Severity::High,

--- a/tests/Unit/Analyzers/Reliability/PHPStanAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/PHPStanAnalyzerTest.php
@@ -545,7 +545,7 @@ PHP;
         $metadata = $analyzer->getMetadata();
 
         $this->assertSame('phpstan', $metadata->id);
-        $this->assertSame('PHPStan Static Analysis', $metadata->name);
+        $this->assertSame('PHPStan Static Analyzer', $metadata->name);
         $this->assertStringContainsString('PHPStan', $metadata->description);
         $this->assertStringContainsString('static analysis', $metadata->description);
     }


### PR DESCRIPTION
## Summary
- Display analyzer metadata names instead of raw IDs when using `--analyzer` flag
- Single: `Running analyzer: SQL Injection Analyzer`
- Multiple: `Running analyzers: SQL Injection and XSS Vulnerabilities Analyzers`
- Rename PHPStan metadata name to "PHPStan Static Analyzer" for consistency