### PR TITLE
refactor: migrate analyzers to resultBySeverity()

### DIFF
--- a/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
+++ b/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
@@ -79,7 +79,7 @@ class ChunkMissingAnalyzer extends AbstractFileAnalyzer
             $count === 1 ? 'query' : 'queries'
         );
 
-        return $this->failed($message, $issues);
+        return $this->resultBySeverity($message, $issues);
     }
 }
 

--- a/src/Analyzers/BestPractices/ConfigOutsideConfigAnalyzer.php
+++ b/src/Analyzers/BestPractices/ConfigOutsideConfigAnalyzer.php
@@ -97,7 +97,7 @@ class ConfigOutsideConfigAnalyzer extends AbstractFileAnalyzer
             return $this->passed('Configuration is properly externalized');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d hardcoded configuration value(s)', count($issues)),
             $issues
         );

--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -103,7 +103,7 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
 
         $totalIssues = count($issues);
 
-        return $this->failed(
+        return $this->resultBySeverity(
             "Found {$totalIssues} potential N+1 query issue(s)",
             $issues
         );

--- a/src/Analyzers/BestPractices/FatModelAnalyzer.php
+++ b/src/Analyzers/BestPractices/FatModelAnalyzer.php
@@ -111,7 +111,7 @@ class FatModelAnalyzer extends AbstractFileAnalyzer
             return $this->passed('All models have appropriate size and complexity');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf(
                 'Found %d issue(s) across %d fat model(s) that should be refactored',
                 count($issues),

--- a/src/Analyzers/BestPractices/FrameworkOverrideAnalyzer.php
+++ b/src/Analyzers/BestPractices/FrameworkOverrideAnalyzer.php
@@ -154,7 +154,7 @@ class FrameworkOverrideAnalyzer extends AbstractFileAnalyzer
             return $this->passed('No dangerous framework overrides detected');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d framework override(s)', count($issues)),
             $issues
         );

--- a/src/Analyzers/BestPractices/HardcodedStoragePathsAnalyzer.php
+++ b/src/Analyzers/BestPractices/HardcodedStoragePathsAnalyzer.php
@@ -167,7 +167,7 @@ class HardcodedStoragePathsAnalyzer extends AbstractFileAnalyzer
             return $this->passed('All paths use Laravel helpers');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d hardcoded path(s)', count($issues)),
             $issues
         );

--- a/src/Analyzers/BestPractices/HelperFunctionAbuseAnalyzer.php
+++ b/src/Analyzers/BestPractices/HelperFunctionAbuseAnalyzer.php
@@ -225,7 +225,7 @@ class HelperFunctionAbuseAnalyzer extends AbstractFileAnalyzer
 
         $totalIssues = count($issues);
 
-        return $this->failed(
+        return $this->resultBySeverity(
             "Found {$totalIssues} class(es) with excessive helper function usage",
             $issues
         );

--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -97,7 +97,7 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
             return $this->passed('No business logic found in Blade templates');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d Blade template(s) with business logic', count($issues)),
             $issues
         );

--- a/src/Analyzers/BestPractices/LogicInRoutesAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInRoutesAnalyzer.php
@@ -103,7 +103,7 @@ class LogicInRoutesAnalyzer extends AbstractFileAnalyzer
             return $this->passed('No business logic found in route files');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d route(s) with business logic that should be moved to controllers', count($issues)),
             $issues
         );

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -102,7 +102,7 @@ class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
             return $this->passed('All multiple write operations are properly wrapped in transactions');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d method(s) with multiple writes missing transaction protection', count($issues)),
             $issues
         );

