### PR TITLE
fix: prevent XssAnalyzer false positive on literal-output ternaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.5 - 2026-02-24
+
+### Fixed
+- `XssAnalyzer` no longer flags literal-output ternaries inside `<script>` tags as JavaScript XSS (e.g. `{{ $coll->contains(request()->route()->getName()) ? 'true' : 'false' }}`) — both branches are string/boolean/numeric/null literals so the output can never contain user-controlled data
+
 ## v1.0.4 - 2026-02-23
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Fixes false positive where `{{ condition ? 'true' : 'false' }}` inside `<script>` tags was flagged as JavaScript XSS when the condition referenced `request()`
- Adds `allBladeExpressionsAreLiteralOutputs()` method that detects ternaries where both branches are string, boolean, numeric, or null literals — safe regardless of the condition
- Elvis operator (`?:`) is explicitly excluded since it can output the condition value directly