### PR TITLE
feat: support comma-separated --category values and warn on --analyzer + --category conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.5.0 - 2026-03-05
+
+### Added
+- `--category` now accepts comma-separated values to run multiple categories in one pass (e.g. `--category=security,performance`)
+- `AnalyzerManager::getByCategories(array $categories)` — filters the registered analyzer pool to any number of categories at once
+- Warning emitted when both `--analyzer` and `--category` are provided simultaneously (`--category` is silently ignored in that case; the warning makes the precedence explicit)
+
+### Changed
+- `--category` help text updated to document comma-separated usage
+
 ## v1.4.0 - 2026-03-03
 
 ### Added

--- a/src/AnalyzerManager.php
+++ b/src/AnalyzerManager.php
@@ -153,6 +153,19 @@ class AnalyzerManager
     }
 
     /**
+     * Get analyzers by multiple categories.
+     *
+     * @param  array<string>  $categories
+     * @return Collection<int, AnalyzerInterface>
+     */
+    public function getByCategories(array $categories): Collection
+    {
+        return $this->getAnalyzers()
+            ->filter(fn (AnalyzerInterface $analyzer) => in_array($analyzer->getMetadata()->category->value, $categories, true)
+            );
+    }
+
+    /**
      * Run all analyzers.
      *
      * @return Collection<int, ResultInterface>

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -20,7 +20,7 @@ class AnalyzeCommand extends Command
 {
     protected $signature = 'shield:analyze
                             {--analyzer= : Run specific analyzer(s). Comma-separated for multiple (e.g., sql-injection,xss-detection)}
-                            {--category= : Run analyzers in category}
+                            {--category= : Run analyzers in category. Comma-separated for multiple (e.g., security,performance)}
                             {--format=console : Output format (console|json)}
                             {--output= : Save report to file}
                             {--baseline : Compare against baseline and only report new issues}
@@ -258,11 +258,14 @@ class AnalyzeCommand extends Command
             return $results;
         }
 
-        // Get analyzers (by category or all)
-        $normalizedCategory = null;
+        // Get analyzers (by category/categories or all)
+        $normalizedCategories = null;
         if ($category) {
-            $normalizedCategory = strtolower($category);
-            $analyzers = $manager->getByCategory($normalizedCategory);
+            $normalizedCategories = array_values(array_filter(
+                array_map(fn (string $c) => strtolower(trim($c)), explode(',', $category)),
+                fn (string $c) => $c !== ''
+            ));
+            $analyzers = $manager->getByCategories($normalizedCategories);
         } else {
             $analyzers = $manager->getAnalyzers();
         }
@@ -271,16 +274,16 @@ class AnalyzeCommand extends Command
 
         // Calculate skipped count
         $skippedCount = 0;
-        if ($normalizedCategory) {
+        if ($normalizedCategories) {
             $skippedCount = $manager->getSkippedAnalyzers()
-                ->filter(function (\ShieldCI\AnalyzersCore\Contracts\ResultInterface $result) use ($normalizedCategory): bool {
+                ->filter(function (\ShieldCI\AnalyzersCore\Contracts\ResultInterface $result) use ($normalizedCategories): bool {
                     $metadata = $result->getMetadata();
                     $resultCategory = $metadata['category'] ?? 'Unknown';
                     if (is_object($resultCategory) && isset($resultCategory->value)) {
                         $resultCategory = $resultCategory->value;
                     }
 
-                    return is_string($resultCategory) && strtolower($resultCategory) === $normalizedCategory;
+                    return is_string($resultCategory) && in_array(strtolower($resultCategory), $normalizedCategories, true);
                 })
                 ->count();
         } else {
@@ -379,16 +382,16 @@ class AnalyzeCommand extends Command
         }
 
         // Add skipped analyzers to results and stream them
-        if ($normalizedCategory) {
+        if ($normalizedCategories) {
             $skippedResults = $manager->getSkippedAnalyzers()
-                ->filter(function (\ShieldCI\AnalyzersCore\Contracts\ResultInterface $result) use ($normalizedCategory): bool {
+                ->filter(function (\ShieldCI\AnalyzersCore\Contracts\ResultInterface $result) use ($normalizedCategories): bool {
                     $metadata = $result->getMetadata();
                     $resultCategory = $metadata['category'] ?? 'Unknown';
                     if (is_object($resultCategory) && isset($resultCategory->value)) {
                         $resultCategory = $resultCategory->value;
                     }
 
-                    return is_string($resultCategory) && strtolower($resultCategory) === $normalizedCategory;
+                    return is_string($resultCategory) && in_array(strtolower($resultCategory), $normalizedCategories, true);
                 });
         } else {
             $skippedResults = $manager->getSkippedAnalyzers();
@@ -441,27 +444,31 @@ class AnalyzeCommand extends Command
 
         // Get category option (if specified)
         $category = $this->option('category');
-        $normalizedCategory = null;
+        $normalizedCategories = null;
 
         if ($category) {
-            $normalizedCategory = strtolower($category);
-            $categoryLabel = Category::from($normalizedCategory)->label();
+            $normalizedCategories = array_values(array_filter(
+                array_map(fn (string $c) => strtolower(trim($c)), explode(',', $category)),
+                fn (string $c) => $c !== ''
+            ));
+            $categoryLabels = array_map(fn (string $c) => Category::from($c)->label(), $normalizedCategories);
+            $categoryLabel = implode(', ', $categoryLabels);
 
-            $analyzers = $manager->getByCategory($normalizedCategory);
+            $analyzers = $manager->getByCategories($normalizedCategories);
             $enabledCount = $analyzers->count();
             // Get actual skipped count (may differ from calculated due to instantiation failures)
             $skippedCount = $manager->getSkippedAnalyzers()
-                ->filter(function (ResultInterface $result) use ($normalizedCategory): bool {
+                ->filter(function (ResultInterface $result) use ($normalizedCategories): bool {
                     $metadata = $result->getMetadata();
                     $resultCategory = $metadata['category'] ?? 'Unknown';
                     if (is_object($resultCategory) && isset($resultCategory->value)) {
                         $resultCategory = $resultCategory->value;
                     }
 
-                    return is_string($resultCategory) && strtolower($resultCategory) === $normalizedCategory;
+                    return is_string($resultCategory) && in_array(strtolower($resultCategory), $normalizedCategories, true);
                 })
                 ->count();
-            // Total count for this specific category (enabled + skipped)
+            // Total count for these categories (enabled + skipped)
             $totalCount = $enabledCount + $skippedCount;
 
             if ($skippedCount > 0) {
@@ -537,17 +544,17 @@ class AnalyzeCommand extends Command
         });
 
         // Add skipped analyzers
-        if ($normalizedCategory) {
-            // Add skipped analyzers for the specified category only
+        if ($normalizedCategories) {
+            // Add skipped analyzers for the specified categories only
             $skippedResults = $manager->getSkippedAnalyzers()
-                ->filter(function (ResultInterface $result) use ($normalizedCategory): bool {
+                ->filter(function (ResultInterface $result) use ($normalizedCategories): bool {
                     $metadata = $result->getMetadata();
                     $resultCategory = $metadata['category'] ?? 'Unknown';
                     if (is_object($resultCategory) && isset($resultCategory->value)) {
                         $resultCategory = $resultCategory->value;
                     }
 
-                    return is_string($resultCategory) && strtolower($resultCategory) === $normalizedCategory;
+                    return is_string($resultCategory) && in_array(strtolower($resultCategory), $normalizedCategories, true);
                 });
         } else {
             // Add all skipped analyzers when running all
@@ -1804,17 +1811,58 @@ class AnalyzeCommand extends Command
                 return false;
             }
 
+            // Parse comma-separated category IDs
+            $categoryIds = array_values(array_filter(
+                array_map('trim', explode(',', $category)),
+                fn (string $c) => $c !== ''
+            ));
+
+            if (empty($categoryIds)) {
+                $this->error('❌ No valid category provided.');
+
+                return false;
+            }
+
             // Get valid categories from Category enum
             $validCategories = array_map(
                 fn ($case) => $case->value,
                 \ShieldCI\AnalyzersCore\Enums\Category::cases()
             );
 
-            $normalizedCategory = strtolower($category);
-            $categoryExists = in_array($normalizedCategory, array_map('strtolower', $validCategories), true);
+            $analyzersConfig = config('shieldci.analyzers', []);
+            $analyzersConfig = is_array($analyzersConfig) ? $analyzersConfig : [];
 
-            if (! $categoryExists) {
-                $this->error("❌ Category '{$category}' is not valid.");
+            $invalidCategories = [];
+            $disabledCategories = [];
+            $emptyCategories = [];
+
+            foreach ($categoryIds as $cat) {
+                $normalized = strtolower($cat);
+                if (! in_array($normalized, array_map('strtolower', $validCategories), true)) {
+                    $invalidCategories[] = $cat;
+
+                    continue;
+                }
+
+                // Check if disabled in config
+                if (isset($analyzersConfig[$normalized])) {
+                    $cfg = $analyzersConfig[$normalized];
+                    if (is_array($cfg) && ($cfg['enabled'] ?? true) === false) {
+                        $disabledCategories[] = $cat;
+
+                        continue;
+                    }
+                }
+
+                // Check if any analyzers exist for this category
+                if ($manager->getByCategory($normalized)->isEmpty()) {
+                    $emptyCategories[] = $cat;
+                }
+            }
+
+            if (! empty($invalidCategories)) {
+                $invalidList = implode(', ', $invalidCategories);
+                $this->error("❌ Category '{$invalidList}' is not valid.");
                 $this->line('');
                 $this->line('Valid categories:');
                 foreach ($validCategories as $validCategory) {
@@ -1824,29 +1872,23 @@ class AnalyzeCommand extends Command
                 return false;
             }
 
-            // Check if category is enabled in config
-            $analyzersConfig = config('shieldci.analyzers', []);
-            $analyzersConfig = is_array($analyzersConfig) ? $analyzersConfig : [];
-
-            if (isset($analyzersConfig[$normalizedCategory])) {
-                $categoryConfig = $analyzersConfig[$normalizedCategory];
-                if (is_array($categoryConfig) && ($categoryConfig['enabled'] ?? true) === false) {
-                    $this->error("❌ Category '{$category}' is disabled in configuration.");
-                    $this->line('');
-                    $this->line("To enable it, set 'analyzers.{$normalizedCategory}.enabled' to true in config/shieldci.php");
-                    $envKey = 'SHIELDCI_'.strtoupper(str_replace('_', '_', $normalizedCategory)).'_ANALYZERS';
-                    $this->line("or set {$envKey}=true in your .env file.");
-
-                    return false;
-                }
-            }
-
-            // Check if category has any analyzers (after filtering by enabled categories)
-            $analyzersInCategory = $manager->getByCategory($normalizedCategory);
-            if ($analyzersInCategory->isEmpty()) {
-                $this->warn("⚠️  No analyzers found for category '{$category}'.");
+            if (! empty($disabledCategories)) {
+                $disabledList = implode(', ', $disabledCategories);
+                $this->error("❌ Category '{$disabledList}' is disabled in configuration.");
 
                 return false;
+            }
+
+            if (! empty($emptyCategories)) {
+                $emptyList = implode(', ', $emptyCategories);
+                $this->warn("⚠️  No analyzers found for category '{$emptyList}'.");
+
+                return false;
+            }
+
+            // Warn if both --analyzer and --category are provided (--category will be ignored)
+            if ($this->option('analyzer') !== null) {
+                $this->warn('⚠️  Both --analyzer and --category were provided. --category will be ignored.');
             }
         }
 

--- a/tests/Unit/AnalyzerManagerTest.php
+++ b/tests/Unit/AnalyzerManagerTest.php
@@ -67,6 +67,23 @@ class AnalyzerManagerTest extends TestCase
     }
 
     #[Test]
+    public function it_can_filter_by_multiple_categories(): void
+    {
+        $manager = $this->createManager([
+            TestAnalyzer::class,
+            AnotherTestAnalyzer::class,
+        ]);
+
+        $both = $manager->getByCategories(['security', 'performance']);
+        $securityOnly = $manager->getByCategories(['security']);
+        $none = $manager->getByCategories(['reliability']);
+
+        $this->assertCount(2, $both);
+        $this->assertCount(1, $securityOnly);
+        $this->assertCount(0, $none);
+    }
+
+    #[Test]
     public function it_can_run_all_analyzers(): void
     {
         $manager = $this->createManager([

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -98,6 +98,30 @@ class AnalyzeCommandTest extends TestCase
     }
 
     #[Test]
+    public function it_runs_multiple_categories_by_comma_separated_names(): void
+    {
+        $this->registerTestAnalyzers();
+
+        $this->artisan('shield:analyze', [
+            '--category' => 'security,performance',
+            '--format' => 'json',
+        ])->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_warns_when_both_analyzer_and_category_are_provided(): void
+    {
+        $this->registerTestAnalyzers();
+
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'test-security-analyzer',
+            '--category' => 'performance',
+            '--format' => 'json',
+        ])->assertSuccessful()
+            ->expectsOutputToContain('--category will be ignored');
+    }
+
+    #[Test]
     public function it_outputs_json_format(): void
     {
         $this->registerTestAnalyzers();
@@ -682,6 +706,29 @@ class AnalyzeCommandTest extends TestCase
 
         $this->artisan('shield:analyze', ['--format' => 'json'])
             ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_succeeds_on_low_severity_when_fail_on_medium(): void
+    {
+        // fail_on=medium does not trigger on low severity (hits the break at L985)
+        config(['shieldci.fail_on' => 'medium']);
+        $this->registerFailedAnalyzersWithSeverity(Severity::Low);
+
+        $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_warns_about_valid_category_with_no_registered_analyzers(): void
+    {
+        $this->registerTestAnalyzers();
+
+        // 'reliability' is a valid Category enum value but no analyzers are
+        // registered for it in registerTestAnalyzers(), so getByCategory returns empty.
+        $this->artisan('shield:analyze', ['--category' => 'reliability'])
+            ->assertFailed()
+            ->expectsOutputToContain('No analyzers found for category');
     }
 
     #[Test]
@@ -2422,6 +2469,26 @@ PHP);
                 ->andReturn(collect());
 
             /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getByCategories')
+                ->with(['security'])
+                ->andReturn(collect([$securityAnalyzer]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getByCategories')
+                ->with(['performance'])
+                ->andReturn(collect([$performanceAnalyzer]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getByCategories')
+                ->with(['security', 'performance'])
+                ->andReturn(collect([$securityAnalyzer, $performanceAnalyzer]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getByCategories')
+                ->with(Mockery::any())
+                ->andReturn(collect());
+
+            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
@@ -2553,6 +2620,16 @@ PHP);
 
             /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
+                ->with(Mockery::any())
+                ->andReturn(collect());
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getByCategories')
+                ->with(['security'])
+                ->andReturn(collect([$passedAnalyzer]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getByCategories')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 


### PR DESCRIPTION
## Summary

- `--category` now accepts comma-separated values (e.g. `--category=security,performance`), closing the gap between the docs and the implementation
- Emits a `⚠️` warning when both `--analyzer` and `--category` are provided so the silent precedence (`--analyzer` wins) is visible to the user
- Adds `AnalyzerManager::getByCategories(array $categories)` as the backing method; existing `getByCategory()` is unchanged (backward compatible)

## Changes

**`src/AnalyzerManager.php`**
- New `getByCategories(array<string> $categories): Collection` method — reuses the `getAnalyzers()` pipeline, changes the predicate from `===` to `in_array()`

**`src/Commands/AnalyzeCommand.php`**
- Signature: updated `--category` help text to document CSV usage
- `validateOptions()`: loops over each parsed category ID collecting invalid / disabled / empty buckets before reporting; emits conflict warning when `--analyzer` is also set
- `runAnalysisWithStreaming()` + `runAnalysis()`: replaced `$normalizedCategory` (single string) with `$normalizedCategories` (array); all filter predicates updated to `in_array()`; display label joins multiple labels with `, `

**`tests/Unit/AnalyzerManagerTest.php`**
- `it_can_filter_by_multiple_categories` — exercises `getByCategories()` directly

**`tests/Unit/Commands/AnalyzeCommandTest.php`**
- `it_runs_multiple_categories_by_comma_separated_names`
- `it_warns_when_both_analyzer_and_category_are_provided`
- `it_warns_about_valid_category_with_no_registered_analyzers`
- `it_succeeds_on_low_severity_when_fail_on_medium` (coverage for the `break` in the medium fail_on switch)
- `getByCategories` mocks added to `registerTestAnalyzers()` and `registerAnalyzersWithSkipped()`