### PR TITLE
fix: widen larastan/phpstan constraints for Laravel 12 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "illuminate/http": "^9.0|^10.0|^11.0|^12.0",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
         "illuminate/view": "^9.0|^10.0|^11.0|^12.0",
-        "larastan/larastan": "^2.0",
-        "phpstan/phpstan": "^1.10",
+        "larastan/larastan": "^2.0|^3.0",
+        "phpstan/phpstan": "^1.10|^2.0",
         "shieldci/analyzers-core": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

- Widen `larastan/larastan` from `^2.0` to `^2.0|^3.0`
- Widen `phpstan/phpstan` from `^1.10` to `^1.10|^2.0`

## Problem

Installing `shieldci/laravel` in a Laravel 12 project resolves to **v0.1.0** instead of v1.0.0. This happens because Larastan 2.x does not support Laravel 12 — Composer cannot satisfy v1.0.0's dependency tree and silently falls back to the highest v0.1.x where larastan wasn't a dependency.

## Fix

Larastan 3.x adds Laravel 12 support but requires PHPStan 2.x. By widening both constraints, Composer resolves:
- **Laravel 9–11** → Larastan 2.x + PHPStan 1.x
- **Laravel 12** → Larastan 3.x + PHPStan 2.x

The package invokes PHPStan purely via CLI (`vendor/bin/phpstan`), so the major version bump has no code impact.