### PR TITLE
fix: prevent SqlInjection false positives on table/column name and placeholder concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.9 - 2026-02-25
+
+### Fixed
+- `SqlInjectionAnalyzer` no longer false-positives on table/column name concatenation in `*Raw()` fragment methods (e.g. `->orderByRaw('(col/' . $table . '.goal) ASC')`) — only direct user input sources (`$_GET`, `$_POST`, `request()`, `Request::input()`) are flagged (#97)
+- `SqlInjectionAnalyzer` no longer false-positives on structural concatenation in `DB::select/insert/update/delete` when bindings are present (e.g. `DB::select('...IN (' . $placeholders . ')', $bindings)`) — the presence of bindings indicates parameterized query awareness (#97)
+
 ## v1.0.8 - 2026-02-25
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Introduces two-tier concatenation detection in `SqlInjectionAnalyzer`: **strict** mode (full-query methods like `DB::select`) flags all concatenation, **lenient** mode (fragment methods like `*Raw()`) only flags concatenation containing direct user input sources (`$_GET`, `$_POST`, `request()`, `Request::input()`, etc.)
- When bindings are present (2+ args), full-query methods also use lenient mode — the developer is already using parameterized queries, so concatenation is likely structural (table names, dynamic placeholders)
- Eliminates false positives for common safe patterns like `->orderByRaw('(col/' . $table . '.goal) ASC')` and `DB::select('...IN (' . $placeholders . ')', $bindings)`