### PR TITLE
feat: notify platform when shield:analyze fails before producing a report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.1.0 - 2026-03-02
+
+### Added
+- Platform failure notifications: `shield:analyze` now POSTs to `/api/reports/failure` whenever analysis exits early, so the ShieldCI dashboard can record and surface failures that never produced a report
+- `AnalysisFailureReason` enum with four cases: `InvalidOptions`, `AllCategoriesDisabled`, `NoAnalyzersRan`, `UncaughtException`
+- `FailureNotification` value object whose `toArray()` output mirrors the `/api/reports` shape (`laravel_version` and `package_version` are top-level fields)
+- `ClientInterface::sendFailureNotification()` / `ShieldCIClient` implementation posting to `POST /api/reports/failure`
+- Failure notifications are sent silently — any API error is swallowed so notifications never interrupt command flow
+
 ## v1.0.12 - 2026-02-27
 
 ### Fixed

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -11,8 +11,10 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\Contracts\ReporterInterface;
+use ShieldCI\Enums\AnalysisFailureReason;
 use ShieldCI\Support\InlineSuppressionParser;
 use ShieldCI\ValueObjects\AnalysisReport;
+use ShieldCI\ValueObjects\FailureNotification;
 
 class AnalyzeCommand extends Command
 {
@@ -37,14 +39,36 @@ class AnalyzeCommand extends Command
         \ShieldCI\Contracts\ClientInterface $client,
     ): int {
         $this->suppressionParser = new InlineSuppressionParser;
+
+        // Resolve trigger source early (needed for failure notifications)
+        $triggeredBy = $this->resolveTriggerSource();
+
         // Validate options
         if (! $this->validateOptions($manager)) {
+            $this->notifyFailure($client, AnalysisFailureReason::InvalidOptions, 'Command validation failed: invalid options provided', $triggeredBy);
+
             return self::FAILURE;
         }
 
-        // Resolve trigger source
-        $triggeredBy = $this->resolveTriggerSource();
+        try {
+            return $this->executeAnalysis($manager, $reporter, $client, $triggeredBy);
+        } catch (\Throwable $e) {
+            $this->error("Analysis failed with error: {$e->getMessage()}");
+            $this->notifyFailure($client, AnalysisFailureReason::UncaughtException, $e->getMessage(), $triggeredBy);
 
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * Execute the main analysis flow.
+     */
+    private function executeAnalysis(
+        AnalyzerManager $manager,
+        ReporterInterface $reporter,
+        \ShieldCI\Contracts\ClientInterface $client,
+        \ShieldCI\Enums\TriggerSource $triggeredBy,
+    ): int {
         // Apply memory limit
         $memoryLimit = config('shieldci.memory_limit');
         if ($memoryLimit !== null && is_string($memoryLimit)) {
@@ -88,6 +112,7 @@ class AnalyzeCommand extends Command
                 $this->line('');
                 $this->line('To enable categories, set their "enabled" flag to true in config/shieldci.php');
                 $this->line('or set the corresponding environment variables (e.g., SHIELDCI_SECURITY_ANALYZERS=true).');
+                $this->notifyFailure($client, AnalysisFailureReason::AllCategoriesDisabled, 'All analyzer categories are disabled in configuration', $triggeredBy);
 
                 return self::FAILURE;
             }
@@ -100,6 +125,7 @@ class AnalyzeCommand extends Command
 
         if ($results->isEmpty()) {
             $this->error('No analyzers were run.');
+            $this->notifyFailure($client, AnalysisFailureReason::NoAnalyzersRan, 'Analysis completed but no analyzers produced results', $triggeredBy);
 
             return self::FAILURE;
         }
@@ -738,6 +764,97 @@ class AnalyzeCommand extends Command
         $code = $colors[$color];
 
         return "\033[{$code}m{$text}\033[0m";
+    }
+
+    /**
+     * Send a failure notification to the ShieldCI platform API.
+     */
+    private function notifyFailure(
+        \ShieldCI\Contracts\ClientInterface $client,
+        AnalysisFailureReason $reason,
+        string $errorMessage,
+        \ShieldCI\Enums\TriggerSource $triggeredBy,
+    ): void {
+        if (! $this->shouldSendToApi()) {
+            return;
+        }
+
+        try {
+            $projectIdConfig = config('shieldci.project_id', 'unknown');
+            $projectId = is_string($projectIdConfig) ? $projectIdConfig : 'unknown';
+
+            $notification = new FailureNotification(
+                projectId: $projectId,
+                laravelVersion: app()->version(),
+                packageVersion: $this->resolvePackageVersion(),
+                reason: $reason,
+                errorMessage: $errorMessage,
+                triggeredBy: $triggeredBy,
+                occurredAt: new \DateTimeImmutable('now', new \DateTimeZone('UTC')),
+                metadata: $this->buildFailureMetadata(),
+            );
+
+            $client->sendFailureNotification($notification->toArray());
+        } catch (\Exception $e) {
+            // Silently fail — failure notifications should never interrupt the command flow
+        }
+    }
+
+    /**
+     * Build metadata array for failure notifications.
+     *
+     * @return array<string, string>
+     */
+    private function buildFailureMetadata(): array
+    {
+        $appName = config('app.name');
+        $appUrl = config('app.url');
+
+        $metadata = [
+            'php_version' => PHP_VERSION,
+            'environment' => $this->resolveEnvironment(),
+            'app_name' => is_string($appName) ? $appName : '',
+            'app_url' => is_string($appUrl) ? $appUrl : '',
+            'os' => PHP_OS_FAMILY,
+        ];
+
+        $gitContext = $this->buildGitContext();
+        if (isset($gitContext['branch']) && $gitContext['branch'] !== '') {
+            $metadata['git_branch'] = $gitContext['branch'];
+        }
+        if (isset($gitContext['commit']) && $gitContext['commit'] !== '') {
+            $metadata['git_commit'] = $gitContext['commit'];
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Resolve the package version from Composer.
+     */
+    private function resolvePackageVersion(): string
+    {
+        if (class_exists(\Composer\InstalledVersions::class)) {
+            try {
+                $version = \Composer\InstalledVersions::getVersion('shieldci/laravel');
+
+                return is_string($version) ? $version : 'unknown';
+            } catch (\Exception $e) {
+                return 'unknown';
+            }
+        }
+
+        return 'unknown';
+    }
+
+    /**
+     * Resolve the current environment name.
+     */
+    private function resolveEnvironment(): string
+    {
+        $env = app()->environment();
+
+        return is_string($env) ? $env : 'unknown';
     }
 
     protected function saveReport(AnalysisReport $report, ReporterInterface $reporter, string $path): void

--- a/src/Contracts/ClientInterface.php
+++ b/src/Contracts/ClientInterface.php
@@ -30,4 +30,12 @@ interface ClientInterface
      * @return array<string, mixed>
      */
     public function getProject(): array;
+
+    /**
+     * Notify the ShieldCI platform that analysis failed before completion.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function sendFailureNotification(array $payload): array;
 }

--- a/src/Enums/AnalysisFailureReason.php
+++ b/src/Enums/AnalysisFailureReason.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Enums;
+
+enum AnalysisFailureReason: string
+{
+    case InvalidOptions = 'invalid_options';
+    case AllCategoriesDisabled = 'all_categories_disabled';
+    case NoAnalyzersRan = 'no_analyzers_ran';
+    case UncaughtException = 'uncaught_exception';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::InvalidOptions => 'Invalid command options',
+            self::AllCategoriesDisabled => 'All analyzer categories are disabled',
+            self::NoAnalyzersRan => 'No analyzers were executed',
+            self::UncaughtException => 'Uncaught exception during analysis',
+        };
+    }
+}

--- a/src/Http/Client/ShieldCIClient.php
+++ b/src/Http/Client/ShieldCIClient.php
@@ -83,4 +83,24 @@ class ShieldCIClient implements ClientInterface
 
         return $data;
     }
+
+    /**
+     * Notify the ShieldCI platform that analysis failed before completion.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     *
+     * @throws ConnectionException
+     */
+    public function sendFailureNotification(array $payload): array
+    {
+        $response = Http::withToken($this->token)
+            ->timeout(15)
+            ->post("{$this->baseUrl}/api/reports/failure", $payload);
+
+        /** @var array<string, mixed> $data */
+        $data = $response->json() ?? [];
+
+        return $data;
+    }
 }

--- a/src/ValueObjects/FailureNotification.php
+++ b/src/ValueObjects/FailureNotification.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\ValueObjects;
+
+use DateTimeImmutable;
+use ShieldCI\Enums\AnalysisFailureReason;
+use ShieldCI\Enums\TriggerSource;
+
+final class FailureNotification
+{
+    /**
+     * @param  array<string, string>  $metadata
+     */
+    public function __construct(
+        public readonly string $projectId,
+        public readonly string $laravelVersion,
+        public readonly string $packageVersion,
+        public readonly AnalysisFailureReason $reason,
+        public readonly string $errorMessage,
+        public readonly TriggerSource $triggeredBy,
+        public readonly DateTimeImmutable $occurredAt,
+        public readonly array $metadata = [],
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'project_id' => $this->projectId,
+            'laravel_version' => $this->laravelVersion,
+            'package_version' => $this->packageVersion,
+            'status' => 'failed',
+            'failure_reason' => $this->reason->value,
+            'failure_label' => $this->reason->label(),
+            'error_message' => $this->errorMessage,
+            'triggered_by' => $this->triggeredBy->value,
+            'occurred_at' => $this->occurredAt->format('c'),
+            'metadata' => $this->metadata,
+        ];
+    }
+}

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -2884,4 +2884,252 @@ PHP);
 
         return $analyzer;
     }
