### PR TITLE
fix: clarify validated() requires FormRequest in MassAssignment recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.8 - 2026-02-25
+
+### Fixed
+- `MassAssignmentAnalyzer` recommendations no longer suggest `request()->validated()` as a universal alternative — clarified that `validated()` requires a `FormRequest` subclass, with `request()->only([...])` as the universal safe option (#96)
+
 ## v1.0.7 - 2026-02-24
 
 ### Fixed

--- a/src/Analyzers/Security/MassAssignmentAnalyzer.php
+++ b/src/Analyzers/Security/MassAssignmentAnalyzer.php
@@ -703,7 +703,7 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
                     filePath: $file,
                     lineNumber: $call->getLine(),
                     severity: Severity::High,
-                    recommendation: 'Use request()->only([...]) or request()->validated() instead of except() for better security. Whitelist (only) is safer than blacklist (except) as new fields are excluded by default',
+                    recommendation: 'Use request()->only([...]) instead of except(), or use a FormRequest with $request->validated(). Whitelist filtering is safer than blacklist as new fields are excluded by default',
                     metadata: [
                         'method' => $method,
                         'call_type' => $callType,
@@ -729,7 +729,7 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
                     filePath: $file,
                     lineNumber: $call->getLine(),
                     severity: Severity::Critical,
-                    recommendation: 'Use request()->only([...]) or request()->validated() to specify allowed fields explicitly',
+                    recommendation: 'Use request()->only([...]) to specify allowed fields, or use a FormRequest with $request->validated() for full validation',
                     metadata: [
                         'method' => $method,
                         'call_type' => $callType,
@@ -1208,7 +1208,7 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
                             filePath: $file,
                             lineNumber: $call->getLine(),
                             severity: Severity::High,
-                            recommendation: 'Use request()->only([...]) or request()->validated() to filter data before passing to relationship methods',
+                            recommendation: 'Use request()->only([...]) to filter data, or use a FormRequest with $request->validated(), before passing to relationship methods',
                             metadata: [
                                 'method' => $method,
                                 'issue_type' => 'relationship_mass_assignment',


### PR DESCRIPTION
## Summary
- Updated 3 recommendation strings in `MassAssignmentAnalyzer` to clarify that `$request->validated()` requires a `FormRequest` subclass, not a plain `Illuminate\Http\Request`
- `request()->only([...])` is now presented as the universal safe alternative, with `FormRequest` + `validated()` as the validation-aware option
- Added 3 regression tests verifying each issue type (unfiltered request data, blacklist filtering, relationship mass assignment) mentions `FormRequest` in its recommendation