### PR TITLE
feat: auto-detect CI provider and git context from environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.2.0 - 2026-03-02
+
+### Added
+- `CiEnvironmentDetector` class that auto-detects the active CI provider and resolves git branch/commit without manual configuration
+- Supported providers: GitHub Actions, GitLab CI, CircleCI, Bitbucket, Azure DevOps, Jenkins, Travis CI
+- Priority chain for branch and commit resolution: CLI flags (`--git-branch`, `--git-commit`) → CI platform env vars → `git` shell fallback
+- `ci_provider` field in report metadata (`POST /api/reports`) and failure notification payloads (`POST /api/reports/failure`) — only present when a known CI system is detected
+
 ## v1.1.0 - 2026-03-02
 
 ### Added

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -825,6 +825,9 @@ class AnalyzeCommand extends Command
         if (isset($gitContext['commit']) && $gitContext['commit'] !== '') {
             $metadata['git_commit'] = $gitContext['commit'];
         }
+        if (isset($gitContext['ci_provider']) && $gitContext['ci_provider'] !== '') {
+            $metadata['ci_provider'] = $gitContext['ci_provider'];
+        }
 
         return $metadata;
     }
@@ -2013,24 +2016,43 @@ class AnalyzeCommand extends Command
     }
 
     /**
-     * Build git context array from CLI flags.
+     * Build git context array from CLI flags, CI env vars, or git shell commands.
+     *
+     * Priority: CLI flags → CI env vars → git shell fallback.
      *
      * @return array<string, string>
      */
     protected function buildGitContext(): array
     {
+        $detector = $this->makeCiDetector();
+        $provider = $detector->detectProvider();
+
         $context = [];
+        if ($provider !== null) {
+            $context['ci_provider'] = $provider;
+        }
 
         $branch = $this->option('git-branch');
+        if (! is_string($branch) || $branch === '') {
+            $branch = $detector->resolveBranch($provider);
+        }
         if (is_string($branch) && $branch !== '') {
             $context['branch'] = $branch;
         }
 
         $commit = $this->option('git-commit');
+        if (! is_string($commit) || $commit === '') {
+            $commit = $detector->resolveCommit($provider);
+        }
         if (is_string($commit) && $commit !== '') {
             $context['commit'] = $commit;
         }
 
         return $context;
+    }
+
+    protected function makeCiDetector(): \ShieldCI\Support\CiEnvironmentDetector
+    {
+        return app(\ShieldCI\Support\CiEnvironmentDetector::class);
     }
 }

