### PR TITLE
fix: resolve env() defaults in config analyzer checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.0.11 - 2026-02-26
+
+### Fixed
+- `CookieSecurityAnalyzer` no longer false-positives on `env()` calls with secure defaults (e.g. `'same_site' => env('SESSION_SAME_SITE', 'lax')` was incorrectly flagged as weak SameSite protection)
+- `CookieSecurityAnalyzer` now detects insecure `env()` defaults for `http_only` and `secure` checks (e.g. `env('SESSION_HTTP_ONLY', false)` was previously missed)
+- `HSTSHeaderAnalyzer` now resolves `env()` defaults when detecting HTTPS-only apps and checking session cookie security (e.g. `'secure' => env('SESSION_SECURE_COOKIE', true)` is now recognised as HTTPS-only)
+- Added `resolveConfigValue()` helper and `envHasDefault` flag to `InspectsCode` trait for correct `env()` default resolution in config array parsing
+
 ## v1.0.10 - 2026-02-26
 
 ### Fixed

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -93,7 +93,7 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
         if (file_exists($sessionConfig)) {
             $config = $this->parseConfigArray($sessionConfig);
 
-            if (isset($config['secure']) && $config['secure']['value'] === true) {
+            if (isset($config['secure']) && $this->resolveConfigValue($config['secure']) === true) {
                 return true;
             }
         }
@@ -115,7 +115,7 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
         if (file_exists($appConfig)) {
             $config = $this->parseConfigArray($appConfig);
 
-            if (isset($config['force_https']) && $config['force_https']['value'] === true) {
+            if (isset($config['force_https']) && $this->resolveConfigValue($config['force_https']) === true) {
                 return true;
             }
         }
@@ -358,7 +358,9 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
         if (isset($configArray['secure'])) {
             $entry = $configArray['secure'];
 
-            if ($entry['value'] === false || $entry['value'] === 0) {
+            $effectiveValue = $this->resolveConfigValue($entry);
+
+            if ($effectiveValue === false || $effectiveValue === 0) {
                 $issues[] = $this->createIssue(
                     message: 'HTTPS-only application has secure cookies disabled',
                     location: new Location($this->getRelativePath($sessionConfig), $entry['line']),

--- a/tests/Unit/Analyzers/Security/CookieSecurityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/CookieSecurityAnalyzerTest.php
@@ -308,6 +308,207 @@ PHP;
         $this->assertPassed($result);
     }
 
+    // ==================== ENV() CALL TESTS ====================
+
+    public function test_passes_when_same_site_uses_env_with_lax_default(): void
+    {
+        $sessionConfig = <<<'PHP'
+<?php
+
+return [
+    'http_only' => true,
+    'secure' => true,
+    'same_site' => env('SESSION_SAME_SITE', 'lax'),
+];
+PHP;
+
+        $tempDir = $this->createTempDirectory(['config/session.php' => $sessionConfig]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_when_same_site_uses_env_with_strict_default(): void
+    {
+        $sessionConfig = <<<'PHP'
+<?php
+
+return [
+    'http_only' => true,
+    'secure' => true,
+    'same_site' => env('SESSION_SAME_SITE', 'strict'),
+];
+PHP;
+
+        $tempDir = $this->createTempDirectory(['config/session.php' => $sessionConfig]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_fails_when_same_site_uses_env_with_null_default(): void
+    {
+        $sessionConfig = <<<'PHP'
+<?php
+
+return [
+    'http_only' => true,
+    'secure' => true,
+    'same_site' => env('SESSION_SAME_SITE', null),
+];
+PHP;
+
+        $tempDir = $this->createTempDirectory(['config/session.php' => $sessionConfig]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFalse($result->isSuccess());
+        $this->assertHasIssueContaining('SameSite', $result);
+    }
+
+    public function test_fails_when_same_site_uses_env_with_none_default(): void
+    {
+        $sessionConfig = <<<'PHP'
+<?php
+
+return [
+    'http_only' => true,
+    'secure' => true,
+    'same_site' => env('SESSION_SAME_SITE', 'none'),
+];
+PHP;
+
+        $tempDir = $this->createTempDirectory(['config/session.php' => $sessionConfig]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFalse($result->isSuccess());
+        $this->assertHasIssueContaining('SameSite', $result);
+    }
+
+    public function test_passes_when_same_site_uses_env_without_default(): void
+    {
+        $sessionConfig = <<<'PHP'
+<?php
+
+return [
+    'http_only' => true,
+    'secure' => true,
+    'same_site' => env('SESSION_SAME_SITE'),
+];
+PHP;
+
+        $tempDir = $this->createTempDirectory(['config/session.php' => $sessionConfig]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        // Indeterminate — should not flag (conservative)
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_when_http_only_uses_env_with_true_default(): void
+    {
+        $sessionConfig = <<<'PHP'
+<?php
+
+return [
+    'http_only' => env('SESSION_HTTP_ONLY', true),
+    'secure' => true,
+];
+PHP;
+
+        $tempDir = $this->createTempDirectory(['config/session.php' => $sessionConfig]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_fails_when_http_only_uses_env_with_false_default(): void
+    {
+        $sessionConfig = <<<'PHP'
+<?php
+
+return [
+    'http_only' => env('SESSION_HTTP_ONLY', false),
+    'secure' => true,
+];
+PHP;
+
+        $tempDir = $this->createTempDirectory(['config/session.php' => $sessionConfig]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('HttpOnly', $result);
+    }
+
+    public function test_passes_when_secure_uses_env_with_true_default(): void
+    {
+        $sessionConfig = <<<'PHP'
+<?php
+
+return [
+    'http_only' => true,
+    'secure' => env('SESSION_SECURE_COOKIE', true),
+];
+PHP;
+
+        $tempDir = $this->createTempDirectory(['config/session.php' => $sessionConfig]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_fails_when_secure_uses_env_with_false_default(): void
+    {
+        $sessionConfig = <<<'PHP'
+<?php
+
+return [
+    'http_only' => true,
+    'secure' => env('SESSION_SECURE_COOKIE', false),
+];
+PHP;
+
+        $tempDir = $this->createTempDirectory(['config/session.php' => $sessionConfig]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('secure', $result);
+    }
+
     // ==================== ENCRYPT_COOKIES MIDDLEWARE TESTS ====================
 
     public function test_fails_when_encrypt_cookies_middleware_missing(): void

--- a/tests/Unit/Concerns/InspectsCodeTest.php
+++ b/tests/Unit/Concerns/InspectsCodeTest.php
@@ -364,6 +364,48 @@ class InspectsCodeTest extends TestCase
     }
 
     #[Test]
+    public function resolve_config_value_returns_literal_for_non_env_entries(): void
+    {
+        $inspector = new ConcreteInspectsCode;
+
+        $this->assertSame('lax', $inspector->publicResolveConfigValue([
+            'value' => 'lax', 'line' => 1, 'isEnvCall' => false, 'envDefault' => null, 'envHasDefault' => false,
+        ]));
+        $this->assertFalse($inspector->publicResolveConfigValue([
+            'value' => false, 'line' => 1, 'isEnvCall' => false, 'envDefault' => null, 'envHasDefault' => false,
+        ]));
+        $this->assertNull($inspector->publicResolveConfigValue([
+            'value' => null, 'line' => 1, 'isEnvCall' => false, 'envDefault' => null, 'envHasDefault' => false,
+        ]));
+    }
+
+    #[Test]
+    public function resolve_config_value_returns_env_default_for_env_entries(): void
+    {
+        $inspector = new ConcreteInspectsCode;
+
+        $this->assertSame('lax', $inspector->publicResolveConfigValue([
+            'value' => null, 'line' => 1, 'isEnvCall' => true, 'envDefault' => 'lax', 'envHasDefault' => true,
+        ]));
+        $this->assertFalse($inspector->publicResolveConfigValue([
+            'value' => null, 'line' => 1, 'isEnvCall' => true, 'envDefault' => false, 'envHasDefault' => true,
+        ]));
+        $this->assertTrue($inspector->publicResolveConfigValue([
+            'value' => null, 'line' => 1, 'isEnvCall' => true, 'envDefault' => true, 'envHasDefault' => true,
+        ]));
+    }
+
+    #[Test]
+    public function resolve_config_value_returns_null_for_env_without_default(): void
+    {
+        $inspector = new ConcreteInspectsCode;
+
+        $this->assertNull($inspector->publicResolveConfigValue([
+            'value' => null, 'line' => 1, 'isEnvCall' => true, 'envDefault' => null, 'envHasDefault' => false,
+        ]));
+    }
+
+    #[Test]
     public function parse_config_array_includes_line_numbers(): void
     {
         $inspector = new ConcreteInspectsCode;
@@ -408,11 +450,19 @@ class ConcreteInspectsCode
     }
 
     /**
-     * @return array<string, array{value: mixed, line: int, isEnvCall: bool, envDefault: mixed}>
+     * @return array<string, array{value: mixed, line: int, isEnvCall: bool, envDefault: mixed, envHasDefault: bool}>
      */
     public function publicParseConfigArray(string $filePath): array
     {
         return $this->parseConfigArray($filePath);
+    }
+
+    /**
+     * @param  array{value: mixed, line: int, isEnvCall: bool, envDefault: mixed, envHasDefault: bool}  $entry
+     */
+    public function publicResolveConfigValue(array $entry): mixed
+    {
+        return $this->resolveConfigValue($entry);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add `resolveConfigValue()` helper to `InspectsCode` trait that looks through `env()` wrappers to evaluate the default argument as the effective config value
- Add `envHasDefault` flag to `parseConfigArray` to distinguish `env('X')` (indeterminate) from `env('X', null)` (explicit null default)
- Fix 6 affected checks across `CookieSecurityAnalyzer` (http_only, secure, same_site) and `HSTSHeaderAnalyzer` (isHttpsOnlyApp secure/force_https, checkSessionConfiguration secure)

**Fixes:**
- **False positive**: `env('SESSION_SAME_SITE', 'lax')` was flagged as weak SameSite protection
- **False negatives**: `env('SESSION_HTTP_ONLY', false)`, `env('SESSION_SECURE_COOKIE', false)`, and `env('SESSION_SECURE_COOKIE', true)` (for HTTPS detection) were not evaluated