### PR TITLE
fix: filter Faker magic method false positives in PHPStanRunner

### DIFF
--- a/src/Support/PHPStanRunner.php
+++ b/src/Support/PHPStanRunner.php
@@ -28,6 +28,11 @@ class PHPStanRunner
         // HigherOrderProxy is too magical for Larastan/PHPStan to understand
         // @see https://github.com/larastan/larastan/blob/2e9ed291bdc1969e7f270fb33c9cdf3c912daeb2/docs/errors-to-ignore.md
         '#Call to an undefined method Illuminate\\\\Support\\\\HigherOrder#',
+
+        // Faker uses __call() and __get() magic methods to proxy calls through providers.
+        // PHPStan cannot resolve these dynamic method/property lookups.
+        '#on an unknown class Faker\\\\#',
+        '#(undefined method|undefined static method|undefined property) Faker\\\\#',
     ];
 
     /**


### PR DESCRIPTION
## Summary
- Add two regex patterns to `PHPStanRunner::KNOWN_FALSE_POSITIVES` that suppress PHPStan errors caused by Faker's `__call()`/`__get()` magic methods (e.g. `fake()->unique()->randomNumber()`)
- Pattern A (`#on an unknown class Faker\\#`) catches method/property access on unknown Faker classes
- Pattern B (`#(undefined method|undefined static method|undefined property) Faker\\#`) catches undefined member access on Faker classes
- Real issues (missing Faker dependency, user-namespace classes) are intentionally preserved