### PR TITLE
fix: remove preload from HSTS missing-header recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.4 - 2026-02-23
+
+### Fixed
+- Remove `preload` from HSTS missing-header recommendation to match default config (`require_preload => false`) and avoid encouraging an irreversible browser preload list submission
+
 ## v1.0.3 - 2026-02-20
 
 ### Fixed

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -247,7 +247,7 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
                 message: 'HTTPS-only application missing HSTS (Strict-Transport-Security) header',
                 location: new Location($middlewarePath),
                 severity: Severity::High,
-                recommendation: 'Add middleware to set Strict-Transport-Security header: "max-age=31536000; includeSubDomains; preload"',
+                recommendation: 'Add middleware to set Strict-Transport-Security header: "max-age=31536000; includeSubDomains"',
                 metadata: [
                     'issue_type' => 'missing_hsts',
                     'https_only' => true,


### PR DESCRIPTION
## Summary
- Removed `preload` from the HSTS missing-header recommendation string to match the default config (`require_preload => false`)
- The previous recommendation could lead users to irreversibly submit their domain to the browser HSTS preload list without understanding the implications
- Added CHANGELOG entry for v1.0.4