+
+    // ─── Failure Notification Tests ──────────────────────────────────
+
+    #[Test]
+    public function it_sends_failure_notification_on_invalid_options(): void
+    {
+        $this->registerTestAnalyzers();
+
+        \Illuminate\Support\Facades\Http::fake([
+            'api.test.shieldci.com/api/reports/failure' => \Illuminate\Support\Facades\Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'non-existent-analyzer',
+            '--report' => true,
+        ])->assertFailed();
+
+        \Illuminate\Support\Facades\Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/api/reports/failure')
+                && $request['status'] === 'failed'
+                && $request['failure_reason'] === 'invalid_options';
+        });
+    }
+
+    #[Test]
+    public function it_does_not_send_failure_notification_when_api_disabled(): void
+    {
+        $this->registerTestAnalyzers();
+
+        config(['shieldci.report.send_to_api' => false]);
+
+        \Illuminate\Support\Facades\Http::fake();
+
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'non-existent-analyzer',
+        ])->assertFailed();
+
+        \Illuminate\Support\Facades\Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function it_sends_failure_notification_on_all_categories_disabled(): void
+    {
+        $this->registerTestAnalyzers();
+
+        config([
+            'shieldci.analyzers.security.enabled' => false,
+            'shieldci.analyzers.performance.enabled' => false,
+            'shieldci.analyzers.reliability.enabled' => false,
+            'shieldci.analyzers.code-quality.enabled' => false,
+            'shieldci.analyzers.best-practices.enabled' => false,
+        ]);
+
+        \Illuminate\Support\Facades\Http::fake([
+            'api.test.shieldci.com/api/reports/failure' => \Illuminate\Support\Facades\Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('shield:analyze', ['--report' => true])
+            ->assertFailed();
+
+        \Illuminate\Support\Facades\Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/api/reports/failure')
+                && $request['failure_reason'] === 'all_categories_disabled';
+        });
+    }
+
+    #[Test]
+    public function it_sends_failure_notification_on_no_analyzers_ran(): void
+    {
+        // Register a manager that returns empty results
+        /** @phpstan-ignore-next-line */
+        $this->app->singleton(AnalyzerManager::class, function () {
+            /** @var \Mockery\MockInterface&AnalyzerManager $manager */
+            $manager = Mockery::mock(AnalyzerManager::class);
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getAnalyzers')->andReturn(collect());
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getByCategory')->with(Mockery::any())->andReturn(collect());
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getSkippedAnalyzers')->andReturn(collect());
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('runAll')->andReturn(collect());
+
+            return $manager;
+        });
+
+        \Illuminate\Support\Facades\Http::fake([
+            'api.test.shieldci.com/api/reports/failure' => \Illuminate\Support\Facades\Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('shield:analyze', ['--format' => 'json', '--report' => true])
+            ->assertFailed();
+
+        \Illuminate\Support\Facades\Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/api/reports/failure')
+                && $request['failure_reason'] === 'no_analyzers_ran';
+        });
+    }
+
+    #[Test]
+    public function it_sends_failure_notification_on_uncaught_exception(): void
+    {
+        // Create an analyzer mock that throws during analyze()
+        /** @var AnalyzerInterface&MockInterface $throwingAnalyzer */
+        $throwingAnalyzer = Mockery::mock(AnalyzerInterface::class);
+        /** @phpstan-ignore-next-line */
+        $throwingAnalyzer->shouldReceive('getId')->andReturn('throwing-analyzer');
+        /** @phpstan-ignore-next-line */
+        $throwingAnalyzer->shouldReceive('getMetadata')->andReturn(new AnalyzerMetadata(
+            id: 'throwing-analyzer',
+            name: 'Throwing Analyzer',
+            description: 'An analyzer that throws',
+            category: Category::Security,
+            severity: Severity::High,
+        ));
+        /** @phpstan-ignore-next-line */
+        $throwingAnalyzer->shouldReceive('analyze')->andThrow(new \RuntimeException('AST parser crashed'));
+        /** @phpstan-ignore-next-line */
+        $throwingAnalyzer->shouldReceive('shouldRun')->andReturn(true);
+        /** @phpstan-ignore-next-line */
+        $throwingAnalyzer->shouldReceive('getSkipReason')->andReturn('');
+
+        /** @phpstan-ignore-next-line */
+        $this->app->singleton(AnalyzerManager::class, function () use ($throwingAnalyzer) {
+            /** @var \Mockery\MockInterface&AnalyzerManager $manager */
+            $manager = Mockery::mock(AnalyzerManager::class);
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getAnalyzers')->andReturn(collect([$throwingAnalyzer]));
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getByCategory')->with(Mockery::any())->andReturn(collect());
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getSkippedAnalyzers')->andReturn(collect());
+
+            return $manager;
+        });
+
+        \Illuminate\Support\Facades\Http::fake([
+            'api.test.shieldci.com/api/reports/failure' => \Illuminate\Support\Facades\Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('shield:analyze', ['--format' => 'json', '--report' => true])
+            ->assertFailed()
+            ->expectsOutputToContain('Analysis failed with error: AST parser crashed');
+
+        \Illuminate\Support\Facades\Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/api/reports/failure')
+                && $request['failure_reason'] === 'uncaught_exception'
+                && str_contains($request['error_message'], 'AST parser crashed');
+        });
+    }
+
+    #[Test]
+    public function it_silently_handles_failure_notification_api_error(): void
+    {
+        $this->registerTestAnalyzers();
+
+        // Mock the client to throw on sendFailureNotification
+        /** @phpstan-ignore-next-line */
+        $this->app->singleton(\ShieldCI\Contracts\ClientInterface::class, function () {
+            $mock = Mockery::mock(\ShieldCI\Contracts\ClientInterface::class);
+            /** @phpstan-ignore-next-line */
+            $mock->shouldReceive('sendFailureNotification')
+                ->andThrow(new \Exception('Connection refused'));
+
+            return $mock;
+        });
+
+        // Trigger a failure (invalid analyzer) with --report
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'non-existent-analyzer',
+            '--report' => true,
+        ])->assertFailed();
+
+        // Command should still return FAILURE, not crash
+    }
+
+    #[Test]
+    public function it_includes_metadata_in_failure_notification(): void
+    {
+        $this->registerTestAnalyzers();
+
+        \Illuminate\Support\Facades\Http::fake([
+            'api.test.shieldci.com/api/reports/failure' => \Illuminate\Support\Facades\Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'non-existent-analyzer',
+            '--report' => true,
+        ])->assertFailed();
+
+        \Illuminate\Support\Facades\Http::assertSent(function ($request) {
+            $metadata = $request['metadata'] ?? [];
+
+            return str_contains($request->url(), '/api/reports/failure')
+                && isset($request['laravel_version'])
+                && isset($request['package_version'])
+                && isset($metadata['php_version'])
+                && isset($metadata['environment'])
+                && isset($metadata['os']);
+        });
+    }
+
+    #[Test]
+    public function it_includes_git_context_in_failure_notification(): void
+    {
+        $this->registerTestAnalyzers();
+
+        \Illuminate\Support\Facades\Http::fake([
+            'api.test.shieldci.com/api/reports/failure' => \Illuminate\Support\Facades\Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'non-existent-analyzer',
+            '--report' => true,
+            '--git-branch' => 'feature/test',
+            '--git-commit' => 'abc123',
+        ])->assertFailed();
+
+        \Illuminate\Support\Facades\Http::assertSent(function ($request) {
+            $metadata = $request['metadata'] ?? [];
+
+            return str_contains($request->url(), '/api/reports/failure')
+                && ($metadata['git_branch'] ?? '') === 'feature/test'
+                && ($metadata['git_commit'] ?? '') === 'abc123';
+        });
+    }
+
+    #[Test]
+    public function it_sends_failure_notification_with_send_to_api_config(): void
+    {
+        $this->registerTestAnalyzers();
+
+        config(['shieldci.report.send_to_api' => true]);
+
+        \Illuminate\Support\Facades\Http::fake([
+            'api.test.shieldci.com/api/reports/failure' => \Illuminate\Support\Facades\Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'non-existent-analyzer',
+        ])->assertFailed();
+
+        \Illuminate\Support\Facades\Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/api/reports/failure');
+        });
+    }
 }

