### PR TITLE
refactor: replace --no-send with --report flag

### DIFF
--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -22,7 +22,7 @@ class AnalyzeCommand extends Command
                             {--format=console : Output format (console|json)}
                             {--output= : Save report to file}
                             {--baseline : Compare against baseline and only report new issues}
-                            {--no-send : Skip sending report to ShieldCI platform}';
+                            {--report : Send report to ShieldCI platform}';
 
     protected $description = 'Run ShieldCI security and code quality analysis';
 
@@ -747,8 +747,8 @@ class AnalyzeCommand extends Command
      */
     protected function shouldSendToApi(): bool
     {
-        if ($this->option('no-send')) {
-            return false;
+        if ($this->option('report')) {
+            return true;
         }
 
         return (bool) config('shieldci.report.send_to_api', false);

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -1833,15 +1833,21 @@ PHP);
     }
 
     #[Test]
-    public function it_does_not_send_to_api_when_no_send_flag_is_used(): void
+    public function it_sends_to_api_when_report_flag_is_used(): void
     {
         $this->registerTestAnalyzers();
 
-        config(['shieldci.report.send_to_api' => true]);
+        config(['shieldci.report.send_to_api' => false]);
 
-        $this->artisan('shield:analyze', ['--format' => 'json', '--no-send' => true])
+        \Illuminate\Support\Facades\Http::fake([
+            'api.test.shieldci.com/api/v1/reports' => \Illuminate\Support\Facades\Http::response([
+                'success' => true,
+            ]),
+        ]);
+
+        $this->artisan('shield:analyze', ['--format' => 'json', '--report' => true])
             ->assertSuccessful()
-            ->doesntExpectOutputToContain('Sending report to ShieldCI platform');
+            ->expectsOutputToContain('Report sent successfully');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Replaces `--no-send` (opt-out) with `--report` (opt-in) flag for API reporting
- Flips `shouldSendToApi()` logic: `--report` returns `true`, instead of `--no-send` returning `false`
- Aligns with `send_to_api` config defaulting to `false` — consistent "don't send unless asked" philosophy
- Updates test to verify `--report` flag triggers API send even when config is disabled

## Rationale
Opt-in is better UX: running `shield:analyze` should never silently upload to an external service. Users explicitly choose to report via `--report` flag or persistent `send_to_api=true` config.