### PR TITLE
fix: show Documentation URL in console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.2 - 2026-02-20
+
+### Fixed
+- Fix "Documentation URL:" never appearing in console output by using `getDocsUrl()` accessor instead of raw `docsUrl` property in `AnalyzeCommand`
+
 ## v1.0.1 - 2026-02-20
 
 ### Fixed

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -195,7 +195,7 @@ class AnalyzeCommand extends Command
                         'description' => $metadata->description,
                         'category' => $metadata->category,
                         'severity' => $metadata->severity,
-                        'docsUrl' => $metadata->docsUrl,
+                        'docsUrl' => $metadata->getDocsUrl(),
                         'timeToFix' => $metadata->timeToFix,
                     ],
                 );
@@ -318,7 +318,7 @@ class AnalyzeCommand extends Command
                         'description' => $metadata->description,
                         'category' => $metadata->category,
                         'severity' => $metadata->severity,
-                        'docsUrl' => $metadata->docsUrl,
+                        'docsUrl' => $metadata->getDocsUrl(),
                         'timeToFix' => $metadata->timeToFix,
                     ],
                 );
@@ -487,7 +487,7 @@ class AnalyzeCommand extends Command
                     'description' => $metadata->description,
                     'category' => $metadata->category,
                     'severity' => $metadata->severity,
-                    'docsUrl' => $metadata->docsUrl,
+                    'docsUrl' => $metadata->getDocsUrl(),
                 ],
             );
         });


### PR DESCRIPTION
## Summary
- Fix "Documentation URL:" line never appearing in `shield:analyze` console output
- `AnalyzeCommand` was using `$metadata->docsUrl` (always `null`) instead of `$metadata->getDocsUrl()` (auto-generates URL from base URL + category + analyzer ID)
- Changed all 3 result enrichment sites in `AnalyzeCommand` (lines 198, 321, 490)