### PR TITLE
feat: add --ci flag to shield:analyze, remove ci_mode config key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.4.0 - 2026-03-03
+
+### Added
+- `--ci` flag on `shield:analyze` — activates CI mode directly from the command line without any environment variable or config file change
+
+### Changed
+- CI mode is now activated exclusively via `--ci` on `shield:analyze` (and the existing `--ci` on `shield:baseline`); the `SHIELDCI_CI_MODE` env var path is removed
+
+### Removed
+- `ci_mode` key from `config/shieldci.php` — the `SHIELDCI_CI_MODE` environment variable is no longer read; use `--ci` instead (`ci_mode_analyzers` and `ci_mode_exclude_analyzers` remain unchanged)
+
 ## v1.3.0 - 2026-03-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,16 +92,16 @@ php artisan shield:analyze --baseline
 #### CI Mode (Optimized for CI/CD)
 Skip slow or network-dependent analyzers in CI/CD:
 
-```php
-// config/shieldci.php
-'ci_mode' => env('SHIELDCI_CI_MODE', false),
-'ci_mode_analyzers' => ['sql-injection', 'xss-vulnerabilities', 'csrf-protection'],
-'ci_mode_exclude_analyzers' => ['vulnerable-dependencies', 'frontend-vulnerable-dependencies'],
+```bash
+# Run in CI mode (only CI-compatible analyzers)
+php artisan shield:analyze --ci
 ```
 
-```bash
-# Run in CI
-SHIELDCI_CI_MODE=true php artisan shield:analyze
+Whitelist/blacklist specific analyzers in `config/shieldci.php`:
+
+```php
+'ci_mode_analyzers' => ['sql-injection', 'xss-vulnerabilities', 'csrf-protection'],
+'ci_mode_exclude_analyzers' => ['vulnerable-dependencies', 'frontend-vulnerable-dependencies'],
 ```
 
 #### Don't Report (Exit Code Control)

--- a/config/shieldci.php
+++ b/config/shieldci.php
@@ -62,10 +62,9 @@ return [
     |--------------------------------------------------------------------------
     |
     | Configure ShieldCI behavior in CI/CD environments.
+    | Activate CI mode via the --ci flag: php artisan shield:analyze --ci
     |
     */
-
-    'ci_mode' => env('SHIELDCI_CI_MODE', false),
 
     'ci_mode_analyzers' => [
         // Whitelist: If specified, ONLY these analyzers run in CI mode

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -25,6 +25,7 @@ class AnalyzeCommand extends Command
                             {--output= : Save report to file}
                             {--baseline : Compare against baseline and only report new issues}
                             {--report : Send report to ShieldCI platform}
+                            {--ci : Run in CI mode (only CI-compatible analyzers)}
                             {--triggered-by= : Override trigger source (manual|ci_cd|scheduled)}
                             {--git-branch= : Git branch name for report metadata}
                             {--git-commit= : Git commit SHA for report metadata}
@@ -42,6 +43,11 @@ class AnalyzeCommand extends Command
         \ShieldCI\Contracts\ClientInterface $client,
     ): int {
         $this->suppressionParser = new InlineSuppressionParser;
+
+        // Activate CI mode for this run if --ci flag is passed
+        if ($this->option('ci')) {
+            config(['shieldci.ci_mode' => true]);
+        }
 
         // Resolve trigger source early (needed for failure notifications)
         $triggeredBy = $this->resolveTriggerSource();
@@ -2014,8 +2020,8 @@ class AnalyzeCommand extends Command
             }
         }
 
-        // 2. CI mode config implies ci_cd
-        if (config('shieldci.ci_mode')) {
+        // 2. --ci flag or CI mode config implies ci_cd
+        if ($this->option('ci') || config('shieldci.ci_mode')) {
             return \ShieldCI\Enums\TriggerSource::CiCd;
         }
 

--- a/src/Commands/BaselineCommand.php
+++ b/src/Commands/BaselineCommand.php
@@ -34,8 +34,7 @@ class BaselineCommand extends Command
      */
     public function handle(AnalyzerManager $manager, Config $config): int
     {
-        // If --ci flag is used, temporarily enable CI mode for baseline generation
-        $wasCiMode = $config->get('shieldci.ci_mode', false);
+        // If --ci flag is used, enable CI mode for baseline generation
         if ($this->option('ci')) {
             $config->set('shieldci.ci_mode', true);
             $this->info('🔍 Running analysis to generate baseline (CI mode)...');
@@ -44,13 +43,8 @@ class BaselineCommand extends Command
         }
         $this->newLine();
 
-        // Run all analyzers (respects CI mode from config or --ci flag)
+        // Run all analyzers (respects CI mode set above or via --ci flag)
         $results = $manager->runAll();
-
-        // Restore original CI mode setting
-        if ($this->option('ci')) {
-            $config->set('shieldci.ci_mode', $wasCiMode);
-        }
 
         // Get output path
         $outputPathRaw = $config->get('shieldci.baseline_file');

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -2007,8 +2007,6 @@ PHP);
     {
         $this->registerTestAnalyzers();
 
-        config(['shieldci.ci_mode' => false]);
-
         $this->artisan('shield:analyze', [
             '--format' => 'json',
         ])->assertSuccessful()
@@ -2016,26 +2014,24 @@ PHP);
     }
 
     #[Test]
-    public function ci_mode_config_sets_triggered_by_to_ci_cd(): void
+    public function ci_flag_sets_triggered_by_to_ci_cd(): void
     {
         $this->registerTestAnalyzers();
 
-        config(['shieldci.ci_mode' => true]);
-
         $this->artisan('shield:analyze', [
+            '--ci' => true,
             '--format' => 'json',
         ])->assertSuccessful()
             ->expectsOutputToContain('"triggered_by": "ci_cd"');
     }
 
     #[Test]
-    public function cli_flag_overrides_ci_mode_config(): void
+    public function triggered_by_flag_overrides_ci_flag(): void
     {
         $this->registerTestAnalyzers();
 
-        config(['shieldci.ci_mode' => true]);
-
         $this->artisan('shield:analyze', [
+            '--ci' => true,
             '--triggered-by' => 'scheduled',
             '--format' => 'json',
         ])->assertSuccessful()


### PR DESCRIPTION
## Summary

- Add `--ci` flag to `shield:analyze` as the canonical way to activate CI mode, replacing the `SHIELDCI_CI_MODE` env var / `ci_mode` config key
- `shield:baseline --ci` already existed and is unchanged in behaviour; its restore logic is simplified since there is no persistent config value to restore
- `AnalyzerManager` is unchanged — it still reads `config('shieldci.ci_mode')`, which commands set at runtime

## Changes

| File | Change |
|------|--------|
| `config/shieldci.php` | Removed `ci_mode` key; updated comment |
| `src/Commands/AnalyzeCommand.php` | Added `{--ci}` to signature; sets config at runtime; `resolveTriggerSource()` checks `--ci` flag |
| `src/Commands/BaselineCommand.php` | Removed `$wasCiMode` save/restore block |
| `tests/Unit/Commands/AnalyzeCommandTest.php` | Updated CI mode tests to use `--ci` flag |
| `README.md` / `CHANGELOG.md` | Updated for v1.4.0 |