--- a/tests/Unit/Enums/AnalysisFailureReasonTest.php
+++ b/tests/Unit/Enums/AnalysisFailureReasonTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Enums;
+
+use PHPUnit\Framework\Attributes\Test;
+use ShieldCI\Enums\AnalysisFailureReason;
+use ShieldCI\Tests\TestCase;
+
+class AnalysisFailureReasonTest extends TestCase
+{
+    #[Test]
+    public function all_cases_have_non_empty_values(): void
+    {
+        foreach (AnalysisFailureReason::cases() as $case) {
+            $this->assertNotEmpty($case->value, "Case {$case->name} has empty value");
+        }
+    }
+
+    #[Test]
+    public function all_cases_have_non_empty_labels(): void
+    {
+        foreach (AnalysisFailureReason::cases() as $case) {
+            $this->assertNotEmpty($case->label(), "Case {$case->name} has empty label");
+        }
+    }
+
+    #[Test]
+    public function try_from_returns_case_for_valid_values(): void
+    {
+        $this->assertSame(AnalysisFailureReason::InvalidOptions, AnalysisFailureReason::tryFrom('invalid_options'));
+        $this->assertSame(AnalysisFailureReason::AllCategoriesDisabled, AnalysisFailureReason::tryFrom('all_categories_disabled'));
+        $this->assertSame(AnalysisFailureReason::NoAnalyzersRan, AnalysisFailureReason::tryFrom('no_analyzers_ran'));
+        $this->assertSame(AnalysisFailureReason::UncaughtException, AnalysisFailureReason::tryFrom('uncaught_exception'));
+    }
+
+    #[Test]
+    public function try_from_returns_null_for_invalid_values(): void
+    {
+        $this->assertNull(AnalysisFailureReason::tryFrom('nonexistent'));
+        $this->assertNull(AnalysisFailureReason::tryFrom(''));
+    }
+
+    #[Test]
+    public function labels_are_human_readable(): void
+    {
+        $this->assertSame('Invalid command options', AnalysisFailureReason::InvalidOptions->label());
+        $this->assertSame('All analyzer categories are disabled', AnalysisFailureReason::AllCategoriesDisabled->label());
+        $this->assertSame('No analyzers were executed', AnalysisFailureReason::NoAnalyzersRan->label());
+        $this->assertSame('Uncaught exception during analysis', AnalysisFailureReason::UncaughtException->label());
+    }
+}