--- a/src/Support/CiEnvironmentDetector.php
+++ b/src/Support/CiEnvironmentDetector.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Detects the CI provider and resolves git branch/commit from environment variables.
+ *
+ * Priority chain for branch and commit:
+ *   1. CI provider env vars (when running in a known CI system)
+ *   2. git shell command fallback (when running locally or in unknown CI)
+ */
+class CiEnvironmentDetector
+{
+    /**
+     * Ordered list of CI providers. First match wins.
+     *
+     * @var array<string, array{var: string, value: string|null}>
+     */
+    private const PROVIDERS = [
+        'github_actions' => ['var' => 'GITHUB_ACTIONS', 'value' => 'true'],
+        'gitlab_ci' => ['var' => 'GITLAB_CI', 'value' => 'true'],
+        'circleci' => ['var' => 'CIRCLECI', 'value' => 'true'],
+        'bitbucket' => ['var' => 'BITBUCKET_BUILD_NUMBER', 'value' => null],
+        'azure_devops' => ['var' => 'TF_BUILD', 'value' => 'True'],
+        'jenkins' => ['var' => 'JENKINS_URL', 'value' => null],
+        'travis_ci' => ['var' => 'TRAVIS', 'value' => 'true'],
+    ];
+
+    /**
+     * Branch env vars per provider. First non-empty wins within platform.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private const BRANCH_VARS = [
+        'github_actions' => ['GITHUB_HEAD_REF', 'GITHUB_REF_NAME'],
+        'gitlab_ci' => ['CI_COMMIT_BRANCH'],
+        'circleci' => ['CIRCLE_BRANCH'],
+        'bitbucket' => ['BITBUCKET_BRANCH'],
+        'azure_devops' => ['BUILD_SOURCEBRANCHNAME'],
+        'jenkins' => ['GIT_BRANCH'],
+        'travis_ci' => ['TRAVIS_BRANCH'],
+    ];
+
+    /**
+     * Commit env vars per provider (single var each).
+     *
+     * @var array<string, string>
+     */
+    private const COMMIT_VARS = [
+        'github_actions' => 'GITHUB_SHA',
+        'gitlab_ci' => 'CI_COMMIT_SHA',
+        'circleci' => 'CIRCLE_SHA1',
+        'bitbucket' => 'BITBUCKET_COMMIT',
+        'azure_devops' => 'BUILD_SOURCEVERSION',
+        'jenkins' => 'GIT_COMMIT',
+        'travis_ci' => 'TRAVIS_COMMIT',
+    ];
+
+    /**
+     * Detect the current CI provider.
+     *
+     * Returns null when running locally or in an unrecognised CI system.
+     */
+    public function detectProvider(): ?string
+    {
+        foreach (self::PROVIDERS as $key => $spec) {
+            $actual = getenv($spec['var']);
+
+            if ($spec['value'] === null) {
+                // Presence check: env var must be non-empty
+                if (is_string($actual) && $actual !== '') {
+                    return $key;
+                }
+            } else {
+                // Exact value match
+                if ($actual === $spec['value']) {
+                    return $key;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve the git branch.
+     *
+     * When a $provider is given, reads the provider-specific env var first.
+     * Falls back to `git rev-parse --abbrev-ref HEAD` when no env var resolves the value.
+     */
+    public function resolveBranch(?string $provider): ?string
+    {
+        if ($provider !== null && isset(self::BRANCH_VARS[$provider])) {
+            foreach (self::BRANCH_VARS[$provider] as $var) {
+                $value = getenv($var);
+                if (is_string($value) && $value !== '') {
+                    return $value;
+                }
+            }
+        }
+
+        return $this->runGitCommand(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], 'HEAD');
+    }
+
+    /**
+     * Resolve the git commit SHA.
+     *
+     * When a $provider is given, reads the provider-specific env var first.
+     * Falls back to `git rev-parse HEAD` when no env var resolves the value.
+     */
+    public function resolveCommit(?string $provider): ?string
+    {
+        if ($provider !== null && isset(self::COMMIT_VARS[$provider])) {
+            $value = getenv(self::COMMIT_VARS[$provider]);
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+
+        return $this->runGitCommand(['git', 'rev-parse', 'HEAD'], null);
+    }
+
+    /**
+     * Run a git command and return trimmed stdout, or null on failure.
+     *
+     * @param  array<int, string>  $command
+     */
+    private function runGitCommand(array $command, ?string $nullIfOutput): ?string
+    {
+        try {
+            $process = $this->getProcess($command);
+            $process->run();
+
+            if (! $process->isSuccessful()) {
+                return null;
+            }
+
+            $output = trim($process->getOutput());
+            if ($output === '' || $output === $nullIfOutput) {
+                return null;
+            }
+
+            return $output;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Get a new Symfony Process instance.
+     *
+     * Overridable in tests to inject mock git scripts.
+     *
+     * @param  array<int, string>  $command
+     */
+    protected function getProcess(array $command): Process
+    {
+        return (new Process($command))->setTimeout(2);
+    }
+}

--- a/src/Support/Reporter.php
+++ b/src/Support/Reporter.php
@@ -555,6 +555,10 @@ class Reporter implements ReporterInterface
             $metadata['git_commit'] = $gitContext['commit'];
         }
 
+        if (isset($gitContext['ci_provider']) && $gitContext['ci_provider'] !== '') {
+            $metadata['ci_provider'] = $gitContext['ci_provider'];
+        }
+
         return $metadata;
     }
 

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -2118,12 +2118,14 @@ PHP);
     public function json_output_excludes_git_fields_when_flags_not_provided(): void
     {
         $this->registerTestAnalyzers();
+        $this->bindNullCiDetector();
 
         \Illuminate\Support\Facades\Artisan::call('shield:analyze', ['--format' => 'json']);
         $output = \Illuminate\Support\Facades\Artisan::output();
 
         $this->assertStringNotContainsString('"git_branch"', $output);
         $this->assertStringNotContainsString('"git_commit"', $output);
+        $this->assertStringNotContainsString('"ci_provider"', $output);
     }
 
     #[Test]
@@ -3130,6 +3132,194 @@ PHP);
 
         \Illuminate\Support\Facades\Http::assertSent(function ($request) {
             return str_contains($request->url(), '/api/reports/failure');
+        });
+    }
+
+    // ─── CI Provider Detection Tests ──────────────────────────────────
+
+    #[Test]
+    public function it_includes_ci_provider_in_metadata_when_github_actions_detected(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_REF_NAME=main');
+        putenv('GITHUB_SHA=abc1234def5678');
+
+        try {
+            \Illuminate\Support\Facades\Artisan::call('shield:analyze', ['--format' => 'json']);
+            $output = \Illuminate\Support\Facades\Artisan::output();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_REF_NAME');
+            putenv('GITHUB_SHA');
+        }
+
+        $this->assertStringContainsString('"ci_provider": "github_actions"', $output);
+    }
+
+    #[Test]
+    public function it_does_not_include_ci_provider_when_no_ci_detected(): void
+    {
+        $this->registerTestAnalyzers();
+        $this->bindNullCiDetector();
+
+        \Illuminate\Support\Facades\Artisan::call('shield:analyze', ['--format' => 'json']);
+        $output = \Illuminate\Support\Facades\Artisan::output();
+
+        $this->assertStringNotContainsString('"ci_provider"', $output);
+    }
+
+    #[Test]
+    public function it_auto_detects_branch_from_github_head_ref(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_HEAD_REF=feature/auto-detect');
+        putenv('GITHUB_SHA=abc1234');
+
+        try {
+            \Illuminate\Support\Facades\Artisan::call('shield:analyze', ['--format' => 'json']);
+            $output = \Illuminate\Support\Facades\Artisan::output();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_HEAD_REF');
+            putenv('GITHUB_SHA');
+        }
+
+        $this->assertStringContainsString('"git_branch": "feature/auto-detect"', $output);
+    }
+
+    #[Test]
+    public function it_auto_detects_commit_from_github_sha(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_REF_NAME=main');
+        putenv('GITHUB_SHA=deadbeef12345678');
+
+        try {
+            \Illuminate\Support\Facades\Artisan::call('shield:analyze', ['--format' => 'json']);
+            $output = \Illuminate\Support\Facades\Artisan::output();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_REF_NAME');
+            putenv('GITHUB_SHA');
+        }
+
+        $this->assertStringContainsString('"git_commit": "deadbeef12345678"', $output);
+    }
+
+    #[Test]
+    public function it_prefers_cli_flag_over_ci_env_vars_for_branch(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_REF_NAME=main');
+        putenv('GITHUB_SHA=abc1234');
+
+        try {
+            \Illuminate\Support\Facades\Artisan::call('shield:analyze', [
+                '--format' => 'json',
+                '--git-branch' => 'cli-override-branch',
+            ]);
+            $output = \Illuminate\Support\Facades\Artisan::output();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_REF_NAME');
+            putenv('GITHUB_SHA');
+        }
+
+        $this->assertStringContainsString('"git_branch": "cli-override-branch"', $output);
+        $this->assertStringNotContainsString('"git_branch": "main"', $output);
+    }
+
+    #[Test]
+    public function it_prefers_cli_flag_over_ci_env_vars_for_commit(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_REF_NAME=main');
+        putenv('GITHUB_SHA=env-sha-000');
+
+        try {
+            \Illuminate\Support\Facades\Artisan::call('shield:analyze', [
+                '--format' => 'json',
+                '--git-commit' => 'cli-override-sha',
+            ]);
+            $output = \Illuminate\Support\Facades\Artisan::output();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_REF_NAME');
+            putenv('GITHUB_SHA');
+        }
+
+        $this->assertStringContainsString('"git_commit": "cli-override-sha"', $output);
+        $this->assertStringNotContainsString('"git_commit": "env-sha-000"', $output);
+    }
+
+    #[Test]
+    public function it_includes_ci_provider_in_failure_notification_metadata(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_REF_NAME=main');
+        putenv('GITHUB_SHA=abc1234');
+
+        \Illuminate\Support\Facades\Http::fake([
+            'api.test.shieldci.com/api/reports/failure' => \Illuminate\Support\Facades\Http::response(['success' => true]),
+        ]);
+
+        try {
+            $this->artisan('shield:analyze', [
+                '--analyzer' => 'non-existent-analyzer',
+                '--report' => true,
+            ])->assertFailed();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_REF_NAME');
+            putenv('GITHUB_SHA');
+        }
+
+        \Illuminate\Support\Facades\Http::assertSent(function ($request) {
+            $metadata = $request['metadata'] ?? [];
+
+            return str_contains($request->url(), '/api/reports/failure')
+                && ($metadata['ci_provider'] ?? '') === 'github_actions';
+        });
+    }
+
+    /**
+     * Bind a stub CiEnvironmentDetector that returns null for everything.
+     * Prevents the real detector from auto-detecting branch/commit from the
+     * package's own git repository during tests.
+     */
+    private function bindNullCiDetector(): void
+    {
+        /** @phpstan-ignore-next-line */
+        $this->app->bind(\ShieldCI\Support\CiEnvironmentDetector::class, function () {
+            return new class extends \ShieldCI\Support\CiEnvironmentDetector
+            {
+                public function detectProvider(): ?string
+                {
+                    return null;
+                }
+
+                public function resolveBranch(?string $provider): ?string
+                {
+                    return null;
+                }
+
+                public function resolveCommit(?string $provider): ?string
+                {
+                    return null;
+                }
+            };
         });
     }
 }

