### PR TITLE
fix: recognise guest middleware groups in AuthenticationAnalyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.0.3 - 2026-02-20
+
+### Fixed
+- `AuthenticationAnalyzer` now recognises `Route::middleware('guest')->group()` wrappers so routes inside guest groups are no longer false-positived as "missing auth middleware"
+- Route groups using array syntax (`Route::group(['middleware' => 'guest', ...])`) are also recognised
+- Controller methods pointed to by routes in guest groups are correctly marked as intentionally public
+- Improved recommendation strings to mention `->middleware("guest")` as a valid alternative for intentionally public routes
+
 ## v1.0.2 - 2026-02-20
 
 ### Fixed


### PR DESCRIPTION
## Summary
- `AuthenticationAnalyzer` now recognises `Route::middleware('guest')->group()` wrappers so routes inside guest groups are no longer false-positived as "missing auth middleware"
- Supports all three Laravel syntaxes: `Route::middleware('guest')`, `Route::middleware(['guest'])`, and `Route::group(['middleware' => 'guest', ...])`
- Controller methods pointed to by routes in guest groups are correctly marked as intentionally public
- Improved recommendation strings to mention `->middleware("guest")` as a valid alternative for intentionally public routes

## Changes
- **`AuthenticationAnalyzer.php`**: Added `checkRouteGroupForGuest()`, `isRouteInGuestGroup()` methods; extended `identifyRouteGroups()` with `hasGuest` field; wired guest checks into `checkRouteFile()` and `buildPublicControllerMap()`; updated 3 recommendation strings; updated PHPDoc types
- **`AuthenticationAnalyzerTest.php`**: Added 5 new tests covering guest group string/array/Route::group syntax, mixed auth+guest groups, and controller integration
- **`CHANGELOG.md`**: Added v1.0.3 entry