### PR TITLE
feat: add pr_number, repository, base_branch to report metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.3.0 - 2026-03-02
+
+### Added
+- `CiEnvironmentDetector::resolvePrNumber()` — auto-detects the pull-request / merge-request number from CI env vars across all 7 supported providers; GitHub falls back from `GITHUB_REF_NUMBER` to parsing `refs/pull/N/` from `GITHUB_REF`
+- `CiEnvironmentDetector::resolveRepository()` — resolves `owner/repo` from CI env vars (GitHub, GitLab, CircleCI, Bitbucket, Travis CI; Azure DevOps and Jenkins are skipped — their vars don't reliably produce this format)
+- `CiEnvironmentDetector::resolveBaseBranch()` — resolves the PR target branch from CI env vars; absent on non-PR builds
+- `--git-pr-number`, `--git-repository`, `--git-base-branch` CLI flags on `shield:analyze` (CLI takes priority over auto-detected env vars, matching the `--git-branch` / `--git-commit` pattern)
+- `pr_number`, `repository`, `base_branch` fields in report metadata (`POST /api/reports`) and failure notification payloads (`POST /api/reports/failure`) — only present when on a PR build or when the corresponding CLI flag is set
+
 ## v1.2.0 - 2026-03-02
 
 ### Added

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -27,7 +27,10 @@ class AnalyzeCommand extends Command
                             {--report : Send report to ShieldCI platform}
                             {--triggered-by= : Override trigger source (manual|ci_cd|scheduled)}
                             {--git-branch= : Git branch name for report metadata}
-                            {--git-commit= : Git commit SHA for report metadata}';
+                            {--git-commit= : Git commit SHA for report metadata}
+                            {--git-pr-number= : Pull request number for report metadata}
+                            {--git-repository= : Repository owner/repo for report metadata}
+                            {--git-base-branch= : PR target branch for report metadata}';
 
     protected $description = 'Run ShieldCI security and code quality analysis';
 
@@ -827,6 +830,11 @@ class AnalyzeCommand extends Command
         }
         if (isset($gitContext['ci_provider']) && $gitContext['ci_provider'] !== '') {
             $metadata['ci_provider'] = $gitContext['ci_provider'];
+        }
+        foreach (['pr_number', 'repository', 'base_branch'] as $key) {
+            if (isset($gitContext[$key]) && $gitContext[$key] !== '') {
+                $metadata[$key] = $gitContext[$key];
+            }
         }
 
         return $metadata;
@@ -2046,6 +2054,31 @@ class AnalyzeCommand extends Command
         }
         if (is_string($commit) && $commit !== '') {
             $context['commit'] = $commit;
+        }
+
+        $prNumber = $this->option('git-pr-number');
+        if (! is_string($prNumber) || $prNumber === '') {
+            $resolved = $detector->resolvePrNumber($provider);
+            $prNumber = $resolved !== null ? (string) $resolved : null;
+        }
+        if (is_string($prNumber) && $prNumber !== '') {
+            $context['pr_number'] = $prNumber;
+        }
+
+        $repository = $this->option('git-repository');
+        if (! is_string($repository) || $repository === '') {
+            $repository = $detector->resolveRepository($provider);
+        }
+        if (is_string($repository) && $repository !== '') {
+            $context['repository'] = $repository;
+        }
+
+        $baseBranch = $this->option('git-base-branch');
+        if (! is_string($baseBranch) || $baseBranch === '') {
+            $baseBranch = $detector->resolveBaseBranch($provider);
+        }
+        if (is_string($baseBranch) && $baseBranch !== '') {
+            $context['base_branch'] = $baseBranch;
         }
 
         return $context;