--- a/tests/Unit/Support/CiEnvironmentDetectorTest.php
+++ b/tests/Unit/Support/CiEnvironmentDetectorTest.php
@@ -1,0 +1,436 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ShieldCI\Support\CiEnvironmentDetector;
+use Symfony\Component\Process\Process;
+
+class CiEnvironmentDetectorTest extends TestCase
+{
+    /** @var array<string, string|false> */
+    private array $envBackup = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->envBackup = [];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envBackup as $var => $original) {
+            if ($original === false) {
+                putenv($var);
+            } else {
+                putenv("{$var}={$original}");
+            }
+        }
+        parent::tearDown();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function setEnv(string $var, string $value): void
+    {
+        $this->envBackup[$var] = getenv($var);
+        putenv("{$var}={$value}");
+    }
+
+    private function clearEnv(string $var): void
+    {
+        $this->envBackup[$var] = getenv($var);
+        putenv($var);
+    }
+
+    private function makeDetector(): CiEnvironmentDetector
+    {
+        return new CiEnvironmentDetector;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Provider detection
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_returns_null_when_no_ci_env_vars_set(): void
+    {
+        foreach (['GITHUB_ACTIONS', 'GITLAB_CI', 'CIRCLECI', 'BITBUCKET_BUILD_NUMBER',
+            'TF_BUILD', 'JENKINS_URL', 'TRAVIS'] as $var) {
+            $this->clearEnv($var);
+        }
+
+        $this->assertNull($this->makeDetector()->detectProvider());
+    }
+
+    #[Test]
+    public function it_detects_github_actions(): void
+    {
+        $this->setEnv('GITHUB_ACTIONS', 'true');
+        $this->assertEquals('github_actions', $this->makeDetector()->detectProvider());
+    }
+
+    #[Test]
+    public function it_detects_gitlab_ci(): void
+    {
+        $this->clearEnv('GITHUB_ACTIONS');
+        $this->setEnv('GITLAB_CI', 'true');
+        $this->assertEquals('gitlab_ci', $this->makeDetector()->detectProvider());
+    }
+
+    #[Test]
+    public function it_detects_circleci(): void
+    {
+        $this->clearEnv('GITHUB_ACTIONS');
+        $this->clearEnv('GITLAB_CI');
+        $this->setEnv('CIRCLECI', 'true');
+        $this->assertEquals('circleci', $this->makeDetector()->detectProvider());
+    }
+
+    #[Test]
+    public function it_detects_bitbucket(): void
+    {
+        $this->clearEnv('GITHUB_ACTIONS');
+        $this->clearEnv('GITLAB_CI');
+        $this->clearEnv('CIRCLECI');
+        $this->setEnv('BITBUCKET_BUILD_NUMBER', '42');
+        $this->assertEquals('bitbucket', $this->makeDetector()->detectProvider());
+    }
+
+    #[Test]
+    public function it_detects_azure_devops(): void
+    {
+        $this->clearEnv('GITHUB_ACTIONS');
+        $this->clearEnv('GITLAB_CI');
+        $this->clearEnv('CIRCLECI');
+        $this->clearEnv('BITBUCKET_BUILD_NUMBER');
+        $this->setEnv('TF_BUILD', 'True');
+        $this->assertEquals('azure_devops', $this->makeDetector()->detectProvider());
+    }
+
+    #[Test]
+    public function it_detects_jenkins(): void
+    {
+        $this->clearEnv('GITHUB_ACTIONS');
+        $this->clearEnv('GITLAB_CI');
+        $this->clearEnv('CIRCLECI');
+        $this->clearEnv('BITBUCKET_BUILD_NUMBER');
+        $this->clearEnv('TF_BUILD');
+        $this->setEnv('JENKINS_URL', 'http://jenkins.example.com/');
+        $this->assertEquals('jenkins', $this->makeDetector()->detectProvider());
+    }
+
+    #[Test]
+    public function it_detects_travis_ci(): void
+    {
+        $this->clearEnv('GITHUB_ACTIONS');
+        $this->clearEnv('GITLAB_CI');
+        $this->clearEnv('CIRCLECI');
+        $this->clearEnv('BITBUCKET_BUILD_NUMBER');
+        $this->clearEnv('TF_BUILD');
+        $this->clearEnv('JENKINS_URL');
+        $this->setEnv('TRAVIS', 'true');
+        $this->assertEquals('travis_ci', $this->makeDetector()->detectProvider());
+    }
+
+    #[Test]
+    public function it_does_not_detect_when_value_wrong(): void
+    {
+        $this->clearEnv('GITLAB_CI');
+        $this->clearEnv('CIRCLECI');
+        $this->clearEnv('BITBUCKET_BUILD_NUMBER');
+        $this->clearEnv('TF_BUILD');
+        $this->clearEnv('JENKINS_URL');
+        $this->clearEnv('TRAVIS');
+        $this->setEnv('GITHUB_ACTIONS', 'false');
+        $this->assertNull($this->makeDetector()->detectProvider());
+    }
+
+    #[Test]
+    public function it_does_not_detect_bitbucket_when_var_is_empty(): void
+    {
+        $this->clearEnv('GITHUB_ACTIONS');
+        $this->clearEnv('GITLAB_CI');
+        $this->clearEnv('CIRCLECI');
+        $this->clearEnv('TF_BUILD');
+        $this->clearEnv('JENKINS_URL');
+        $this->clearEnv('TRAVIS');
+        $this->setEnv('BITBUCKET_BUILD_NUMBER', '');
+        $this->assertNull($this->makeDetector()->detectProvider());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Branch resolution
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_reads_github_head_ref_first_for_branch(): void
+    {
+        $this->setEnv('GITHUB_HEAD_REF', 'feature/pr-branch');
+        $this->setEnv('GITHUB_REF_NAME', 'main');
+
+        $this->assertEquals('feature/pr-branch', $this->makeDetector()->resolveBranch('github_actions'));
+    }
+
+    #[Test]
+    public function it_falls_back_to_github_ref_name_when_head_ref_empty(): void
+    {
+        $this->setEnv('GITHUB_HEAD_REF', '');
+        $this->setEnv('GITHUB_REF_NAME', 'main');
+
+        $this->assertEquals('main', $this->makeDetector()->resolveBranch('github_actions'));
+    }
+
+    #[Test]
+    public function it_reads_branch_for_gitlab_ci(): void
+    {
+        $this->setEnv('CI_COMMIT_BRANCH', 'develop');
+        $this->assertEquals('develop', $this->makeDetector()->resolveBranch('gitlab_ci'));
+    }
+
+    #[Test]
+    public function it_reads_branch_for_circleci(): void
+    {
+        $this->setEnv('CIRCLE_BRANCH', 'release/1.0');
+        $this->assertEquals('release/1.0', $this->makeDetector()->resolveBranch('circleci'));
+    }
+
+    #[Test]
+    public function it_reads_branch_for_bitbucket(): void
+    {
+        $this->setEnv('BITBUCKET_BRANCH', 'hotfix/x');
+        $this->assertEquals('hotfix/x', $this->makeDetector()->resolveBranch('bitbucket'));
+    }
+
+    #[Test]
+    public function it_reads_branch_for_azure_devops(): void
+    {
+        $this->setEnv('BUILD_SOURCEBRANCHNAME', 'main');
+        $this->assertEquals('main', $this->makeDetector()->resolveBranch('azure_devops'));
+    }
+
+    #[Test]
+    public function it_reads_branch_for_jenkins(): void
+    {
+        $this->setEnv('GIT_BRANCH', 'origin/main');
+        $this->assertEquals('origin/main', $this->makeDetector()->resolveBranch('jenkins'));
+    }
+
+    #[Test]
+    public function it_reads_branch_for_travis_ci(): void
+    {
+        $this->setEnv('TRAVIS_BRANCH', 'master');
+        $this->assertEquals('master', $this->makeDetector()->resolveBranch('travis_ci'));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Commit resolution
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_reads_commit_for_github_actions(): void
+    {
+        $this->setEnv('GITHUB_SHA', 'abc1234def5678');
+        $this->assertEquals('abc1234def5678', $this->makeDetector()->resolveCommit('github_actions'));
+    }
+
+    #[Test]
+    public function it_reads_commit_for_gitlab_ci(): void
+    {
+        $this->setEnv('CI_COMMIT_SHA', 'deadbeef');
+        $this->assertEquals('deadbeef', $this->makeDetector()->resolveCommit('gitlab_ci'));
+    }
+
+    #[Test]
+    public function it_reads_commit_for_circleci(): void
+    {
+        $this->setEnv('CIRCLE_SHA1', 'cafebabe');
+        $this->assertEquals('cafebabe', $this->makeDetector()->resolveCommit('circleci'));
+    }
+
+    #[Test]
+    public function it_reads_commit_for_bitbucket(): void
+    {
+        $this->setEnv('BITBUCKET_COMMIT', 'badf00d');
+        $this->assertEquals('badf00d', $this->makeDetector()->resolveCommit('bitbucket'));
+    }
+
+    #[Test]
+    public function it_reads_commit_for_azure_devops(): void
+    {
+        $this->setEnv('BUILD_SOURCEVERSION', '1234567890abcdef');
+        $this->assertEquals('1234567890abcdef', $this->makeDetector()->resolveCommit('azure_devops'));
+    }
+
+    #[Test]
+    public function it_reads_commit_for_jenkins(): void
+    {
+        $this->setEnv('GIT_COMMIT', 'feedface');
+        $this->assertEquals('feedface', $this->makeDetector()->resolveCommit('jenkins'));
+    }
+
+    #[Test]
+    public function it_reads_commit_for_travis_ci(): void
+    {
+        $this->setEnv('TRAVIS_COMMIT', 'c0ffee');
+        $this->assertEquals('c0ffee', $this->makeDetector()->resolveCommit('travis_ci'));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Real process execution (exercises getProcess())
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_executes_real_git_process_without_throwing(): void
+    {
+        // Exercises the real getProcess() implementation path.
+        // In a git repository the call succeeds; outside one it returns null gracefully.
+        $detector = $this->makeDetector();
+        $branch = $detector->resolveBranch(null);
+        $commit = $detector->resolveCommit(null);
+
+        // Either value is acceptable — we only assert no exception was thrown
+        // and, if we are inside a git repo, the values are non-empty strings.
+        $this->assertTrue($branch === null || is_string($branch));
+        $this->assertTrue($commit === null || is_string($commit));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Git command fallback
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_falls_back_to_git_command_for_branch(): void
+    {
+        $this->clearEnv('GITHUB_HEAD_REF');
+        $this->clearEnv('GITHUB_REF_NAME');
+
+        $detector = $this->makeDetectorWithMockGit('main', 'abc1234');
+        $this->assertEquals('main', $detector->resolveBranch(null));
+    }
+
+    #[Test]
+    public function it_returns_null_for_detached_head_state(): void
+    {
+        $detector = $this->makeDetectorWithMockGit('HEAD', 'abc1234');
+        $this->assertNull($detector->resolveBranch(null));
+    }
+
+    #[Test]
+    public function it_returns_null_for_branch_when_git_fails(): void
+    {
+        $detector = $this->makeDetectorWithFailingGit();
+        $this->assertNull($detector->resolveBranch(null));
+    }
+
+    #[Test]
+    public function it_returns_null_for_branch_when_process_throws(): void
+    {
+        $detector = $this->makeDetectorWithThrowingProcess();
+        $this->assertNull($detector->resolveBranch(null));
+    }
+
+    #[Test]
+    public function it_falls_back_to_git_command_for_commit(): void
+    {
+        $this->clearEnv('GITHUB_SHA');
+
+        $detector = $this->makeDetectorWithMockGit('main', 'abc1234deadbeef');
+        $this->assertEquals('abc1234deadbeef', $detector->resolveCommit(null));
+    }
+
+    #[Test]
+    public function it_returns_null_for_commit_when_git_fails(): void
+    {
+        $detector = $this->makeDetectorWithFailingGit();
+        $this->assertNull($detector->resolveCommit(null));
+    }
+
+    #[Test]
+    public function it_returns_null_for_commit_when_process_throws(): void
+    {
+        $detector = $this->makeDetectorWithThrowingProcess();
+        $this->assertNull($detector->resolveCommit(null));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Mock git helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function makeDetectorWithMockGit(string $branch, string $commit): CiEnvironmentDetector
+    {
+        $scriptPath = $this->createMockGitScript($branch, $commit);
+
+        return new class($scriptPath) extends CiEnvironmentDetector
+        {
+            public function __construct(private string $scriptPath) {}
+
+            protected function getProcess(array $command): Process
+            {
+                // Map git subcommand to the mock script args
+                $arg = in_array('--abbrev-ref', $command) ? '--abbrev-ref' : '--sha';
+
+                return (new Process([$this->scriptPath, $arg]))->setTimeout(2);
+            }
+        };
+    }
+
+    private function makeDetectorWithThrowingProcess(): CiEnvironmentDetector
+    {
+        return new class extends CiEnvironmentDetector
+        {
+            protected function getProcess(array $command): Process
+            {
+                throw new \RuntimeException('Simulated process creation failure');
+            }
+        };
+    }
+
+    private function makeDetectorWithFailingGit(): CiEnvironmentDetector
+    {
+        $scriptPath = $this->createFailingGitScript();
+
+        return new class($scriptPath) extends CiEnvironmentDetector
+        {
+            public function __construct(private string $scriptPath) {}
+
+            protected function getProcess(array $command): Process
+            {
+                return (new Process([$this->scriptPath]))->setTimeout(2);
+            }
+        };
+    }
+
+    private function createMockGitScript(string $branch, string $commit): string
+    {
+        $path = sys_get_temp_dir().'/mock-git-'.uniqid();
+        $branch = escapeshellarg($branch);
+        $commit = escapeshellarg($commit);
+
+        file_put_contents($path, <<<BASH
+#!/bin/bash
+if [ "\$1" = "--abbrev-ref" ]; then
+    echo {$branch}
+else
+    echo {$commit}
+fi
+BASH);
+        chmod($path, 0755);
+
+        return $path;
+    }
+
+    private function createFailingGitScript(): string
+    {
+        $path = sys_get_temp_dir().'/mock-git-fail-'.uniqid();
+        file_put_contents($path, "#!/bin/bash\nexit 128\n");
+        chmod($path, 0755);
+
+        return $path;
+    }
+}

--- a/tests/Unit/Support/ReporterTest.php
+++ b/tests/Unit/Support/ReporterTest.php
@@ -1077,4 +1077,70 @@ class ReporterTest extends TestCase
 
         $this->assertEquals('production', $report->metadata['environment']);
     }
+
+    #[Test]
+    public function it_includes_ci_provider_in_metadata_when_provided(): void
+    {
+        $results = collect([
+            AnalysisResult::passed('analyzer-1', 'Passed'),
+        ]);
+
+        $report = $this->reporter->generate($results, TriggerSource::CiCd, [
+            'branch' => 'main',
+            'commit' => 'abc1234',
+            'ci_provider' => 'github_actions',
+        ]);
+
+        $this->assertEquals('github_actions', $report->metadata['ci_provider']);
+    }
+
+    #[Test]
+    public function it_excludes_ci_provider_from_metadata_when_not_in_context(): void
+    {
+        $results = collect([
+            AnalysisResult::passed('analyzer-1', 'Passed'),
+        ]);
+
+        $report = $this->reporter->generate($results, TriggerSource::Manual, [
+            'branch' => 'main',
+            'commit' => 'abc1234',
+        ]);
+
+        $this->assertArrayNotHasKey('ci_provider', $report->metadata);
+    }
+
+    #[Test]
+    public function ci_provider_appears_in_json_output(): void
+    {
+        $results = collect([
+            AnalysisResult::passed('analyzer-1', 'Passed'),
+        ]);
+
+        $report = $this->reporter->generate($results, TriggerSource::CiCd, [
+            'ci_provider' => 'gitlab_ci',
+        ]);
+
+        $json = $this->reporter->toJson($report);
+        $decoded = json_decode($json, true);
+
+        $this->assertEquals('gitlab_ci', $decoded['metadata']['ci_provider']);
+    }
+
+    #[Test]
+    public function ci_provider_appears_in_api_payload(): void
+    {
+        $results = collect([
+            AnalysisResult::passed('analyzer-1', 'Passed'),
+        ]);
+
+        $report = $this->reporter->generate($results, TriggerSource::CiCd, [
+            'branch' => 'develop',
+            'commit' => 'def5678',
+            'ci_provider' => 'circleci',
+        ]);
+
+        $payload = $this->reporter->toApi($report);
+
+        $this->assertEquals('circleci', $payload['metadata']['ci_provider']);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `CiEnvironmentDetector` class that detects the active CI provider and resolves git branch/commit via a priority chain: CLI flags → CI platform env vars → git shell fallback
- Supports GitHub Actions, GitLab CI, CircleCI, Bitbucket, Azure DevOps, Jenkins, and Travis CI
- Surfaces `ci_provider` in both report metadata (`POST /api/reports`) and failure notification payloads (`POST /api/reports/failure`)
- `CiEnvironmentDetector::getProcess()` is a protected seam for test injection, following the same pattern as `PHPStan::getProcess()`