--- a/tests/Unit/Http/Client/ShieldCIClientTest.php
+++ b/tests/Unit/Http/Client/ShieldCIClientTest.php
@@ -197,4 +197,59 @@ class ShieldCIClientTest extends TestCase
             return $request->hasHeader('Authorization', 'Bearer test-token');
         });
     }
+
+    #[Test]
+    public function send_failure_notification_posts_to_failure_endpoint(): void
+    {
+        Http::fake([
+            'api.test.shieldci.com/api/reports/failure' => Http::response([
+                'success' => true,
+            ]),
+        ]);
+
+        $client = new ShieldCIClient;
+        $payload = [
+            'project_id' => 'proj-1',
+            'status' => 'failed',
+            'failure_reason' => 'invalid_options',
+        ];
+
+        $result = $client->sendFailureNotification($payload);
+
+        $this->assertEquals(['success' => true], $result);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://api.test.shieldci.com/api/reports/failure'
+                && $request->method() === 'POST'
+                && $request['project_id'] === 'proj-1'
+                && $request['status'] === 'failed';
+        });
+    }
+
+    #[Test]
+    public function send_failure_notification_includes_bearer_token(): void
+    {
+        Http::fake(['*' => Http::response([])]);
+
+        $client = new ShieldCIClient;
+        $client->sendFailureNotification(['data' => 'test']);
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('Authorization', 'Bearer test-token')
+                && str_contains($request->url(), '/api/reports/failure');
+        });
+    }
+
+    #[Test]
+    public function send_failure_notification_returns_empty_array_on_null_json(): void
+    {
+        Http::fake([
+            'api.test.shieldci.com/*' => Http::response('', 204),
+        ]);
+
+        $client = new ShieldCIClient;
+        $result = $client->sendFailureNotification(['test' => true]);
+
+        $this->assertEquals([], $result);
+    }
 }