--- a/src/Support/CiEnvironmentDetector.php
+++ b/src/Support/CiEnvironmentDetector.php
@@ -151,6 +151,144 @@ class CiEnvironmentDetector
     }
 
     /**
+     * Resolve the pull-request / merge-request number from CI env vars.
+     *
+     * Returns null when not on a PR build or when the env var is absent.
+     */
+    public function resolvePrNumber(?string $provider): ?int
+    {
+        return match ($provider) {
+            'github_actions' => $this->resolveNumericEnv('GITHUB_REF_NUMBER') ?? $this->parsePrFromGithubRef(),
+            'gitlab_ci' => $this->resolveNumericEnv('CI_MERGE_REQUEST_IID'),
+            'circleci' => $this->resolveNumericEnv('CIRCLE_PR_NUMBER'),
+            'bitbucket' => $this->resolveNumericEnv('BITBUCKET_PR_ID'),
+            'azure_devops' => $this->resolveNumericEnv('SYSTEM_PULLREQUEST_PULLREQUESTNUMBER'),
+            'jenkins' => $this->resolveNumericEnv('CHANGE_ID'),
+            'travis_ci' => $this->resolveTravisPrNumber(),
+            default => null,
+        };
+    }
+
+    /**
+     * Resolve the repository in owner/repo format from CI env vars.
+     *
+     * Returns null when the format is unavailable for the provider.
+     */
+    public function resolveRepository(?string $provider): ?string
+    {
+        return match ($provider) {
+            'github_actions' => $this->resolveNonEmptyEnv('GITHUB_REPOSITORY'),
+            'gitlab_ci' => $this->resolveNonEmptyEnv('CI_PROJECT_PATH'),
+            'circleci' => $this->resolveCircleCiRepository(),
+            'bitbucket' => $this->resolveNonEmptyEnv('BITBUCKET_REPO_FULL_NAME'),
+            'azure_devops' => null,
+            'jenkins' => null,
+            'travis_ci' => $this->resolveNonEmptyEnv('TRAVIS_REPO_SLUG'),
+            default => null,
+        };
+    }
+
+    /**
+     * Resolve the PR target (base) branch from CI env vars.
+     *
+     * Returns null on non-PR builds (the env var is typically absent or empty).
+     */
+    public function resolveBaseBranch(?string $provider): ?string
+    {
+        return match ($provider) {
+            'github_actions' => $this->resolveNonEmptyEnv('GITHUB_BASE_REF'),
+            'gitlab_ci' => $this->resolveNonEmptyEnv('CI_MERGE_REQUEST_TARGET_BRANCH_NAME'),
+            'circleci' => null,
+            'bitbucket' => $this->resolveNonEmptyEnv('BITBUCKET_PR_DESTINATION_BRANCH'),
+            'azure_devops' => $this->resolveNonEmptyEnv('SYSTEM_PULLREQUEST_TARGETBRANCH'),
+            'jenkins' => $this->resolveNonEmptyEnv('CHANGE_TARGET'),
+            'travis_ci' => $this->resolveTravisBaseBranch(),
+            default => null,
+        };
+    }
+
+    /**
+     * Read an env var and cast it to int if numeric, otherwise return null.
+     */
+    private function resolveNumericEnv(string $var): ?int
+    {
+        $value = getenv($var);
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        return is_numeric($value) ? (int) $value : null;
+    }
+
+    /**
+     * Read an env var and return its value if non-empty, otherwise null.
+     */
+    private function resolveNonEmptyEnv(string $var): ?string
+    {
+        $value = getenv($var);
+
+        return (is_string($value) && $value !== '') ? $value : null;
+    }
+
+    /**
+     * Parse the PR number from GITHUB_REF (e.g. refs/pull/42/merge).
+     */
+    private function parsePrFromGithubRef(): ?int
+    {
+        $ref = getenv('GITHUB_REF');
+        if (! is_string($ref) || $ref === '') {
+            return null;
+        }
+
+        if (preg_match('#^refs/pull/(\d+)/#', $ref, $matches)) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve PR number for Travis CI (TRAVIS_PULL_REQUEST is 'false' on non-PR builds).
+     */
+    private function resolveTravisPrNumber(): ?int
+    {
+        $value = getenv('TRAVIS_PULL_REQUEST');
+        if (! is_string($value) || $value === '' || $value === 'false') {
+            return null;
+        }
+
+        return is_numeric($value) ? (int) $value : null;
+    }
+
+    /**
+     * Resolve repository in owner/repo format for CircleCI.
+     */
+    private function resolveCircleCiRepository(): ?string
+    {
+        $username = getenv('CIRCLE_PROJECT_USERNAME');
+        $reponame = getenv('CIRCLE_PROJECT_REPONAME');
+
+        if (! is_string($username) || $username === '' || ! is_string($reponame) || $reponame === '') {
+            return null;
+        }
+
+        return $username.'/'.$reponame;
+    }
+
+    /**
+     * Resolve base branch for Travis CI (only available on PR builds).
+     */
+    private function resolveTravisBaseBranch(): ?string
+    {
+        $pr = getenv('TRAVIS_PULL_REQUEST');
+        if (! is_string($pr) || $pr === '' || $pr === 'false') {
+            return null;
+        }
+
+        return $this->resolveNonEmptyEnv('TRAVIS_BRANCH');
+    }
+
+    /**
      * Get a new Symfony Process instance.
      *
      * Overridable in tests to inject mock git scripts.

--- a/src/Support/Reporter.php
+++ b/src/Support/Reporter.php
@@ -558,6 +558,11 @@ class Reporter implements ReporterInterface
         if (isset($gitContext['ci_provider']) && $gitContext['ci_provider'] !== '') {
             $metadata['ci_provider'] = $gitContext['ci_provider'];
         }
+        foreach (['pr_number', 'repository', 'base_branch'] as $key) {
+            if (isset($gitContext[$key]) && $gitContext[$key] !== '') {
+                $metadata[$key] = $gitContext[$key];
+            }
+        }
 
         return $metadata;
     }

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -3319,7 +3319,174 @@ PHP);
                 {
                     return null;
                 }
+
+                public function resolvePrNumber(?string $provider): ?int
+                {
+                    return null;
+                }
+
+                public function resolveRepository(?string $provider): ?string
+                {
+                    return null;
+                }
+
+                public function resolveBaseBranch(?string $provider): ?string
+                {
+                    return null;
+                }
             };
+        });
+    }
+
+    // ─── PR metadata auto-detection tests ─────────────────────────────────
+
+    #[Test]
+    public function it_auto_detects_pr_number_from_github_ref_number(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_REF_NUMBER=42');
+        putenv('GITHUB_SHA=abc1234');
+        putenv('GITHUB_REF_NAME=main');
+
+        try {
+            \Illuminate\Support\Facades\Artisan::call('shield:analyze', ['--format' => 'json']);
+            $output = \Illuminate\Support\Facades\Artisan::output();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_REF_NUMBER');
+            putenv('GITHUB_SHA');
+            putenv('GITHUB_REF_NAME');
+        }
+
+        $this->assertStringContainsString('"pr_number": "42"', $output);
+    }
+
+    #[Test]
+    public function it_auto_detects_repository_from_github_repository(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_REPOSITORY=owner/repo');
+        putenv('GITHUB_SHA=abc1234');
+        putenv('GITHUB_REF_NAME=main');
+
+        try {
+            \Illuminate\Support\Facades\Artisan::call('shield:analyze', ['--format' => 'json']);
+            $output = \Illuminate\Support\Facades\Artisan::output();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_REPOSITORY');
+            putenv('GITHUB_SHA');
+            putenv('GITHUB_REF_NAME');
+        }
+
+        $this->assertStringContainsString('"repository": "owner/repo"', $output);
+    }
+
+    #[Test]
+    public function it_auto_detects_base_branch_from_github_base_ref(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_BASE_REF=main');
+        putenv('GITHUB_SHA=abc1234');
+        putenv('GITHUB_REF_NAME=feature/x');
+
+        try {
+            \Illuminate\Support\Facades\Artisan::call('shield:analyze', ['--format' => 'json']);
+            $output = \Illuminate\Support\Facades\Artisan::output();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_BASE_REF');
+            putenv('GITHUB_SHA');
+            putenv('GITHUB_REF_NAME');
+        }
+
+        $this->assertStringContainsString('"base_branch": "main"', $output);
+    }
+
+    #[Test]
+    public function it_prefers_cli_flags_over_ci_env_vars_for_pr_number(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_REF_NUMBER=1');
+        putenv('GITHUB_SHA=abc1234');
+        putenv('GITHUB_REF_NAME=main');
+
+        try {
+            \Illuminate\Support\Facades\Artisan::call('shield:analyze', [
+                '--format' => 'json',
+                '--git-pr-number' => '99',
+            ]);
+            $output = \Illuminate\Support\Facades\Artisan::output();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_REF_NUMBER');
+            putenv('GITHUB_SHA');
+            putenv('GITHUB_REF_NAME');
+        }
+
+        $this->assertStringContainsString('"pr_number": "99"', $output);
+        $this->assertStringNotContainsString('"pr_number": "1"', $output);
+    }
+
+    #[Test]
+    public function it_does_not_include_pr_fields_when_not_on_a_pr(): void
+    {
+        $this->registerTestAnalyzers();
+        $this->bindNullCiDetector();
+
+        \Illuminate\Support\Facades\Artisan::call('shield:analyze', ['--format' => 'json']);
+        $output = \Illuminate\Support\Facades\Artisan::output();
+
+        $this->assertStringNotContainsString('"pr_number"', $output);
+        $this->assertStringNotContainsString('"repository"', $output);
+        $this->assertStringNotContainsString('"base_branch"', $output);
+    }
+
+    #[Test]
+    public function it_includes_pr_fields_in_failure_notification_metadata(): void
+    {
+        $this->registerTestAnalyzers();
+
+        putenv('GITHUB_ACTIONS=true');
+        putenv('GITHUB_REF_NUMBER=42');
+        putenv('GITHUB_REPOSITORY=owner/repo');
+        putenv('GITHUB_BASE_REF=main');
+        putenv('GITHUB_SHA=abc1234');
+        putenv('GITHUB_REF_NAME=feature/x');
+
+        \Illuminate\Support\Facades\Http::fake([
+            'api.test.shieldci.com/api/reports/failure' => \Illuminate\Support\Facades\Http::response(['success' => true]),
+        ]);
+
+        try {
+            $this->artisan('shield:analyze', [
+                '--analyzer' => 'non-existent-analyzer',
+                '--report' => true,
+            ])->assertFailed();
+        } finally {
+            putenv('GITHUB_ACTIONS');
+            putenv('GITHUB_REF_NUMBER');
+            putenv('GITHUB_REPOSITORY');
+            putenv('GITHUB_BASE_REF');
+            putenv('GITHUB_SHA');
+            putenv('GITHUB_REF_NAME');
+        }
+
+        \Illuminate\Support\Facades\Http::assertSent(function ($request) {
+            $metadata = $request['metadata'] ?? [];
+
+            return str_contains($request->url(), '/api/reports/failure')
+                && ($metadata['pr_number'] ?? '') === '42'
+                && ($metadata['repository'] ?? '') === 'owner/repo'
+                && ($metadata['base_branch'] ?? '') === 'main';
         });
     }
 }

--- a/tests/Unit/Support/CiEnvironmentDetectorTest.php
+++ b/tests/Unit/Support/CiEnvironmentDetectorTest.php
@@ -433,4 +433,223 @@ BASH);
 
         return $path;
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // resolvePrNumber
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_reads_pr_number_from_github_ref_number(): void
+    {
+        $this->setEnv('GITHUB_REF_NUMBER', '42');
+        $this->assertEquals(42, $this->makeDetector()->resolvePrNumber('github_actions'));
+    }
+
+    #[Test]
+    public function it_parses_pr_number_from_github_ref_merge_event(): void
+    {
+        $this->clearEnv('GITHUB_REF_NUMBER');
+        $this->setEnv('GITHUB_REF', 'refs/pull/42/merge');
+        $this->assertEquals(42, $this->makeDetector()->resolvePrNumber('github_actions'));
+    }
+
+    #[Test]
+    public function it_parses_pr_number_from_github_ref_head_event(): void
+    {
+        $this->clearEnv('GITHUB_REF_NUMBER');
+        $this->setEnv('GITHUB_REF', 'refs/pull/42/head');
+        $this->assertEquals(42, $this->makeDetector()->resolvePrNumber('github_actions'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_pr_number_when_github_ref_is_push(): void
+    {
+        $this->clearEnv('GITHUB_REF_NUMBER');
+        $this->setEnv('GITHUB_REF', 'refs/heads/main');
+        $this->assertNull($this->makeDetector()->resolvePrNumber('github_actions'));
+    }
+
+    #[Test]
+    public function it_reads_pr_number_for_gitlab_ci(): void
+    {
+        $this->setEnv('CI_MERGE_REQUEST_IID', '7');
+        $this->assertEquals(7, $this->makeDetector()->resolvePrNumber('gitlab_ci'));
+    }
+
+    #[Test]
+    public function it_reads_pr_number_for_circleci(): void
+    {
+        $this->setEnv('CIRCLE_PR_NUMBER', '15');
+        $this->assertEquals(15, $this->makeDetector()->resolvePrNumber('circleci'));
+    }
+
+    #[Test]
+    public function it_reads_pr_number_for_bitbucket(): void
+    {
+        $this->setEnv('BITBUCKET_PR_ID', '8');
+        $this->assertEquals(8, $this->makeDetector()->resolvePrNumber('bitbucket'));
+    }
+
+    #[Test]
+    public function it_reads_pr_number_for_azure_devops(): void
+    {
+        $this->setEnv('SYSTEM_PULLREQUEST_PULLREQUESTNUMBER', '33');
+        $this->assertEquals(33, $this->makeDetector()->resolvePrNumber('azure_devops'));
+    }
+
+    #[Test]
+    public function it_reads_pr_number_for_jenkins(): void
+    {
+        $this->setEnv('CHANGE_ID', '21');
+        $this->assertEquals(21, $this->makeDetector()->resolvePrNumber('jenkins'));
+    }
+
+    #[Test]
+    public function it_reads_pr_number_for_travis_ci(): void
+    {
+        $this->setEnv('TRAVIS_PULL_REQUEST', '99');
+        $this->assertEquals(99, $this->makeDetector()->resolvePrNumber('travis_ci'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_travis_pr_number_when_not_a_pr(): void
+    {
+        $this->setEnv('TRAVIS_PULL_REQUEST', 'false');
+        $this->assertNull($this->makeDetector()->resolvePrNumber('travis_ci'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_pr_number_when_env_var_missing(): void
+    {
+        $this->clearEnv('CI_MERGE_REQUEST_IID');
+        $this->assertNull($this->makeDetector()->resolvePrNumber('gitlab_ci'));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // resolveRepository
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_reads_repository_for_github_actions(): void
+    {
+        $this->setEnv('GITHUB_REPOSITORY', 'owner/repo');
+        $this->assertEquals('owner/repo', $this->makeDetector()->resolveRepository('github_actions'));
+    }
+
+    #[Test]
+    public function it_reads_repository_for_gitlab_ci(): void
+    {
+        $this->setEnv('CI_PROJECT_PATH', 'group/project');
+        $this->assertEquals('group/project', $this->makeDetector()->resolveRepository('gitlab_ci'));
+    }
+
+    #[Test]
+    public function it_reads_repository_for_circleci(): void
+    {
+        $this->setEnv('CIRCLE_PROJECT_USERNAME', 'myorg');
+        $this->setEnv('CIRCLE_PROJECT_REPONAME', 'myrepo');
+        $this->assertEquals('myorg/myrepo', $this->makeDetector()->resolveRepository('circleci'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_circleci_repository_when_either_var_missing(): void
+    {
+        $this->setEnv('CIRCLE_PROJECT_USERNAME', 'myorg');
+        $this->clearEnv('CIRCLE_PROJECT_REPONAME');
+        $this->assertNull($this->makeDetector()->resolveRepository('circleci'));
+    }
+
+    #[Test]
+    public function it_reads_repository_for_bitbucket(): void
+    {
+        $this->setEnv('BITBUCKET_REPO_FULL_NAME', 'team/project');
+        $this->assertEquals('team/project', $this->makeDetector()->resolveRepository('bitbucket'));
+    }
+
+    #[Test]
+    public function it_reads_repository_for_travis_ci(): void
+    {
+        $this->setEnv('TRAVIS_REPO_SLUG', 'user/app');
+        $this->assertEquals('user/app', $this->makeDetector()->resolveRepository('travis_ci'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_azure_devops_repository(): void
+    {
+        $this->assertNull($this->makeDetector()->resolveRepository('azure_devops'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_jenkins_repository(): void
+    {
+        $this->assertNull($this->makeDetector()->resolveRepository('jenkins'));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // resolveBaseBranch
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_reads_base_branch_for_github_actions(): void
+    {
+        $this->setEnv('GITHUB_BASE_REF', 'main');
+        $this->assertEquals('main', $this->makeDetector()->resolveBaseBranch('github_actions'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_base_branch_when_github_base_ref_is_empty(): void
+    {
+        $this->setEnv('GITHUB_BASE_REF', '');
+        $this->assertNull($this->makeDetector()->resolveBaseBranch('github_actions'));
+    }
+
+    #[Test]
+    public function it_reads_base_branch_for_gitlab_ci(): void
+    {
+        $this->setEnv('CI_MERGE_REQUEST_TARGET_BRANCH_NAME', 'develop');
+        $this->assertEquals('develop', $this->makeDetector()->resolveBaseBranch('gitlab_ci'));
+    }
+
+    #[Test]
+    public function it_reads_base_branch_for_bitbucket(): void
+    {
+        $this->setEnv('BITBUCKET_PR_DESTINATION_BRANCH', 'main');
+        $this->assertEquals('main', $this->makeDetector()->resolveBaseBranch('bitbucket'));
+    }
+
+    #[Test]
+    public function it_reads_base_branch_for_azure_devops(): void
+    {
+        $this->setEnv('SYSTEM_PULLREQUEST_TARGETBRANCH', 'main');
+        $this->assertEquals('main', $this->makeDetector()->resolveBaseBranch('azure_devops'));
+    }
+
+    #[Test]
+    public function it_reads_base_branch_for_jenkins(): void
+    {
+        $this->setEnv('CHANGE_TARGET', 'master');
+        $this->assertEquals('master', $this->makeDetector()->resolveBaseBranch('jenkins'));
+    }
+
+    #[Test]
+    public function it_reads_base_branch_for_travis_ci(): void
+    {
+        $this->setEnv('TRAVIS_PULL_REQUEST', '42');
+        $this->setEnv('TRAVIS_BRANCH', 'main');
+        $this->assertEquals('main', $this->makeDetector()->resolveBaseBranch('travis_ci'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_travis_base_branch_when_not_a_pr(): void
+    {
+        $this->setEnv('TRAVIS_PULL_REQUEST', 'false');
+        $this->setEnv('TRAVIS_BRANCH', 'main');
+        $this->assertNull($this->makeDetector()->resolveBaseBranch('travis_ci'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_circleci_base_branch(): void
+    {
+        $this->assertNull($this->makeDetector()->resolveBaseBranch('circleci'));
+    }
 }

--- a/tests/Unit/Support/ReporterTest.php
+++ b/tests/Unit/Support/ReporterTest.php
@@ -1143,4 +1143,90 @@ class ReporterTest extends TestCase
 
         $this->assertEquals('circleci', $payload['metadata']['ci_provider']);
     }
+
+    // ─── PR metadata tests ────────────────────────────────────────────────
+
+    #[Test]
+    public function it_includes_pr_number_in_metadata_when_provided(): void
+    {
+        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+
+        $report = $this->reporter->generate($results, TriggerSource::Manual, [
+            'pr_number' => '42',
+        ]);
+
+        $this->assertEquals('42', $report->metadata['pr_number']);
+    }
+
+    #[Test]
+    public function it_includes_repository_in_metadata_when_provided(): void
+    {
+        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+
+        $report = $this->reporter->generate($results, TriggerSource::Manual, [
+            'repository' => 'owner/repo',
+        ]);
+
+        $this->assertEquals('owner/repo', $report->metadata['repository']);
+    }
+
+    #[Test]
+    public function it_includes_base_branch_in_metadata_when_provided(): void
+    {
+        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+
+        $report = $this->reporter->generate($results, TriggerSource::Manual, [
+            'base_branch' => 'main',
+        ]);
+
+        $this->assertEquals('main', $report->metadata['base_branch']);
+    }
+
+    #[Test]
+    public function it_excludes_pr_fields_from_metadata_when_not_in_context(): void
+    {
+        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+
+        $report = $this->reporter->generate($results, TriggerSource::Manual, []);
+
+        $this->assertArrayNotHasKey('pr_number', $report->metadata);
+        $this->assertArrayNotHasKey('repository', $report->metadata);
+        $this->assertArrayNotHasKey('base_branch', $report->metadata);
+    }
+
+    #[Test]
+    public function pr_fields_appear_in_json_output(): void
+    {
+        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+
+        $report = $this->reporter->generate($results, TriggerSource::Manual, [
+            'pr_number' => '7',
+            'repository' => 'org/proj',
+            'base_branch' => 'develop',
+        ]);
+
+        $decoded = json_decode($this->reporter->toJson($report), true);
+
+        $this->assertEquals('7', $decoded['metadata']['pr_number']);
+        $this->assertEquals('org/proj', $decoded['metadata']['repository']);
+        $this->assertEquals('develop', $decoded['metadata']['base_branch']);
+    }
+
+    #[Test]
+    public function pr_fields_appear_in_api_payload(): void
+    {
+        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+
+        $report = $this->reporter->generate($results, TriggerSource::CiCd, [
+            'pr_number' => '15',
+            'repository' => 'acme/app',
+            'base_branch' => 'main',
+        ]);
+
+        $payload = $this->reporter->toApi($report);
+
+        $this->assertEquals('15', $payload['metadata']['pr_number']);
+        $this->assertEquals('acme/app', $payload['metadata']['repository']);
+        $this->assertEquals('main', $payload['metadata']['base_branch']);
+    }
 }


### PR DESCRIPTION
## Summary

- **Auto-detect PR context from CI env vars** (`pr_number`, `repository`, `base_branch`) across all 7 supported CI providers (GitHub Actions, GitLab CI, CircleCI, Bitbucket, Azure DevOps, Jenkins, Travis CI)
- **Expose via CLI flags** (`--git-pr-number`, `--git-repository`, `--git-base-branch`) with the established CLI-takes-priority pattern
- **Include in both report payloads**: `POST /api/reports` (via `Reporter::buildMetadata()`) and `POST /api/reports/failure` (via `AnalyzeCommand::buildFailureMetadata()`)
- This unblocks the platform's `PostGitHubCheckJob`, which reads `pr_number` to post inline PR comments on GitHub

## Key implementation notes

- `CiEnvironmentDetector::resolvePrNumber()`: GitHub falls back from `GITHUB_REF_NUMBER` → regex on `GITHUB_REF` (`refs/pull/N/merge|head`); Travis CI guards against `TRAVIS_PULL_REQUEST=false` (string, not absent)
- `resolveRepository()`: Azure DevOps and Jenkins return `null` — their env vars don't reliably yield `owner/repo` format
- `resolveBaseBranch()`: CircleCI always `null` (no standard env var); Travis only returns a value when `TRAVIS_PULL_REQUEST != 'false'`