--- a/src/Analyzers/BestPractices/MissingErrorTrackingAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingErrorTrackingAnalyzer.php
@@ -151,7 +151,7 @@ class MissingErrorTrackingAnalyzer extends AbstractFileAnalyzer
         $composer = $this->parseComposerJson($composerPath);
         if ($composer === null) {
             // Malformed JSON - fail with error
-            return $this->failed(
+            return $this->resultBySeverity(
                 'composer.json contains invalid JSON',
                 [$this->createIssue(
                     message: 'composer.json contains invalid JSON and cannot be parsed',
@@ -186,7 +186,7 @@ class MissingErrorTrackingAnalyzer extends AbstractFileAnalyzer
             return $this->passed('Error tracking service is configured');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             'No error tracking service detected',
             $issues
         );

--- a/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
+++ b/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
@@ -403,7 +403,7 @@ class MixedQueryBuilderEloquentAnalyzer extends AbstractFileAnalyzer
             return $this->passed('Consistent use of Eloquent or Query Builder');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d file(s) mixing Query Builder and Eloquent inconsistently', count($issues)),
             $issues
         );

--- a/src/Analyzers/BestPractices/PhpSideFilteringAnalyzer.php
+++ b/src/Analyzers/BestPractices/PhpSideFilteringAnalyzer.php
@@ -141,7 +141,7 @@ class PhpSideFilteringAnalyzer extends AbstractFileAnalyzer
             return $this->passed('No PHP-side filtering detected (filter/reject/whereIn/whereNotIn after fetch)');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d instance(s) of PHP-side filtering that should be done in database', count($issues)),
             $issues
         );

--- a/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
+++ b/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
@@ -320,7 +320,7 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
 
         $totalIssues = count($issues);
 
-        return $this->failed(
+        return $this->resultBySeverity(
             "Found {$totalIssues} instance(s) of manual service container resolution",
             $issues
         );

--- a/src/Analyzers/CodeQuality/CommentedCodeAnalyzer.php
+++ b/src/Analyzers/CodeQuality/CommentedCodeAnalyzer.php
@@ -170,7 +170,7 @@ class CommentedCodeAnalyzer extends AbstractFileAnalyzer
 
         $totalIssues = count($issues);
 
-        return $this->failed(
+        return $this->resultBySeverity(
             "Found {$totalIssues} block(s) of commented-out code",
             $issues
         );

--- a/src/Analyzers/CodeQuality/MethodLengthAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MethodLengthAnalyzer.php
@@ -120,7 +120,7 @@ class MethodLengthAnalyzer extends AbstractFileAnalyzer
 
         $totalIssues = count($issues);
 
-        return $this->failed(
+        return $this->resultBySeverity(
             "Found {$totalIssues} method(s) or function(s) exceeding recommended length",
             $issues
         );

--- a/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
@@ -104,7 +104,7 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
         $issueWord = $totalIssues === 1 ? 'issue' : 'issues';
         $methodWord = $affectedMethodCount === 1 ? 'method' : 'methods';
 
-        return $this->failed(
+        return $this->resultBySeverity(
             "Found {$totalIssues} documentation {$issueWord} across {$affectedMethodCount} public {$methodWord}",
             $issues
         );

--- a/src/Analyzers/CodeQuality/NamingConventionAnalyzer.php
+++ b/src/Analyzers/CodeQuality/NamingConventionAnalyzer.php
@@ -89,7 +89,7 @@ class NamingConventionAnalyzer extends AbstractFileAnalyzer
 
         $totalIssues = count($issues);
 
-        return $this->failed(
+        return $this->resultBySeverity(
             "Found {$totalIssues} naming convention violation(s)",
             $issues
         );

--- a/src/Analyzers/CodeQuality/NestingDepthAnalyzer.php
+++ b/src/Analyzers/CodeQuality/NestingDepthAnalyzer.php
@@ -97,7 +97,7 @@ class NestingDepthAnalyzer extends AbstractFileAnalyzer
 
         $totalIssues = count($issues);
 
-        return $this->failed(
+        return $this->resultBySeverity(
             "Found {$totalIssues} deeply nested code block(s)",
             $issues
         );

--- a/src/Analyzers/Reliability/CachePrefixAnalyzer.php
+++ b/src/Analyzers/Reliability/CachePrefixAnalyzer.php
@@ -83,7 +83,7 @@ class CachePrefixAnalyzer extends AbstractFileAnalyzer
 
         // Check if prefix is empty
         if ($prefix === '') {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'Cache prefix is not configured',
                 [$this->createIssue(
                     message: 'Cache prefix is empty or not set',
@@ -101,7 +101,7 @@ class CachePrefixAnalyzer extends AbstractFileAnalyzer
 
         // Check if prefix is too generic
         if ($this->isGenericPrefix($prefix)) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'Cache prefix is too generic',
                 [$this->createIssue(
                     message: "Cache prefix '{$prefix}' is too generic and may cause collisions",

--- a/src/Analyzers/Reliability/CacheStatusAnalyzer.php
+++ b/src/Analyzers/Reliability/CacheStatusAnalyzer.php
@@ -70,7 +70,7 @@ class CacheStatusAnalyzer extends AbstractFileAnalyzer
                 // Clean up test key before returning
                 $this->cleanupTestKey($testKey);
 
-                return $this->failed(
+                return $this->resultBySeverity(
                     'Cache storage is not working correctly - values are not being retrieved as expected',
                     [$this->createIssue(
                         message: 'Cache write/read test failed',
@@ -114,7 +114,7 @@ class CacheStatusAnalyzer extends AbstractFileAnalyzer
             // Ensure cleanup on exception
             $this->cleanupTestKey($testKey);
 
-            return $this->failed(
+            return $this->resultBySeverity(
                 'Cache is not accessible or not functioning properly',
                 [$this->createIssue(
                     message: 'Cache connection/operation failed',

--- a/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
+++ b/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
@@ -44,7 +44,7 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
         $composerJsonPath = $this->buildPath('composer.json');
 
         if (! file_exists($composerJsonPath)) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'composer.json file not found',
                 [$this->createIssue(
                     message: 'composer.json file is missing',
@@ -66,7 +66,7 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
         $result = $this->composerValidator->validate($basePath);
 
         if (! $result->successful) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'composer.json validation failed',
                 [$this->createIssue(
                     message: 'composer validate command reported issues',
@@ -90,7 +90,7 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
     {
         $content = FileParser::readFile($composerJsonPath);
         if ($content === null) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'Unable to read composer.json file',
                 [$this->createIssue(
                     message: 'composer.json file exists but cannot be read',
@@ -106,7 +106,7 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
         $jsonError = json_last_error();
 
         if ($jsonError !== JSON_ERROR_NONE) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'composer.json contains invalid JSON',
                 [$this->createIssue(
                     message: 'composer.json is not valid JSON: '.json_last_error_msg(),
@@ -124,7 +124,7 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
         // Validate that decoded JSON is an object (composer.json should be an object, not an array or primitive)
         // Note: array_is_list([]) returns true, but empty objects are valid, so check non-empty arrays only
         if (! is_array($decoded) || (! empty($decoded) && array_is_list($decoded))) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'composer.json is not a valid JSON object',
                 [$this->createIssue(
                     message: 'composer.json must be a JSON object, not a primitive value or array',

--- a/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
+++ b/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
@@ -102,7 +102,7 @@ class CustomErrorPageAnalyzer extends AbstractAnalyzer
 
         $resourcesViewsPath = $this->getResourcesViewsPath();
 
-        return $this->warning(
+        return $this->resultBySeverity(
             'Application does not define conventional Laravel error page templates',
             [$this->createIssue(
                 message: 'Custom error pages not configured for: '.implode(', ', $missing),

--- a/src/Analyzers/Reliability/DatabaseStatusAnalyzer.php
+++ b/src/Analyzers/Reliability/DatabaseStatusAnalyzer.php
@@ -91,7 +91,7 @@ class DatabaseStatusAnalyzer extends AbstractFileAnalyzer
             return $this->passed('All database connections are accessible');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Failed to connect to %d database connection(s)', count($issues)),
             $issues
         );

--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -75,7 +75,7 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
 
         $totalIssues = count($missingDirs) + count($nonWritableDirs) + count($brokenSymlinks);
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d filesystem issue(s)', $totalIssues),
             $issues
         );

--- a/src/Analyzers/Reliability/EnvExampleAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvExampleAnalyzer.php
@@ -48,7 +48,7 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
 
         // Check if .env.example exists
         if (! file_exists($envExamplePath)) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 '.env.example file not found',
                 [$this->createIssue(
                     message: '.env.example file is missing',
@@ -71,7 +71,7 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
             return $this->passed('All environment variables are documented in .env.example');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d undocumented environment variable(s)', count($undocumentedVars)),
             [$this->createIssueWithSnippet(
                 message: 'Undocumented environment variables',

--- a/src/Analyzers/Reliability/EnvFileAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvFileAnalyzer.php
@@ -42,7 +42,7 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
         if (is_link($envPath) && ! file_exists($envPath)) {
             $target = readlink($envPath);
 
-            return $this->failed(
+            return $this->resultBySeverity(
                 'Application .env symlink is broken',
                 [$this->createIssueWithSnippet(
                     message: 'The .env file is a broken symlink',
@@ -68,7 +68,7 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
 
         // Check if .env is readable
         if (! is_readable($envPath)) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'Application .env file is not readable',
                 [$this->createIssueWithSnippet(
                     message: 'The .env file exists but is not readable',
@@ -88,7 +88,7 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
         // Check if .env is empty
         $stat = @stat($envPath);
         if ($stat !== false && $stat['size'] === 0) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'Application .env file is empty',
                 [$this->createIssueWithSnippet(
                     message: 'The .env file exists but contains no configuration',
@@ -116,7 +116,7 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
         $envExamplePath = $this->getEnvExamplePath($basePath);
         $envExampleExists = file_exists($envExamplePath);
 
-        return $this->failed(
+        return $this->resultBySeverity(
             'Application .env file is missing',
             [$this->createIssueWithSnippet(
                 message: 'The .env file does not exist',

--- a/src/Analyzers/Reliability/EnvVariableAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvVariableAnalyzer.php
@@ -48,7 +48,7 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
 
         // Check if .env exists
         if (! file_exists($envPath)) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 '.env file not found',
                 [$this->createIssue(
                     message: '.env file is missing',
@@ -67,7 +67,7 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
 
         // Handle parsing failures
         if ($exampleResult['error'] !== null) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'Failed to parse .env.example file',
                 [$this->createIssue(
                     message: 'Unable to parse .env.example file',
@@ -84,7 +84,7 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
         }
 
         if ($actualResult['error'] !== null) {
-            return $this->failed(
+            return $this->resultBySeverity(
                 'Failed to parse .env file',
                 [$this->createIssue(
                     message: 'Unable to parse .env file',
@@ -181,7 +181,7 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
 
         $totalCount = count($missingVars) + count($commentedOnlyVars);
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d environment variable issue(s)', $totalCount),
             $issues
         );

--- a/src/Analyzers/Reliability/MaintenanceModeAnalyzer.php
+++ b/src/Analyzers/Reliability/MaintenanceModeAnalyzer.php
@@ -88,7 +88,7 @@ class MaintenanceModeAnalyzer extends AbstractFileAnalyzer
                 $environment
             );
 
-            return $this->failed(
+            return $this->resultBySeverity(
                 'Application is in maintenance mode',
                 [$this->createIssue(
                     message: $message,

--- a/src/Analyzers/Reliability/PHPStanAnalyzer.php
+++ b/src/Analyzers/Reliability/PHPStanAnalyzer.php
@@ -349,7 +349,7 @@ class PHPStanAnalyzer extends AbstractFileAnalyzer
         $displayedCount = count($allIssueObjects);
         $message = $this->formatIssueCountMessage($totalIssues, $displayedCount, 'PHPStan issue(s)');
 
-        return $this->failed($message, $allIssueObjects);
+        return $this->resultBySeverity($message, $allIssueObjects);
     }
 
     /**

--- a/src/Analyzers/Reliability/QueueTimeoutAnalyzer.php
+++ b/src/Analyzers/Reliability/QueueTimeoutAnalyzer.php
@@ -130,7 +130,7 @@ class QueueTimeoutAnalyzer extends AbstractFileAnalyzer
             return $this->passed('Queue timeout configurations are correct');
         }
 
-        return $this->failed(
+        return $this->resultBySeverity(
             sprintf('Found %d queue configuration issue(s)', count($issues)),
             $issues
         );

--- a/src/Analyzers/Reliability/UpToDateMigrationsAnalyzer.php
+++ b/src/Analyzers/Reliability/UpToDateMigrationsAnalyzer.php
@@ -77,7 +77,7 @@ class UpToDateMigrationsAnalyzer extends AbstractFileAnalyzer
         try {
             // Check if migrations table exists
             if (! Schema::hasTable('migrations')) {
-                return $this->failed(
+                return $this->resultBySeverity(
                     'Migrations table does not exist',
                     [$this->createIssueWithSnippet(
                         message: 'The migrations table has not been created yet',
@@ -117,7 +117,7 @@ class UpToDateMigrationsAnalyzer extends AbstractFileAnalyzer
                 return $this->passed('All migrations are up to date');
             }
 
-            return $this->failed(
+            return $this->resultBySeverity(
                 sprintf('Found %d pending migration(s)', count($pendingMigrations)),
                 [$this->createIssueWithSnippet(
                     message: 'Pending migrations detected',

--- a/tests/Unit/Analyzers/BestPractices/ConfigOutsideConfigAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ConfigOutsideConfigAnalyzerTest.php
@@ -117,7 +117,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -284,7 +284,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('localhost', $result);
     }
 
@@ -309,7 +309,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -334,7 +334,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -941,7 +941,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -1022,7 +1022,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -1047,7 +1047,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -1072,7 +1072,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -1097,7 +1097,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -1122,7 +1122,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -1175,7 +1175,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -1227,7 +1227,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 
@@ -1252,7 +1252,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('URL', $result);
     }
 }

--- a/tests/Unit/Analyzers/BestPractices/FatModelAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/FatModelAnalyzerTest.php
@@ -94,7 +94,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('business methods', $result);
     }
 
@@ -130,7 +130,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('lines', $result);
     }
 
@@ -162,7 +162,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThan(0, count($issues));
         $this->assertStringContainsString('service', $issues[0]->recommendation);
@@ -604,7 +604,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('complexity', $result);
     }
 
@@ -669,7 +669,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertEquals(Severity::Low, $issues[0]->severity);
@@ -704,7 +704,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertEquals(Severity::Medium, $issues[0]->severity);
@@ -776,7 +776,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(2, count($issues)); // At least 2 issues
     }
@@ -810,7 +810,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('business methods', $result);
     }
 
@@ -842,7 +842,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('business methods', $result);
     }
 
@@ -906,7 +906,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result); // 8 > 5, should fail
+        $this->assertWarning($result); // 8 > 5, should warn (Low severity)
         $this->assertHasIssueContaining('threshold: 5', $result);
     }
 
@@ -945,7 +945,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('lines', $result);
     }
 
@@ -987,7 +987,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('complexity', $result);
     }
 
@@ -1019,7 +1019,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('business methods', $result);
     }
 
@@ -1051,7 +1051,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('business methods', $result);
     }
 
@@ -1083,7 +1083,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('business methods', $result);
     }
 
@@ -1321,7 +1321,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('complexity', $result);
     }
 
@@ -1369,7 +1369,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('complexity', $result);
     }
 
@@ -1423,7 +1423,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         // Should show "2 issue(s) across 2 fat model(s)"
         $this->assertStringContainsString('2 issue(s)', $result->getMessage());
         $this->assertStringContainsString('2 fat model(s)', $result->getMessage());
@@ -1600,7 +1600,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('business methods', $result);
     }
 
@@ -1634,7 +1634,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('business methods', $result);
     }
 
@@ -1702,7 +1702,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should be detected as a model and flagged for too many business methods
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('business methods', $result);
     }
 }

--- a/tests/Unit/Analyzers/BestPractices/FrameworkOverrideAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/FrameworkOverrideAnalyzerTest.php
@@ -110,7 +110,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_passes_with_boot_method(): void
@@ -410,7 +410,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThan(0, count($issues));
         $this->assertEquals('medium', $issues[0]->severity->value);
@@ -445,7 +445,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertEquals('medium', $issues[0]->severity->value);
     }
@@ -871,7 +871,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertStringContainsString('query scopes', $issues[0]->recommendation);
         $this->assertStringContainsString('scopeActive', $issues[0]->recommendation);

--- a/tests/Unit/Analyzers/BestPractices/HardcodedStoragePathsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/HardcodedStoragePathsAnalyzerTest.php
@@ -85,7 +85,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('storage', $result);
     }
 
@@ -113,7 +113,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_detects_hardcoded_log_paths(): void
@@ -140,7 +140,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_provides_helper_recommendation(): void
@@ -168,7 +168,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThan(0, count($issues));
         $this->assertStringContainsString('storage_path', $issues[0]->recommendation);
@@ -245,7 +245,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('storage', $result);
     }
 
@@ -273,7 +273,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('public', $result);
     }
 
@@ -306,7 +306,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
     }
@@ -335,7 +335,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertStringContainsString('app_path', $issues[0]->recommendation);
     }
@@ -364,7 +364,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertStringContainsString('resource_path', $issues[0]->recommendation);
     }
@@ -393,7 +393,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertStringContainsString('database_path', $issues[0]->recommendation);
     }
@@ -422,7 +422,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertStringContainsString('config_path', $issues[0]->recommendation);
     }
@@ -455,7 +455,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('storage', $result);
     }
 
@@ -494,7 +494,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(3, count($issues));
     }
@@ -570,7 +570,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertStringContainsString('custom_upload_path', $issues[0]->recommendation);
     }
@@ -603,7 +603,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(2, count($issues));
     }
@@ -631,7 +631,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(2, count($issues));
     }
@@ -663,7 +663,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('storage', $result);
     }
 
@@ -731,7 +731,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     // =========================================================================
@@ -866,7 +866,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(3, count($issues));
     }
@@ -908,7 +908,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(3, count($issues));
     }
@@ -938,7 +938,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('storage', $result);
     }
 
@@ -971,7 +971,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(2, count($issues));
     }
@@ -1005,7 +1005,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(2, count($issues));
     }
@@ -1042,7 +1042,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(2, count($issues));
     }
@@ -1111,7 +1111,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail (flag) - strong context
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('public', $result);
     }
 
@@ -1144,7 +1144,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail (flag) - weak context sufficient for /storage/
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('storage', $result);
     }
 
@@ -1210,7 +1210,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('storage', $result);
     }
 
@@ -1243,7 +1243,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(2, count($issues));
     }
@@ -1277,7 +1277,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThanOrEqual(2, count($issues));
     }
@@ -1307,7 +1307,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('storage', $result);
     }
 
@@ -1336,7 +1336,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('storage', $result);
     }
 
@@ -1369,7 +1369,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertStringContainsString('public_path', $issues[0]->recommendation);
@@ -1402,7 +1402,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertStringContainsString('public_path', $issues[0]->recommendation);

--- a/tests/Unit/Analyzers/BestPractices/HelperFunctionAbuseAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/HelperFunctionAbuseAnalyzerTest.php
@@ -59,7 +59,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('helper', $result);
     }
 
@@ -208,7 +208,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertNotEmpty($issues);
         $this->assertEquals('medium', $issues[0]->severity->value);
@@ -317,7 +317,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_custom_helper_functions_list(): void
@@ -415,7 +415,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_multiple_classes_in_same_file(): void
@@ -458,7 +458,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertStringContainsString('BadService', $issues[0]->message);
@@ -637,7 +637,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertEquals(6, $issues[0]->metadata['count']);
     }
@@ -720,7 +720,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('LoggableTrait', $result);
     }
 
@@ -783,7 +783,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertEquals(7, $issues[0]->metadata['count']);
         $this->assertEquals(2, $issues[0]->metadata['helpers']['auth']);
@@ -821,7 +821,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertNotNull($issues[0]->codeSnippet);
         $this->assertNotEmpty($issues[0]->codeSnippet->getLines());
@@ -1415,7 +1415,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertEquals(3, $issues[0]->metadata['count']);
     }
@@ -1454,6 +1454,6 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should NOT be whitelisted - "contests" contains "test" but isn't tests directory
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 }

--- a/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
@@ -89,7 +89,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('calculation', $result);
     }
 
@@ -112,7 +112,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('calculation', $result);
     }
 
@@ -353,7 +353,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('11 lines', $result);
     }
 
@@ -425,7 +425,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('Inline PHP', $result);
     }
 
@@ -447,7 +447,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('Business logic', $result);
     }
 
@@ -469,7 +469,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_detects_collection_map_in_foreach(): void
@@ -490,7 +490,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_detects_overly_complex_if_conditions(): void
@@ -511,7 +511,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_allows_reasonable_if_conditions(): void
@@ -653,7 +653,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertEquals('medium', $issues[0]->severity->value);
     }
@@ -674,7 +674,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertEquals('low', $issues[0]->severity->value);
     }
@@ -763,7 +763,7 @@ BLADE;
         $result = $analyzer->analyze();
 
         // Should fail with custom threshold of 5
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_passes_when_no_views_directory(): void
@@ -866,7 +866,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
 
         $this->assertArrayHasKey('block_lines', $issues[0]->metadata);
@@ -1051,7 +1051,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     // =========================================================================
@@ -1207,7 +1207,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_detects_collection_unique_in_foreach(): void
@@ -1228,7 +1228,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_detects_collection_group_by_in_foreach(): void
@@ -1249,7 +1249,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_detects_collect_helper_with_filter(): void
@@ -1270,7 +1270,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     // =========================================================================
@@ -2228,7 +2228,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('Nested @foreach', $result);
     }
 
@@ -2252,7 +2252,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $nestedIssue = null;
         foreach ($issues as $issue) {
@@ -2307,7 +2307,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('Expensive computation', $result);
     }
 
@@ -2329,7 +2329,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('Expensive computation', $result);
     }
 
@@ -2373,7 +2373,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('Expensive computation', $result);
     }
 
@@ -2395,7 +2395,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('Expensive computation', $result);
     }
 
@@ -2438,7 +2438,7 @@ BLADE;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $computeIssue = null;
         foreach ($issues as $issue) {

--- a/tests/Unit/Analyzers/BestPractices/LogicInRoutesAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/LogicInRoutesAnalyzerTest.php
@@ -125,7 +125,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('database queries', $result);
     }
 
@@ -380,7 +380,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('lines', $result);
     }
 
@@ -531,7 +531,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertEquals('medium', $issues[0]->severity->value);
     }
@@ -618,7 +618,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertEquals('route-closure-too-long', $issues[0]->code);
     }
@@ -772,7 +772,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail with custom threshold of 3
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_provides_controller_recommendation_for_db_writes(): void
@@ -1666,7 +1666,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // In strict mode, even simple reads are flagged
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('database queries (strict mode)', $result);
         $issues = $result->getIssues();
         $this->assertEquals('low', $issues[0]->severity->value);
@@ -1694,7 +1694,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Complex reads (3+ method chain) should be flagged as medium
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('complex database queries', $result);
         $issues = $result->getIssues();
         $this->assertEquals('medium', $issues[0]->severity->value);
@@ -1775,7 +1775,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertEquals('route-has-complex-queries', $issues[0]->code);
     }
@@ -1905,7 +1905,7 @@ PHP;
 
         // 2-method chain without terminal read (where + orderBy) is complex
         // The separate ->get() creates a 3-chain which is also complex
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('complex database queries', $result);
     }
 

--- a/tests/Unit/Analyzers/BestPractices/MissingErrorTrackingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MissingErrorTrackingAnalyzerTest.php
@@ -194,7 +194,7 @@ class MissingErrorTrackingAnalyzerTest extends AnalyzerTestCase
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('No error tracking service detected', $result);
     }
 
@@ -231,7 +231,7 @@ class MissingErrorTrackingAnalyzerTest extends AnalyzerTestCase
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThan(0, count($issues));
         $this->assertStringContainsString('Sentry', $issues[0]->recommendation);
@@ -425,7 +425,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('No error tracking service detected', $result);
     }
 
@@ -551,7 +551,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('No error tracking service detected', $result);
     }
 
@@ -594,7 +594,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('No error tracking service detected', $result);
     }
 
@@ -639,7 +639,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('No error tracking service detected', $result);
     }
 
@@ -687,7 +687,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('No error tracking service detected', $result);
     }
 }

--- a/tests/Unit/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzerTest.php
@@ -259,7 +259,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_provides_consistency_recommendation(): void
@@ -918,7 +918,7 @@ PHP;
         $analyzer->setPaths(['Services']);
 
         $result = $analyzer->analyze();
-        $this->assertFailed($result);
+        $this->assertWarning($result);
 
         // With higher threshold, it should pass
         $analyzer2 = $this->createAnalyzer([

--- a/tests/Unit/Analyzers/BestPractices/PhpSideFilteringAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/PhpSideFilteringAnalyzerTest.php
@@ -892,7 +892,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('whereIn', $result);
     }
 
@@ -1289,7 +1289,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('filter', $result);
     }
 
@@ -1318,7 +1318,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('filter', $result);
     }
 
@@ -1347,7 +1347,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('filter', $result);
     }
 
@@ -1406,7 +1406,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('reject', $result);
     }
 
@@ -1468,7 +1468,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertEquals(\ShieldCI\AnalyzersCore\Enums\Severity::Medium, $issues[0]->severity);
@@ -1563,7 +1563,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertEquals(\ShieldCI\AnalyzersCore\Enums\Severity::Medium, $issues[0]->severity);
@@ -1594,7 +1594,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertEquals(\ShieldCI\AnalyzersCore\Enums\Severity::Medium, $issues[0]->severity);
@@ -1625,7 +1625,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertEquals(\ShieldCI\AnalyzersCore\Enums\Severity::Medium, $issues[0]->severity);
@@ -1658,7 +1658,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('Filtering data in PHP', $result);
     }
 
@@ -1685,7 +1685,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('Filtering data in PHP', $result);
     }
 
@@ -1712,7 +1712,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('whereIn', $result);
     }
 
@@ -1739,7 +1739,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('whereNotIn', $result);
     }
 
@@ -1826,7 +1826,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertEquals(\ShieldCI\AnalyzersCore\Enums\Severity::Medium, $issues[0]->severity);
@@ -1855,7 +1855,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertGreaterThan(0, count($issues));
         $this->assertStringContainsString('eager loading', $issues[0]->recommendation);
@@ -1928,7 +1928,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('filter', $result);
     }
 
@@ -2539,7 +2539,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 
@@ -2574,7 +2574,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 
@@ -2608,7 +2608,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 
@@ -2642,7 +2642,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 
@@ -2716,7 +2716,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(3, $issues);
     }
@@ -2746,7 +2746,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
     }
@@ -2777,7 +2777,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(3, $issues);
     }
@@ -2808,7 +2808,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(3, $issues);
     }
@@ -2895,7 +2895,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
     }
@@ -2956,7 +2956,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(3, $issues);
     }
@@ -2986,7 +2986,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
     }

--- a/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
@@ -407,7 +407,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Bindings (bind, singleton) should be skipped, but resolution (app()->make()) should be flagged
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertHasIssueContaining('app()->make()', $result);
@@ -627,7 +627,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertSame(Severity::Medium, $issues[0]->severity);
         $this->assertSame('class', $issues[0]->metadata['argument_type']);
@@ -694,7 +694,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertSame(Severity::Medium, $issues[0]->severity);
         $this->assertSame('variable', $issues[0]->metadata['argument_type']);
@@ -783,7 +783,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('global scope', $result);
     }
 
@@ -928,7 +928,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should detect because it doesn't extend ServiceProvider
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('app()', $result);
     }
 
@@ -1101,7 +1101,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame(Severity::Low, $issues[0]->severity);
@@ -1410,7 +1410,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('new PaymentHandler()', $result);
     }
 
@@ -1508,7 +1508,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame(Severity::Low, $issues[0]->severity);
@@ -1547,7 +1547,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Resolution in closure with string argument gets Medium severity
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame(Severity::Medium, $issues[0]->severity);
@@ -1587,7 +1587,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Bindings are skipped (service provider), resolution in closure with string arg is Medium
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame(Severity::Medium, $issues[0]->severity);
@@ -1623,7 +1623,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame(Severity::Medium, $issues[0]->severity);
@@ -1725,7 +1725,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame(Severity::Low, $issues[0]->severity);
@@ -1810,7 +1810,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail - PaymentServiceProviderFake doesn't extend Illuminate ServiceProvider
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('app()', $result);
     }
 
@@ -1849,7 +1849,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Binding in register() should be skipped, but app() resolution in boot() should be flagged
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertHasIssueContaining('app()', $result);
@@ -1923,7 +1923,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Resolution inside closure is now reported at Low severity
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame(Severity::Low, $issues[0]->severity);
@@ -2144,7 +2144,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
 
         // Should remain Medium severity (not escalated)
@@ -2374,7 +2374,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame(Severity::Low, $issues[0]->severity);
@@ -2483,7 +2483,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertStringContainsString('sometimes necessary when dependency injection is unavailable', $issues[0]->recommendation);
         $this->assertStringContainsString('extracting to an injectable class', $issues[0]->recommendation);
@@ -2521,7 +2521,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail - PaymentService matches *Service and no exclusion
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('new PaymentService()', $result);
     }
 }

--- a/tests/Unit/Analyzers/CodeQuality/CommentedCodeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/CommentedCodeAnalyzerTest.php
@@ -103,7 +103,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('commented-out code', $result);
     }
 
@@ -141,7 +141,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('commented-out code', $result);
     }
 
@@ -336,7 +336,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('3 consecutive lines', $result);
     }
 
@@ -369,7 +369,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     #[Test]
@@ -401,7 +401,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     #[Test]
@@ -433,7 +433,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     #[Test]
@@ -465,7 +465,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     #[Test]
@@ -497,7 +497,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     #[Test]
@@ -538,7 +538,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
     }
@@ -580,7 +580,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $issue = $issues[0];
         $this->assertEquals(Severity::Low, $issue->severity);
@@ -618,7 +618,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $issue = $issues[0];
         $this->assertEquals(Severity::Medium, $issue->severity);
@@ -654,7 +654,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $issue = $issues[0];
         $metadata = $issue->metadata;
@@ -700,7 +700,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $issue = $issues[0];
 
@@ -742,7 +742,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $issue = $issues[0];
 
@@ -831,7 +831,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('commented-out code', $result);
 
         $issues = $result->getIssues();
@@ -926,7 +926,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
 
         $issues = $result->getIssues();
         // Should detect both block comments
@@ -968,7 +968,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
 
         $issues = $result->getIssues();
         // Should detect both single-line and block comments
@@ -1007,7 +1007,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
 
         $issues = $result->getIssues();
         // Should detect as ONE block despite blank comment lines (within tolerance)
@@ -1187,7 +1187,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail - the second block has actual code with assignments and method calls
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('3 consecutive lines', $result);
     }
 
@@ -1232,7 +1232,7 @@ PHP;
         // Should FAIL - strong code indicators (public function, private function)
         // should be detected even with TODO/FIXME markers
         // This demonstrates inverted logic: code signals win over documentation markers
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('commented-out code', $result);
     }
 
@@ -1344,7 +1344,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should FAIL - block has code
-        $this->assertFailed($result);
+        $this->assertWarning($result);
 
         // The fix ensures lineCount represents code lines only (4), not total lines (8)
         // Block has: 1 prose, 1 blank, 4 code lines, 1 blank, 1 prose = 8 total
@@ -1387,7 +1387,7 @@ PHP;
         $analyzer->setBasePath($tempDir);
         $analyzer->setPaths(['app']);
         $result = $analyzer->analyze();
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     #[Test]
@@ -1426,7 +1426,7 @@ PHP;
         $analyzer->setBasePath($tempDir);
         $analyzer->setPaths(['app']);
         $result = $analyzer->analyze();
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     #[Test]
@@ -1470,6 +1470,6 @@ PHP;
         $analyzer->setBasePath($tempDir);
         $analyzer->setPaths(['app']);
         $result = $analyzer->analyze();
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 }

--- a/tests/Unit/Analyzers/CodeQuality/MethodLengthAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/MethodLengthAnalyzerTest.php
@@ -59,7 +59,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('lines', $result);
     }
 
@@ -164,7 +164,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail because large methods are not excluded, even if they start with "get"
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('getUsersWithComplexFiltering', $result);
     }
 
@@ -314,7 +314,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail because these methods are too large to be simple accessors
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('setConfigurationFromMultipleSources', $result);
         $this->assertHasIssueContaining('isOrderValidForProcessing', $result);
         $this->assertHasIssueContaining('hasAdvancedPermissions', $result);
@@ -385,7 +385,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail because we're over threshold
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     #[Test]
@@ -418,7 +418,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame(Severity::Low, $issues[0]->severity);
@@ -454,7 +454,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame(Severity::Medium, $issues[0]->severity);
@@ -487,7 +487,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('processHelper', $result);
     }
 
@@ -566,7 +566,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
         $this->assertHasIssueContaining('firstMethod', $result);
@@ -602,7 +602,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 
@@ -649,7 +649,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 
@@ -686,7 +686,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 
@@ -727,7 +727,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
 
@@ -785,7 +785,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('getUser', $result);
 
         // Test with low main threshold (5) but lenient accessor threshold (10)

--- a/tests/Unit/Analyzers/CodeQuality/MissingDocBlockAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/MissingDocBlockAnalyzerTest.php
@@ -43,7 +43,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('PHPDoc', $result);
     }
 
@@ -306,7 +306,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('@param', $result);
     }
 
@@ -343,7 +343,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         // Should flag that 4 out of 5 parameters are missing @param tags
         $this->assertHasIssueContaining('4 parameter(s) missing @param', $result);
         $this->assertHasIssueContaining('found 1, need 5', $result);
@@ -422,7 +422,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('@throws', $result);
     }
 
@@ -465,7 +465,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('@throws', $result);
     }
 
@@ -506,7 +506,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('@throws', $result);
     }
 
@@ -547,7 +547,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('@throws', $result);
     }
 
@@ -633,7 +633,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail - new exception in catch block propagates
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('@throws', $result);
     }
 
@@ -770,7 +770,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should fail - methods without return type need @return documentation
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('@return', $result);
     }
 
@@ -811,7 +811,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
 
         // These should be flagged (missing @return)
         $this->assertHasIssueContaining('needsReturnMixed', $result);
@@ -926,7 +926,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
         $this->assertHasIssueContaining('firstMethod', $result);
@@ -963,7 +963,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
 
         // This method has 3 issues: missing @param (2 params), missing @throws, and missing @return (no return type)
@@ -1000,7 +1000,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 

--- a/tests/Unit/Analyzers/CodeQuality/NamingConventionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/NamingConventionAnalyzerTest.php
@@ -116,7 +116,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertStringContainsString("Class 'user_controller' does not follow PascalCase convention", $issues[0]->message);
@@ -147,7 +147,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining("Interface 'user_repository' does not follow PascalCase convention", $result);
     }
 
@@ -175,7 +175,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining("Trait 'has_timestamps' does not follow PascalCase convention", $result);
         $issues = $result->getIssues();
         $this->assertSame('HasTimestamps', $issues[0]->metadata['suggestion']);
@@ -206,7 +206,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining("Enum 'user_status' does not follow PascalCase convention", $result);
     }
 
@@ -236,7 +236,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
         $this->assertStringContainsString("Method 'get_user_by_id' does not follow camelCase convention", $issues[0]->message);
@@ -299,7 +299,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
         $this->assertStringContainsString("Property 'first_name' does not follow camelCase convention", $issues[0]->message);
@@ -334,7 +334,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(3, $issues);
         $this->assertStringContainsString("Public constant 'maxRetries' does not follow SCREAMING_SNAKE_CASE convention", $issues[0]->message);
@@ -395,7 +395,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(4, $issues);
 
@@ -448,7 +448,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(3, $issues);
         $this->assertStringContainsString("Property 'first_name' does not follow camelCase convention", $issues[0]->message);
@@ -482,7 +482,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertSame('userFirstName', $issues[0]->metadata['suggestion']);
         $this->assertSame('getUserById', $issues[1]->metadata['suggestion']);
@@ -513,7 +513,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertSame('MAX_RETRY_ATTEMPTS', $issues[0]->metadata['suggestion']);
         $this->assertSame('API_BASE_URL', $issues[1]->metadata['suggestion']);
@@ -548,7 +548,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(6, $issues);
 
@@ -626,7 +626,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
 
         // Only 2 issues for the public constants
@@ -699,7 +699,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertStringContainsString("Laravel table name 'user' should be plural", $issues[0]->message);
@@ -732,7 +732,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertStringContainsString("Laravel table name 'UserAccounts' should use snake_case convention", $issues[0]->message);
@@ -799,7 +799,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertStringContainsString("Laravel table name 'person' should be plural", $issues[0]->message);
@@ -832,7 +832,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame('categories', $issues[0]->metadata['suggestion']);
@@ -867,7 +867,7 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should only flag 'custom_data' for camelCase, not check table naming
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
 
         // Should have issues for camelCase properties, not table naming

--- a/tests/Unit/Analyzers/CodeQuality/NestingDepthAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/NestingDepthAnalyzerTest.php
@@ -69,7 +69,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('nesting depth', $result);
     }
 
@@ -192,7 +192,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('nesting depth', $result);
     }
 
@@ -234,7 +234,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('nesting depth', $result);
     }
 
@@ -276,7 +276,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('nesting depth', $result);
     }
 
@@ -361,7 +361,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('nesting depth', $result);
     }
 
@@ -405,7 +405,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('nesting depth', $result);
     }
 
@@ -449,7 +449,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('nesting depth', $result);
     }
 
@@ -531,7 +531,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('nesting depth of 5', $result);
     }
 
@@ -618,7 +618,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('nesting depth', $result);
     }
 
@@ -668,7 +668,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
 
         // Only badMethod should have issues
         $issues = $result->getIssues();
@@ -715,7 +715,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('nesting depth', $result);
     }
 
@@ -868,7 +868,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
 
         $issues = $result->getIssues();
         $this->assertNotEmpty($issues);
@@ -931,7 +931,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
 
         $issues = $result->getIssues();
         $this->assertEquals('global scope (file-level code)', $issues[0]->metadata['context']);

--- a/tests/Unit/Analyzers/Reliability/DatabaseStatusAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/DatabaseStatusAnalyzerTest.php
@@ -921,7 +921,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
         $this->assertSame('medium', $issues[0]->severity->value);

--- a/tests/Unit/Analyzers/Reliability/EnvExampleAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/EnvExampleAnalyzerTest.php
@@ -63,7 +63,7 @@ APP_ENV=local';
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertHasIssueContaining('Undocumented environment variables', $result);
     }
 
@@ -152,7 +152,7 @@ APP_ENV=local';
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertStringContainsString('5 undocumented environment variable(s)', $result->getMessage());
     }
 
@@ -302,7 +302,7 @@ NEW_VAR_3=value3';
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 
@@ -329,7 +329,7 @@ CUSTOM_VAR=value';
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 
@@ -384,7 +384,7 @@ STRIPE_SECRET=sk_test';
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
 
@@ -429,7 +429,7 @@ APP_ENV=production';
         $result = $analyzer->analyze();
 
         // Should fail - variables need to be documented
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertStringContainsString('2 undocumented environment variable(s)', $result->getMessage());
     }
 
@@ -476,7 +476,7 @@ APP_ENV=production';
         chmod($examplePath, 0644);
 
         // Should fail - can't read .env.example, all variables appear undocumented
-        $this->assertFailed($result);
+        $this->assertWarning($result);
     }
 
     public function test_handles_empty_basepath(): void
@@ -523,7 +523,7 @@ APP_ENV=local';
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertWarning($result);
         $this->assertStringContainsString('1 undocumented environment variable(s)', $result->getMessage());
 
         $issues = $result->getIssues();


### PR DESCRIPTION
## Summary

- Migrated analyzers from direct `$this->failed()` to `$this->resultBySeverity()` across BestPractices, CodeQuality, and Reliability categories
- Low/Medium/Info severity issues now return `warning` instead of `failed`, reducing false failure noise and improving developer experience
- Updated 18 test files to assert `isWarning()` where all fixture issues are Medium or lower severity; tests with High/Critical issues remain unchanged
- 72 of 73 analyzers now use `resultBySeverity()` — the 4 remaining Performance analyzers intentionally use `failed()` for binary environment checks

## Behavioral Impact

| Issue Severity | Before | After |
|---|---|---|
| Critical / High | `failed` | `failed` (unchanged) |
| Medium / Low / Info | `failed` | `warning` |

## Verification

- PHPStan Level 9: 0 errors
- Tests: 3577 passed, 0 failures, 9 skipped
- 49 files changed, 307 insertions, 307 deletions (perfectly balanced)