### PR TITLE
fix: prevent HSTS analyzer false positive on multi-line header definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.7 - 2026-02-24
+
+### Fixed
+- `HSTSHeaderAnalyzer` no longer false-positives on multi-line header definitions (e.g. `$response->headers->set(\n  'Strict-Transport-Security',\n  'max-age=31536000; includeSubDomains'\n)`) — now gathers a context window across subsequent lines (#95)
+- `includeSubDomains` and `preload` directive checks are now case-insensitive per RFC 6797
+
 ## v1.0.6 - 2026-02-24
 
 ### Added


### PR DESCRIPTION
## Summary

- Fix `HSTSHeaderAnalyzer::validateHSTSConfiguration()` false positive when HSTS header is defined across multiple lines (e.g. `$response->headers->set(\n  'Strict-Transport-Security',\n  'max-age=...; includeSubDomains'\n)`)
- Gather a 6-line context window when `Strict-Transport-Security` is found, running directive checks against the joined context instead of a single line
- Use `stripos` for case-insensitive `includeSubDomains` and `preload` matching per RFC 6797