--- a/tests/Unit/ValueObjects/FailureNotificationTest.php
+++ b/tests/Unit/ValueObjects/FailureNotificationTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\ValueObjects;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\Attributes\Test;
+use ShieldCI\Enums\AnalysisFailureReason;
+use ShieldCI\Enums\TriggerSource;
+use ShieldCI\Tests\TestCase;
+use ShieldCI\ValueObjects\FailureNotification;
+
+class FailureNotificationTest extends TestCase
+{
+    #[Test]
+    public function it_constructs_with_all_parameters(): void
+    {
+        $occurredAt = new DateTimeImmutable('2026-02-28T14:30:00+00:00');
+
+        $notification = new FailureNotification(
+            projectId: 'proj-123',
+            laravelVersion: '11.40.0',
+            packageVersion: '1.2.0',
+            reason: AnalysisFailureReason::InvalidOptions,
+            errorMessage: 'Invalid analyzer ID',
+            triggeredBy: TriggerSource::Manual,
+            occurredAt: $occurredAt,
+            metadata: ['php_version' => '8.3.2'],
+        );
+
+        $this->assertSame('proj-123', $notification->projectId);
+        $this->assertSame('11.40.0', $notification->laravelVersion);
+        $this->assertSame('1.2.0', $notification->packageVersion);
+        $this->assertSame(AnalysisFailureReason::InvalidOptions, $notification->reason);
+        $this->assertSame('Invalid analyzer ID', $notification->errorMessage);
+        $this->assertSame(TriggerSource::Manual, $notification->triggeredBy);
+        $this->assertSame($occurredAt, $notification->occurredAt);
+        $this->assertSame(['php_version' => '8.3.2'], $notification->metadata);
+    }
+
+    #[Test]
+    public function it_defaults_metadata_to_empty_array(): void
+    {
+        $notification = new FailureNotification(
+            projectId: 'proj-123',
+            laravelVersion: '11.0.0',
+            packageVersion: '1.0.0',
+            reason: AnalysisFailureReason::NoAnalyzersRan,
+            errorMessage: 'No analyzers ran',
+            triggeredBy: TriggerSource::CiCd,
+            occurredAt: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $this->assertSame([], $notification->metadata);
+    }
+
+    #[Test]
+    public function to_array_produces_correct_structure(): void
+    {
+        $occurredAt = new DateTimeImmutable('2026-02-28T14:30:00+00:00');
+
+        $notification = new FailureNotification(
+            projectId: 'proj-456',
+            laravelVersion: '10.48.29',
+            packageVersion: '1.5.0',
+            reason: AnalysisFailureReason::AllCategoriesDisabled,
+            errorMessage: 'All categories disabled',
+            triggeredBy: TriggerSource::Scheduled,
+            occurredAt: $occurredAt,
+            metadata: ['os' => 'Linux', 'php_version' => '8.2.0'],
+        );
+
+        $array = $notification->toArray();
+
+        $this->assertSame('proj-456', $array['project_id']);
+        $this->assertSame('10.48.29', $array['laravel_version']);
+        $this->assertSame('1.5.0', $array['package_version']);
+        $this->assertSame('failed', $array['status']);
+        $this->assertSame('all_categories_disabled', $array['failure_reason']);
+        $this->assertSame('All analyzer categories are disabled', $array['failure_label']);
+        $this->assertSame('All categories disabled', $array['error_message']);
+        $this->assertSame('scheduled', $array['triggered_by']);
+        $this->assertSame($occurredAt->format('c'), $array['occurred_at']);
+        $this->assertSame(['os' => 'Linux', 'php_version' => '8.2.0'], $array['metadata']);
+    }
+
+    #[Test]
+    public function status_is_always_failed(): void
+    {
+        foreach (AnalysisFailureReason::cases() as $reason) {
+            $notification = new FailureNotification(
+                projectId: 'proj-test',
+                laravelVersion: '11.0.0',
+                packageVersion: '1.0.0',
+                reason: $reason,
+                errorMessage: 'test',
+                triggeredBy: TriggerSource::Manual,
+                occurredAt: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+            );
+
+            $this->assertSame('failed', $notification->toArray()['status'], "Status should be 'failed' for reason {$reason->value}");
+        }
+    }
+
+    #[Test]
+    public function occurred_at_is_iso_8601_format(): void
+    {
+        $occurredAt = new DateTimeImmutable('2026-01-15T09:45:30+03:00');
+
+        $notification = new FailureNotification(
+            projectId: 'proj-test',
+            laravelVersion: '11.0.0',
+            packageVersion: '1.0.0',
+            reason: AnalysisFailureReason::UncaughtException,
+            errorMessage: 'Something broke',
+            triggeredBy: TriggerSource::Manual,
+            occurredAt: $occurredAt,
+        );
+
+        $array = $notification->toArray();
+
+        // Verify it's a valid ISO 8601 datetime
+        $occurredAtValue = $array['occurred_at'];
+        $this->assertIsString($occurredAtValue);
+        $parsed = new DateTimeImmutable($occurredAtValue);
+        $this->assertSame('2026-01-15', $parsed->format('Y-m-d'));
+    }
+
+    #[Test]
+    public function failure_reason_matches_enum_value(): void
+    {
+        foreach (AnalysisFailureReason::cases() as $reason) {
+            $notification = new FailureNotification(
+                projectId: 'proj-test',
+                laravelVersion: '11.0.0',
+                packageVersion: '1.0.0',
+                reason: $reason,
+                errorMessage: 'test',
+                triggeredBy: TriggerSource::Manual,
+                occurredAt: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+            );
+
+            $array = $notification->toArray();
+            $this->assertSame($reason->value, $array['failure_reason']);
+            $this->assertSame($reason->label(), $array['failure_label']);
+        }
+    }
+
+    #[Test]
+    public function laravel_and_package_versions_are_top_level_fields(): void
+    {
+        $notification = new FailureNotification(
+            projectId: 'proj-test',
+            laravelVersion: '12.0.0',
+            packageVersion: '2.0.0',
+            reason: AnalysisFailureReason::InvalidOptions,
+            errorMessage: 'test',
+            triggeredBy: TriggerSource::Manual,
+            occurredAt: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $array = $notification->toArray();
+
+        // These must be top-level, not inside metadata
+        $this->assertArrayHasKey('laravel_version', $array);
+        $this->assertArrayHasKey('package_version', $array);
+        $this->assertSame('12.0.0', $array['laravel_version']);
+        $this->assertSame('2.0.0', $array['package_version']);
+        $this->assertArrayNotHasKey('laravel_version', $array['metadata']);
+        $this->assertArrayNotHasKey('package_version', $array['metadata']);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `AnalysisFailureReason` enum and `FailureNotification` value object to represent pre-report failures
- Extends `ClientInterface` / `ShieldCIClient` with `sendFailureNotification()` posting to `POST /api/reports/failure`
- Refactors `AnalyzeCommand::handle()` into a thin wrapper with `try-catch(\Throwable)` delegating to `executeAnalysis()`, notifying the platform on all 4 early-exit paths: `InvalidOptions`, `AllCategoriesDisabled`, `NoAnalyzersRan`, `UncaughtException`
- Aligns failure payload shape with success payload: `laravel_version` and `package_version` are top-level fields; `metadata` carries `php_version`, `environment`, `app_name`, `app_url`, `os`, and optional git context

## Failure paths covered

| Reason | Trigger |
|---|---|
| `invalid_options` | Unknown `--analyzer` or `--category` value |
| `all_categories_disabled` | Every category set to `enabled: false` in config |
| `no_analyzers_ran` | Analyzers registered but none produced results |
| `uncaught_exception` | Any `\Throwable` thrown during analysis |

## Payload shape (`/api/reports/failure`)

```json
{
  "project_id": "...",
  "laravel_version": "11.40.0",
  "package_version": "1.2.0",
  "status": "failed",
  "failure_reason": "invalid_options",
  "failure_label": "Invalid analyzer options",
  "error_message": "...",
  "triggered_by": "manual",
  "occurred_at": "2026-03-02T14:30:00+00:00",
  "metadata": {
    "php_version": "8.3.21",
    "environment": "production",
    "app_name": "My App",
    "app_url": "https://example.com",
    "os": "Darwin",
    "git_branch": "main",
    "git_commit": "abc1234"
  }
}
```

## Test plan

- [x] `AnalysisFailureReasonTest` — enum values, labels, all cases covered
- [x] `FailureNotificationTest` — construction, `toArray()` structure, `laravel_version`/`package_version` are top-level not in metadata
- [x] `ShieldCIClientTest` — `sendFailureNotification` posts to correct endpoint, includes bearer token, handles null JSON
- [x] `AnalyzeCommandTest` — notification sent for each failure reason, silently swallowed when API call throws, not sent when `send_to_api` disabled, metadata fields correct
- [x] 3713 tests pass, PHPStan Level 9: 0 errors