### PR TITLE
refactor: use metadata()->severity for single-severity analyzers

### DIFF
--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -65,7 +65,7 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
                         message: "Potential N+1 query: accessing '{$issue['relationship']}' inside loop",
                         filePath: $file,
                         lineNumber: $issue['line'],
-                        severity: Severity::High,
+                        severity: $this->metadata()->severity,
                         recommendation: $this->getRecommendation($issue['relationship'], $issue['loop_type']),
                         metadata: [
                             'relationship' => $issue['relationship'],
@@ -82,7 +82,7 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
                         message: "N+1 query: executing '{$issue['query']}' inside loop",
                         filePath: $file,
                         lineNumber: $issue['line'],
-                        severity: Severity::High,
+                        severity: $this->metadata()->severity,
                         recommendation: $this->getQueryRecommendation($issue['query'], $issue['loop_type']),
                         metadata: [
                             'query' => $issue['query'],

--- a/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
@@ -72,7 +72,7 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
                     message: $issue['message'],
                     filePath: $file,
                     lineNumber: $issue['line'],
-                    severity: Severity::Low,
+                    severity: $this->metadata()->severity,
                     recommendation: $this->getRecommendation($issue['type'], $issue['method']),
                     column: null,
                     contextLines: null,

--- a/src/Analyzers/Performance/DebugLogAnalyzer.php
+++ b/src/Analyzers/Performance/DebugLogAnalyzer.php
@@ -156,7 +156,7 @@ class DebugLogAnalyzer extends AbstractAnalyzer
                 message: "Log channel '{$channel}' is set to debug level in {$environment} environment",
                 filePath: $configPath,
                 lineNumber: $lineNumber,
-                severity: Severity::High,
+                severity: $this->metadata()->severity,
                 recommendation: "Change the log level to 'info' or higher in production. Debug logging causes significant performance degradation, generates massive log files that can exhaust disk space, and exposes sensitive data in logs. Update your logging configuration or set LOG_LEVEL environment variable to 'info', 'warning', or 'error'.",
                 code: 'debug-log-level',
                 metadata: [

--- a/src/Analyzers/Performance/DevDependencyAnalyzer.php
+++ b/src/Analyzers/Performance/DevDependencyAnalyzer.php
@@ -100,7 +100,7 @@ class DevDependencyAnalyzer extends AbstractAnalyzer
             $issues[] = $this->createIssue(
                 message: sprintf('composer.lock file not found in %s', $this->getEnvironment()),
                 location: null,
-                severity: Severity::High,
+                severity: $this->metadata()->severity,
                 recommendation: sprintf('Always commit composer.lock to ensure consistent dependency versions across environments. Run "composer install" instead of "composer update" in %s.', $this->getEnvironment()),
                 metadata: [
                     'environment' => $this->getEnvironment(),
@@ -197,7 +197,7 @@ class DevDependencyAnalyzer extends AbstractAnalyzer
             return $this->createIssue(
                 message: sprintf('Dev dependencies are installed in %s environment', $this->getEnvironment()),
                 location: null,
-                severity: Severity::High,
+                severity: $this->metadata()->severity,
                 recommendation: sprintf('Use "composer install --no-dev" in %s to exclude development dependencies. Dev packages like Ignition and Debugbar can cause memory leaks and slow down your application. Add --no-dev flag to your deployment script.', $this->getEnvironment()),
                 metadata: [
                     'detection_method' => 'composer_dry_run',
@@ -298,7 +298,7 @@ class DevDependencyAnalyzer extends AbstractAnalyzer
         return $this->createIssue(
             message: sprintf('Found %d dev dependencies installed in %s environment', count($installedDevPackages), $this->getEnvironment()),
             location: null,
-            severity: Severity::High,
+            severity: $this->metadata()->severity,
             recommendation: sprintf('Use "composer install --no-dev" in %s to exclude development dependencies. Dev packages like Ignition and Debugbar can cause memory leaks and slow down your application. Add --no-dev flag to your deployment script.', $this->getEnvironment()),
             metadata: [
                 'detection_method' => 'file_system',

--- a/src/Analyzers/Performance/EnvCallAnalyzer.php
+++ b/src/Analyzers/Performance/EnvCallAnalyzer.php
@@ -110,7 +110,7 @@ class EnvCallAnalyzer extends AbstractFileAnalyzer
                 message: $message,
                 filePath: $filePath,
                 lineNumber: $line,
-                severity: Severity::High,
+                severity: $this->metadata()->severity,
                 recommendation: ConfigSuggester::getRecommendation($varNameString),
                 code: $callType === 'static' ? 'Env::get' : 'env',
                 metadata: [

--- a/src/Analyzers/Performance/HorizonSuggestionAnalyzer.php
+++ b/src/Analyzers/Performance/HorizonSuggestionAnalyzer.php
@@ -106,7 +106,7 @@ class HorizonSuggestionAnalyzer extends AbstractAnalyzer
             $issues[] = $this->createIssue(
                 message: 'Laravel Horizon is installed but not configured',
                 location: null,
-                severity: Severity::Low,
+                severity: $this->metadata()->severity,
                 recommendation: 'Configure Laravel Horizon by running: php artisan horizon:install. This will publish the configuration file, create the service provider, and register it in your application.',
                 metadata: [
                     'queue_driver' => 'redis',
@@ -120,7 +120,7 @@ class HorizonSuggestionAnalyzer extends AbstractAnalyzer
             $issues[] = $this->createIssue(
                 message: 'Laravel Horizon is not installed for Redis queue management',
                 location: null,
-                severity: Severity::Low,
+                severity: $this->metadata()->severity,
                 recommendation: 'Install Laravel Horizon for Redis queue management. Horizon provides a beautiful dashboard for monitoring queues and jobs, configurable provisioning plans for workers, load balancing strategies, and advanced memory management features. Install with: composer require laravel/horizon && php artisan horizon:install',
                 metadata: [
                     'queue_driver' => 'redis',

--- a/src/Analyzers/Performance/SharedCacheLockAnalyzer.php
+++ b/src/Analyzers/Performance/SharedCacheLockAnalyzer.php
@@ -119,7 +119,7 @@ class SharedCacheLockAnalyzer extends AbstractFileAnalyzer
             $issues[] = $this->createIssue(
                 message: 'Cache lock usage detected on default cache store',
                 location: new Location($this->getRelativePath($usage['file']), $usage['line']),
-                severity: Severity::Low,
+                severity: $this->metadata()->severity,
                 recommendation: $this->getRecommendation(),
                 code: FileParser::getCodeSnippet($usage['file'], $usage['line']),
                 metadata: [

--- a/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
+++ b/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
@@ -86,7 +86,7 @@ class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
                 message: "Unused global middleware detected: {$middleware['name']}",
                 filePath: $kernelPath,
                 lineNumber: $middlewareLine,
-                severity: Severity::Low,
+                severity: $this->metadata()->severity,
                 recommendation: $middleware['recommendation'],
                 code: $middleware['name'],
                 metadata: [

--- a/src/Analyzers/Performance/ViewCachingAnalyzer.php
+++ b/src/Analyzers/Performance/ViewCachingAnalyzer.php
@@ -108,7 +108,7 @@ class ViewCachingAnalyzer extends AbstractAnalyzer
                 $this->createIssue(
                     message: 'Compiled views directory does not exist - view cache has not been generated',
                     location: null,
-                    severity: Severity::Medium,
+                    severity: $this->metadata()->severity,
                     recommendation: 'Run "php artisan view:cache" as part of your deployment process to generate compiled views.',
                     metadata: [
                         'environment' => $environment,
@@ -129,7 +129,7 @@ class ViewCachingAnalyzer extends AbstractAnalyzer
                 $this->createIssue(
                     message: 'No compiled views found - view cache has not been generated',
                     location: null,
-                    severity: Severity::Medium,
+                    severity: $this->metadata()->severity,
                     recommendation: 'Run "php artisan view:cache" as part of your deployment process to pre-compile all Blade templates. This eliminates on-demand compilation overhead in production.',
                     metadata: [
                         'environment' => $environment,
@@ -153,7 +153,7 @@ class ViewCachingAnalyzer extends AbstractAnalyzer
                         $this->humanDuration($staleDuration)
                     ),
                     location: null,
-                    severity: Severity::Medium,
+                    severity: $this->metadata()->severity,
                     recommendation: 'Run "php artisan view:cache" to regenerate the view cache. Add this command to your deployment script after any code changes.',
                     metadata: [
                         'environment' => $environment,

--- a/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
+++ b/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
@@ -49,7 +49,7 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
                 [$this->createIssue(
                     message: 'composer.json file is missing',
                     location: new Location('composer.json'),
-                    severity: Severity::Critical,
+                    severity: $this->metadata()->severity,
                     recommendation: 'Create a composer.json file in the root of your project. Run "composer init" to create one interactively.',
                     metadata: []
                 )]
@@ -71,7 +71,7 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
                 [$this->createIssue(
                     message: 'composer validate command reported issues',
                     location: new Location($this->getRelativePath($composerJsonPath)),
-                    severity: Severity::Critical,
+                    severity: $this->metadata()->severity,
                     recommendation: 'Run "composer validate" to see full details and resolve the reported issues. Ensure version constraints and schema match Composer expectations.',
                     code: null,
                     metadata: ['composer_output' => trim($result->output)],
@@ -95,7 +95,7 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
                 [$this->createIssue(
                     message: 'composer.json file exists but cannot be read',
                     location: new Location($this->getRelativePath($composerJsonPath)),
-                    severity: Severity::Critical,
+                    severity: $this->metadata()->severity,
                     recommendation: 'Check file permissions on composer.json. Ensure the file is readable by the web server user.',
                     metadata: []
                 )]
@@ -111,7 +111,7 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
                 [$this->createIssue(
                     message: 'composer.json is not valid JSON: '.json_last_error_msg(),
                     location: new Location($this->getRelativePath($composerJsonPath)),
-                    severity: Severity::Critical,
+                    severity: $this->metadata()->severity,
                     recommendation: 'Fix the JSON syntax errors in composer.json. Use a JSON validator or run "composer validate" to see specific errors. Common issues: missing commas, trailing commas, unescaped quotes.',
                     code: null,
                     metadata: [
@@ -129,7 +129,7 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
                 [$this->createIssue(
                     message: 'composer.json must be a JSON object, not a primitive value or array',
                     location: new Location($this->getRelativePath($composerJsonPath)),
-                    severity: Severity::Critical,
+                    severity: $this->metadata()->severity,
                     recommendation: 'composer.json must be a valid JSON object. Ensure the root element is an object (wrapped in curly braces {}), not an array (square brackets []).',
                     code: null,
                     metadata: []

--- a/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
+++ b/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
@@ -107,7 +107,7 @@ class CustomErrorPageAnalyzer extends AbstractAnalyzer
             [$this->createIssue(
                 message: 'Custom error pages not configured for: '.implode(', ', $missing),
                 location: new Location($this->getRelativePath($resourcesViewsPath)),
-                severity: Severity::Low,
+                severity: $this->metadata()->severity,
                 recommendation: $this->getCustomErrorPagesRecommendation(),
                 metadata: [
                     'missing_templates' => $missing,

--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -234,7 +234,7 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
         $issues[] = $this->createIssue(
             message: $message,
             location: new Location($this->getRelativePath($locationPath)),
-            severity: Severity::Critical,
+            severity: $this->metadata()->severity,
             recommendation: $this->buildRecommendation($formattedMissing, $formattedNonWritable),
             code: null,
             metadata: [
@@ -481,7 +481,7 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
         $issues[] = $this->createIssue(
             message: $message,
             location: new Location($this->getRelativePath($locationPath)),
-            severity: Severity::Critical,
+            severity: $this->metadata()->severity,
             recommendation: $this->buildSymlinkRecommendation($formattedSymlinks),
             code: null,
             metadata: [

--- a/src/Analyzers/Reliability/EnvFileAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvFileAnalyzer.php
@@ -48,7 +48,7 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
                     message: 'The .env file is a broken symlink',
                     filePath: $envPath,
                     lineNumber: null,
-                    severity: Severity::Critical,
+                    severity: $this->metadata()->severity,
                     recommendation: sprintf('Fix the broken symlink. Target: %s', $target ?: 'unknown'),
                     code: 'broken-symlink',
                     metadata: [
@@ -74,7 +74,7 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
                     message: 'The .env file exists but is not readable',
                     filePath: $envPath,
                     lineNumber: null,
-                    severity: Severity::Critical,
+                    severity: $this->metadata()->severity,
                     recommendation: 'Fix file permissions to make .env readable. Run: chmod 600 .env',
                     code: 'not-readable',
                     metadata: [
@@ -94,7 +94,7 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
                     message: 'The .env file exists but contains no configuration',
                     filePath: $envPath,
                     lineNumber: null,
-                    severity: Severity::Critical,
+                    severity: $this->metadata()->severity,
                     recommendation: 'Add environment variables to your .env file. At minimum, configure: APP_KEY, APP_ENV, APP_DEBUG, DB_CONNECTION',
                     code: 'empty-file',
                     metadata: [

--- a/src/Analyzers/Reliability/MaintenanceModeAnalyzer.php
+++ b/src/Analyzers/Reliability/MaintenanceModeAnalyzer.php
@@ -93,7 +93,7 @@ class MaintenanceModeAnalyzer extends AbstractFileAnalyzer
                 [$this->createIssue(
                     message: $message,
                     location: null,
-                    severity: Severity::High,
+                    severity: $this->metadata()->severity,
                     recommendation: $recommendation,
                     metadata: [
                         'is_down' => true,

--- a/src/Analyzers/Reliability/QueueTimeoutAnalyzer.php
+++ b/src/Analyzers/Reliability/QueueTimeoutAnalyzer.php
@@ -119,7 +119,7 @@ class QueueTimeoutAnalyzer extends AbstractFileAnalyzer
                 $issues[] = $this->createIssue(
                     message: "Queue connection '{$name}' has improper timeout configuration",
                     location: $location,
-                    severity: Severity::High,
+                    severity: $this->metadata()->severity,
                     recommendation: $this->getRecommendation($name, $timeout, $retryAfter, $minimumBuffer),
                     metadata: $metadata
                 );

--- a/src/Analyzers/Reliability/UpToDateMigrationsAnalyzer.php
+++ b/src/Analyzers/Reliability/UpToDateMigrationsAnalyzer.php
@@ -83,7 +83,7 @@ class UpToDateMigrationsAnalyzer extends AbstractFileAnalyzer
                         message: 'The migrations table has not been created yet',
                         filePath: $migrationsPath,
                         lineNumber: null,
-                        severity: Severity::High,
+                        severity: $this->metadata()->severity,
                         recommendation: 'This appears to be a new installation. Run "php artisan migrate:install" to create the migrations table, then run "php artisan migrate" to execute all migrations.',
                         code: 'migrations-table-missing',
                         metadata: [
@@ -143,7 +143,7 @@ class UpToDateMigrationsAnalyzer extends AbstractFileAnalyzer
                         message: 'Migration status check failed due to database connection issue',
                         filePath: $migrationsPath,
                         lineNumber: null,
-                        severity: Severity::High,
+                        severity: $this->metadata()->severity,
                         recommendation: $this->getDatabaseErrorRecommendation($e),
                         code: 'database-error',
                         metadata: [
@@ -159,7 +159,7 @@ class UpToDateMigrationsAnalyzer extends AbstractFileAnalyzer
                         message: 'Migration status check failed: '.$e->getMessage(),
                         filePath: $migrationsPath,
                         lineNumber: null,
-                        severity: Severity::High,
+                        severity: $this->metadata()->severity,
                         recommendation: 'Ensure the database connection is working and the migrations table exists. If this is a new installation, run "php artisan migrate:install" followed by "php artisan migrate". Error: '.$e->getMessage(),
                         code: 'migration-check-error',
                         metadata: [


### PR DESCRIPTION
## Summary
- Migrate 16 single-severity analyzers to use `$this->metadata()->severity` instead of hardcoded `Severity::` values in issue creation calls
- Keeps severity as a single source of truth in `metadata()`, reducing duplication across ~33 lines
- Multi-severity analyzers (e.g. `SilentFailureAnalyzer`, `XssAnalyzer`, `PasswordSecurityAnalyzer`) are intentionally excluded — they need different severities per issue type

## Analyzers Updated
- **Performance (7):** EnvCallAnalyzer, DevDependencyAnalyzer, SharedCacheLockAnalyzer, UnusedGlobalMiddlewareAnalyzer, DebugLogAnalyzer, ViewCachingAnalyzer, HorizonSuggestionAnalyzer
- **Reliability (7):** CustomErrorPageAnalyzer, MaintenanceModeAnalyzer, QueueTimeoutAnalyzer, EnvFileAnalyzer, ComposerValidationAnalyzer, UpToDateMigrationsAnalyzer, DirectoryWritePermissionsAnalyzer
- **Best Practices (1):** EloquentNPlusOneAnalyzer
- **Code Quality (1):** MissingDocBlockAnalyzer