### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## v1.0.0 - 2026-02-19
+
+First stable release. Graduated from 14 pre-release versions (v0.1.0–v0.1.13).
+
+### Highlights
+- 73 production-ready analyzers across 5 categories
+- PHPStan Level 9, 98%+ test coverage, Laravel 9–12 support
+
+### Analyzers (73 total)
+- 22 Security (OWASP Top 10 2021 coverage)
+- 18 Performance
+- 13 Reliability (includes PHPStan integration with 13 categories)
+- 5 Code Quality
+- 15 Best Practices
+
+### Features
+- `shield:analyze` command with category/analyzer/format/output filtering
+- `shield:baseline` command for gradual adoption
+- Baseline comparison (`--baseline`) — only report new issues
+- Inline suppression (`@shieldci-ignore`) support
+- Code snippets with syntax highlighting and env variable redaction
+- Severity-aware results (resultBySeverity) for granular issue tiers
+- CI mode for fast pipeline-friendly analysis
+- Configurable fail conditions (severity threshold + score threshold)
+- Don't-report list for informational-only analyzers
+- Ignore-errors config with glob/wildcard pattern matching
+- Environment mapping for multi-environment deployments
+- Human-readable analyzer names in CLI output
+- Laravel Vapor support (OpcacheAnalyzer, PHPIniAnalyzer)
+
+### Quality
+- AST-based analysis for security analyzers (migrated from regex)
+- Extensive false-positive reduction (10+ analyzers improved)
+- Passwordless project detection
+- PHPStan Faker/Carbon/Eloquent scope handling

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # ShieldCI Laravel Package
 
-> **⚠️ Initial Development Release (v0.1.x)** - This package is under active development. APIs may change between minor versions until v1.0.0 is released.
-
 Modern security and code quality analysis for Laravel applications with 73 comprehensive analyzers covering security, performance, reliability, and code quality.
 
-Built on top of [`shieldci/analyzers-core`](https://github.com/shieldci/analyzers-core) (v0.1.x) - a shared, framework-agnostic foundation for static analysis tools.
+Built on top of [`shieldci/analyzers-core`](https://github.com/shieldci/analyzers-core) (v1.x) - a shared, framework-agnostic foundation for static analysis tools.
 
 ## Requirements
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/view": "^9.0|^10.0|^11.0|^12.0",
         "larastan/larastan": "^2.0",
         "phpstan/phpstan": "^1.10",
-        "shieldci/analyzers-core": "^0.1"
+        "shieldci/analyzers-core": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",


### PR DESCRIPTION
## Summary
- Graduate from 14 pre-release versions (v0.1.0–v0.1.13) to stable **v1.0.0**
- Bump `shieldci/analyzers-core` dependency from `^0.1` to `^1.0`
- Remove pre-release warning banner from README
- Add CHANGELOG.md with grouped release notes

## What's in v1.0.0
- 73 production-ready analyzers across 5 categories
- PHPStan Level 9, 98%+ test coverage, Laravel 9–12 support
- Full OWASP Top 10 2021 coverage (22 security analyzers)
- `shield:analyze` and `shield:baseline` commands
- API integration for report sending
- CI mode, baseline comparison, inline suppression, and more

## Verification
- PHPStan Level 9: 0 errors (216 files)
- PHPUnit: 3596 tests, 6980 assertions, 0 failures
- Pint: format OK

## After merge
Tag `v1.0.0` on the merge commit and create a GitHub release.