### PR TITLE
fix: suppress AuthenticationAnalyzer false positives for auth-protected code paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## v1.5.1 - 2026-03-05
+## v1.5.1 - 2026-03-06
 
 ### Fixed
+- `AuthenticationAnalyzer` no longer false-positives on invokable controllers registered on plain `Route::get()` routes (e.g. `PrivacyController`, `LandingController`) — unauthenticated GET routes now mark the target method as intentionally public, consistent with named resource actions `index`/`show`; POST/PUT/PATCH/DELETE routes without auth middleware continue to be flagged
+- `AuthenticationAnalyzer` no longer false-positives on `FormRequest::authorize() => true` when the `FormRequest` is injected into an auth-gated controller action (route middleware, constructor middleware, or `middleware()` method) — only unprotected sensitive actions are flagged; orphaned `FormRequest` classes are also skipped
 - `AuthenticationAnalyzer` no longer false-positives on `Auth::user()->`, `auth()->user()->`, or `$request->user()->` calls inside controller methods that are verifiably protected by auth middleware — suppression uses the already-computed `routeAuthStats` and `publicControllerMethods` maps (route-level) or constructor / `middleware()` method inspection (controller-level)
 
 ## v1.5.0 - 2026-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.1 - 2026-03-05
+
+### Fixed
+- `AuthenticationAnalyzer` no longer false-positives on `Auth::user()->`, `auth()->user()->`, or `$request->user()->` calls inside controller methods that are verifiably protected by auth middleware — suppression uses the already-computed `routeAuthStats` and `publicControllerMethods` maps (route-level) or constructor / `middleware()` method inspection (controller-level)
+
 ## v1.5.0 - 2026-03-05
 
 ### Added

--- a/src/Analyzers/Security/AuthenticationAnalyzer.php
+++ b/src/Analyzers/Security/AuthenticationAnalyzer.php
@@ -552,6 +552,17 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
                 continue;
             }
 
+            // Extract namespace for FQCN construction
+            $namespaceNodes = $this->parser->findNodes($ast, Node\Stmt\Namespace_::class);
+            $namespace = '';
+            if (! empty($namespaceNodes) && $namespaceNodes[0] instanceof Node\Stmt\Namespace_
+                    && $namespaceNodes[0]->name !== null) {
+                $namespace = $namespaceNodes[0]->name->toString();
+            }
+
+            // Build FQCN from namespace + short name
+            $fqcn = $namespace !== '' ? "{$namespace}\\{$className}" : $className;
+
             // Find authorize() method
             $authorizeMethod = null;
             foreach ($class->stmts as $stmt) {
@@ -568,17 +579,21 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
 
             // Check if authorize() returns true without any checks
             if ($this->authorizesWithoutChecks($authorizeMethod)) {
-                $issues[] = $this->createIssueWithSnippet(
-                    message: "{$className}::authorize() returns true without authorization checks",
-                    filePath: $file,
-                    lineNumber: $authorizeMethod->getLine(),
-                    severity: Severity::High,
-                    recommendation: 'Add proper authorization logic to the authorize() method or remove it to deny by default',
-                    metadata: [
-                        'type' => 'form_request_authorization',
-                        'class' => $className,
-                    ]
-                );
+                // Only flag if actually used in a sensitive, unprotected action.
+                // Without usage context, authorize() => true is ambiguous.
+                if ($this->isFormRequestUsedInUnprotectedSensitiveAction($className, $fqcn)) {
+                    $issues[] = $this->createIssueWithSnippet(
+                        message: "{$className}::authorize() returns true without authorization checks",
+                        filePath: $file,
+                        lineNumber: $authorizeMethod->getLine(),
+                        severity: Severity::High,
+                        recommendation: 'Add authorization logic in authorize() (e.g., return $this->user()->can(\'delete\', $model)), add auth middleware to the route, or add $this->middleware(\'auth\') in the controller constructor.',
+                        metadata: [
+                            'type' => 'form_request_authorization',
+                            'class' => $className,
+                        ]
+                    );
+                }
             }
         }
     }
@@ -640,6 +655,139 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
         }
 
         return $files;
+    }
+
+    /**
+     * Find all controller methods that type-hint the given FormRequest.
+     *
+     * Resolves parameter type names through each file's use imports so that
+     * imported short names (e.g. "DeleteAccountRequest") correctly match the FQCN.
+     *
+     * @return array<array{controllerClass: string, namespace: string, methodName: string, classNode: Node\Stmt\Class_}>
+     */
+    private function findFormRequestUsagesInControllers(string $shortClassName, string $fqcn): array
+    {
+        $usages = [];
+
+        foreach ($this->getControllerFiles() as $file) {
+            $ast = $this->parser->parseFile($file);
+            if (empty($ast)) {
+                continue;
+            }
+
+            // Resolve use imports so short names expand to their FQCN
+            $fileLines = FileParser::getLines($file);
+            $useImports = $this->extractUseImports($fileLines);
+
+            // Extract namespace
+            $namespaceNodes = $this->parser->findNodes($ast, Node\Stmt\Namespace_::class);
+            $ns = '';
+            if (! empty($namespaceNodes) && $namespaceNodes[0] instanceof Node\Stmt\Namespace_
+                    && $namespaceNodes[0]->name !== null) {
+                $ns = $namespaceNodes[0]->name->toString();
+            }
+
+            foreach ($this->parser->findClasses($ast) as $class) {
+                $controllerClass = $class->name ? $class->name->toString() : 'Unknown';
+
+                foreach ($class->stmts as $stmt) {
+                    if (! ($stmt instanceof Node\Stmt\ClassMethod) || ! $stmt->isPublic()) {
+                        continue;
+                    }
+
+                    foreach ($stmt->getParams() as $param) {
+                        if ($param->type === null) {
+                            continue;
+                        }
+
+                        $typeName = $param->type instanceof Node\Name
+                            ? $param->type->toString()
+                            : '';
+
+                        if ($typeName === '') {
+                            continue;
+                        }
+
+                        // Resolve through use imports (covers the common "imported short name" case)
+                        $resolvedType = $useImports[$typeName] ?? $typeName;
+
+                        $matches = $resolvedType === $fqcn
+                            || $typeName === $shortClassName
+                            || str_ends_with($resolvedType, '\\'.$shortClassName);
+
+                        if ($matches) {
+                            $usages[] = [
+                                'controllerClass' => $controllerClass,
+                                'namespace' => $ns,
+                                'methodName' => $stmt->name->toString(),
+                                'classNode' => $class,
+                            ];
+                            break; // Found usage in this method; skip remaining params
+                        }
+                    }
+                }
+            }
+        }
+
+        return $usages;
+    }
+
+    /**
+     * Return true only when the FormRequest with authorize() => true is injected into
+     * a sensitive controller action that is not protected by any auth signal.
+     */
+    private function isFormRequestUsedInUnprotectedSensitiveAction(
+        string $shortClassName,
+        string $fqcn
+    ): bool {
+        $usages = $this->findFormRequestUsagesInControllers($shortClassName, $fqcn);
+
+        if (empty($usages)) {
+            return false; // No usage found — cannot determine risk
+        }
+
+        foreach ($usages as $usage) {
+            $method = $usage['methodName'];
+            $controllerClass = $usage['controllerClass'];
+            $ns = $usage['namespace'];
+            $classNode = $usage['classNode'];
+
+            // Only flag if method is sensitive
+            if (! in_array($method, $this->sensitiveControllerMethods, true)
+                    && $method !== '__invoke') {
+                continue;
+            }
+
+            // Build lookup keys (same pattern as checkController())
+            $shortKey = "{$controllerClass}::{$method}";
+            $fqcnKey = $ns !== '' ? "{$ns}\\{$controllerClass}::{$method}" : $shortKey;
+
+            // 1. Intentionally public via route analysis
+            //    (covers guest groups, GET routes, explicit ->withoutMiddleware(['auth']))
+            if (isset($this->publicControllerMethods[$fqcnKey])
+                    || isset($this->publicControllerMethods[$shortKey])) {
+                continue;
+            }
+
+            // 2. Route-level auth/authorization middleware
+            $stats = $this->routeAuthStats[$fqcnKey] ?? $this->routeAuthStats[$shortKey] ?? null;
+            if ($stats !== null && $stats['total'] > 0
+                    && $stats['authenticated'] === $stats['total']) {
+                continue;
+            }
+
+            // 3. Controller constructor or middleware() method protection
+            $constructorInfo = $this->getConstructorMiddlewareInfo($classNode);
+            $middlewareMethodInfo = $this->getMiddlewareMethodInfo($classNode);
+            if ($this->isControllerMethodAuthenticated($method, $constructorInfo, $middlewareMethodInfo)) {
+                continue;
+            }
+
+            // Sensitive + unprotected across all signals → real risk
+            return true;
+        }
+
+        return false; // All usages are either non-sensitive or already protected
     }
 
     /**

--- a/src/Analyzers/Security/AuthenticationAnalyzer.php
+++ b/src/Analyzers/Security/AuthenticationAnalyzer.php
@@ -246,9 +246,27 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
 
                 if ($isAuthenticated) {
                     $this->routeAuthStats[$method]['authenticated']++;
+                } elseif (preg_match('/Route::get\s*\(/i', $line)) {
+                    // Unauthenticated GET routes are read-only and treated as intentionally public,
+                    // consistent with `index`/`show` being absent from sensitiveControllerMethods.
+                    $this->publicControllerMethods[$method] = true;
                 }
             }
         }
+    }
+
+    /**
+     * Resolve a controller class name to its FQCN using use imports.
+     * Falls back to the input if no import is found.
+     */
+    private function resolveControllerFqcn(string $nameOrAlias): string
+    {
+        if (str_contains($nameOrAlias, '\\')) {
+            // Already qualified — just normalise leading backslash
+            return ltrim($nameOrAlias, '\\');
+        }
+
+        return $this->useImports[$nameOrAlias] ?? $nameOrAlias;
     }
 
     /**
@@ -276,37 +294,37 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
             }
         }
 
-        // Check if this is a resource or apiResource route
+        // Pattern 1 — resource routes
         if (preg_match('/Route::(resource|apiResource)\s*\(/i', $routeContent)) {
-            // Match: Route::resource('name', ControllerClass::class)
             if (preg_match('/Route::(?:resource|apiResource)\s*\([^,]+,\s*([A-Za-z_\\\\]+)::class/i', $routeContent, $matches)) {
-                $controller = $matches[1];
-
-                // Extract just the class name if it's fully qualified
-                $parts = explode('\\', $controller);
-                $className = end($parts);
-
-                // Return all resource methods
+                $fqcn = $this->resolveControllerFqcn($matches[1]);
                 $resourceMethods = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
-                $results = [];
-                foreach ($resourceMethods as $method) {
-                    $results[] = "{$className}::{$method}";
-                }
 
-                return $results;
+                return array_map(fn ($m) => "{$fqcn}::{$m}", $resourceMethods);
             }
         }
 
-        // Match [SomeController::class, 'method'] pattern for regular routes
-        if (preg_match('/\[([A-Za-z_\\\\]+)::class,\s*[\'"]([a-zA-Z_][a-zA-Z0-9_]*)[\'"]/', $routeContent, $matches)) {
-            $controller = $matches[1];
-            $method = $matches[2];
+        // Pattern 2 — array syntax [Controller::class, 'method']
+        if (preg_match('/\[([A-Za-z_\\\\]+)::class,\s*[\'"]([a-zA-Z_][a-zA-Z0-9_]*)["\']\]/', $routeContent, $matches)) {
+            $fqcn = $this->resolveControllerFqcn($matches[1]);
 
-            // Extract just the class name if it's fully qualified
-            $parts = explode('\\', $controller);
-            $className = end($parts);
+            return "{$fqcn}::{$matches[2]}";
+        }
 
-            return "{$className}::{$method}";
+        // Pattern 3 — invokable ::class syntax: Route::verb('uri', Controller::class)
+        // Anchored to Route::verb('...', ...) so it cannot match ->middleware(SomeClass::class)
+        if (preg_match('/Route::\w+\s*\(\s*[\'"][^\'"]*[\'"]\s*,\s*([A-Za-z_\\\\]+)::class\s*\)/', $routeContent, $matches)) {
+            $fqcn = $this->resolveControllerFqcn($matches[1]);
+
+            return "{$fqcn}::__invoke";
+        }
+
+        // Pattern 4 — legacy string syntax: Route::verb('uri', 'Controller') or 'Controller@method'
+        if (preg_match('/Route::\w+\s*\(\s*[\'"][^\'"]*[\'"]\s*,\s*[\'"]([A-Za-z_\\\\]+)(?:@([a-zA-Z_][a-zA-Z0-9_]*))?[\'"]\s*\)/', $routeContent, $matches)) {
+            $fqcn = $this->resolveControllerFqcn($matches[1]);
+            $method = isset($matches[2]) && $matches[2] !== '' ? $matches[2] : '__invoke';
+
+            return "{$fqcn}::{$method}";
         }
 
         return null;
@@ -341,7 +359,7 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
                         filePath: $file,
                         lineNumber: $lineNumber + 1,
                         severity: Severity::High,
-                        recommendation: 'Add auth middleware to this route group, or use Route::middleware("guest")->group() if routes are intentionally public. You can also add route URIs to the public_routes config option',
+                        recommendation: 'Add auth middleware to this route group: Route::middleware(["auth"])->group(). If these routes are intentionally public, add their URIs to the public_routes config option.',
                         metadata: ['route_type' => 'group', 'file' => basename($file)]
                     );
                 }
@@ -398,8 +416,8 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
                         lineNumber: $lineNumber + 1,
                         severity: Severity::High,
                         recommendation: $isClosure
-                            ? 'Add auth middleware: ->middleware("auth") or wrap in Route::middleware(["auth"])->group(). If intentionally public, use ->middleware("guest") or add the route URI to the public_routes config option. Consider moving closure logic to a controller.'
-                            : 'Protect this route with auth middleware or wrap in Route::middleware(["auth"])->group(). If intentionally public, use ->middleware("guest") or add the route URI to the public_routes config option',
+                            ? 'Add auth middleware: ->middleware("auth") or wrap in Route::middleware(["auth"])->group(). If intentionally public, add the route URI to the public_routes config option. Consider moving closure logic to a controller.'
+                            : 'Protect this route with auth middleware or wrap in Route::middleware(["auth"])->group(). If intentionally public, add the route URI to the public_routes config option.',
                         metadata: [
                             'type' => 'authentication',
                             'method' => $method,
@@ -445,6 +463,13 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
             return;
         }
 
+        // Extract namespace once per file for FQCN key construction
+        $namespaceNodes = $this->parser->findNodes($ast, Node\Stmt\Namespace_::class);
+        $namespace = '';
+        if (! empty($namespaceNodes) && $namespaceNodes[0] instanceof Node\Stmt\Namespace_ && $namespaceNodes[0]->name !== null) {
+            $namespace = $namespaceNodes[0]->name->toString();
+        }
+
         $classes = $this->parser->findClasses($ast);
 
         foreach ($classes as $class) {
@@ -473,17 +498,20 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
 
                     // Check sensitive methods (including invokable controllers)
                     if (in_array($methodName, $this->sensitiveControllerMethods) || $methodName === '__invoke') {
-                        // Skip if this controller method is intentionally public (from route analysis)
+                        // Build both short-name and FQCN keys for lookup
                         $controllerMethodKey = "{$className}::{$methodName}";
-                        if (isset($this->publicControllerMethods[$controllerMethodKey])) {
+                        $fqcnKey = $namespace !== '' ? "{$namespace}\\{$className}::{$methodName}" : $controllerMethodKey;
+
+                        // Skip if this controller method is intentionally public (check both key forms)
+                        if (isset($this->publicControllerMethods[$fqcnKey]) || isset($this->publicControllerMethods[$controllerMethodKey])) {
                             continue; // Method is intentionally public via route-level decision
                         }
 
                         // Check if method has controller-level auth middleware
                         $hasAuthMiddleware = $this->isControllerMethodAuthenticated($methodName, $constructorMiddlewareInfo, $middlewareMethodInfo);
 
-                        // Also consider method authenticated if protected at route level
-                        $stats = $this->routeAuthStats[$controllerMethodKey] ?? null;
+                        // Also consider method authenticated if protected at route level (check both key forms)
+                        $stats = $this->routeAuthStats[$fqcnKey] ?? $this->routeAuthStats[$controllerMethodKey] ?? null;
 
                         $isRouteProtected = $stats !== null && $stats['total'] > 0 && $stats['authenticated'] === $stats['total'];
 
@@ -493,7 +521,7 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
                                 filePath: $file,
                                 lineNumber: $stmt->getLine(),
                                 severity: Severity::High,
-                                recommendation: 'Add $this->middleware("auth") in constructor, protect all routes to this method with route-level auth middleware, or use ->middleware("guest") if intentionally public. You can also add route URIs to the public_routes config option'
+                                recommendation: 'Add $this->middleware("auth") in constructor, or protect all routes to this method with route-level auth middleware. If intentionally public, add route URIs to the public_routes config option.'
                             );
 
                             continue;

--- a/src/Analyzers/Security/AuthenticationAnalyzer.php
+++ b/src/Analyzers/Security/AuthenticationAnalyzer.php
@@ -1060,6 +1060,15 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
     {
         $lines = FileParser::getLines($file);
 
+        $ast = $this->parser->parseFile($file);
+
+        $namespaceNodes = $this->parser->findNodes($ast, Node\Stmt\Namespace_::class);
+        $namespace = '';
+        if (! empty($namespaceNodes) && $namespaceNodes[0] instanceof Node\Stmt\Namespace_
+                && $namespaceNodes[0]->name !== null) {
+            $namespace = $namespaceNodes[0]->name->toString();
+        }
+
         foreach ($lines as $lineNumber => $line) {
             // Check for Auth::user()-> (but NOT Auth::user()?-> which is safe)
             if (preg_match('/Auth::user\(\)\s*->/i', $line) && ! preg_match('/Auth::user\(\)\s*\?->/i', $line)) {
@@ -1069,7 +1078,9 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
                     lineNumber: $lineNumber,
                     method: 'Auth::user()',
                     checkMethod: 'Auth::check()',
-                    issues: $issues
+                    issues: $issues,
+                    ast: $ast,
+                    namespace: $namespace
                 );
             }
 
@@ -1081,7 +1092,9 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
                     lineNumber: $lineNumber,
                     method: 'auth()->user()',
                     checkMethod: 'auth()->check()',
-                    issues: $issues
+                    issues: $issues,
+                    ast: $ast,
+                    namespace: $namespace
                 );
             }
 
@@ -1093,7 +1106,9 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
                     lineNumber: $lineNumber,
                     method: '$request->user()',
                     checkMethod: '$request->user()',
-                    issues: $issues
+                    issues: $issues,
+                    ast: $ast,
+                    namespace: $namespace
                 );
             }
         }
@@ -1101,6 +1116,9 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if auth method is used with proper null safety.
+     *
+     * @param  array<int, string>  $lines
+     * @param  array<\PhpParser\Node>  $ast
      */
     private function checkAuthUsageWithNullSafety(
         string $file,
@@ -1108,7 +1126,9 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
         int $lineNumber,
         string $method,
         string $checkMethod,
-        array &$issues
+        array &$issues,
+        array $ast = [],
+        string $namespace = '',
     ): void {
         // Look for null checks in surrounding lines
         $searchRange = max(0, $lineNumber - 3);
@@ -1122,6 +1142,11 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
         }
 
         if (! $hasNullCheck) {
+            // Suppress when the enclosing method is guaranteed non-null by auth middleware
+            if (! empty($ast) && $this->isLineInAuthProtectedMethod($ast, $namespace, $lineNumber)) {
+                return;
+            }
+
             $issues[] = $this->createIssueWithSnippet(
                 message: "Unsafe {$method} usage without null check",
                 filePath: $file,
@@ -1135,6 +1160,78 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
                 ]
             );
         }
+    }
+
+    /**
+     * Return true when the method enclosing $lineNumber is guaranteed to receive
+     * only authenticated requests, making Auth::user() / $request->user() non-null.
+     *
+     * @param  array<\PhpParser\Node>  $ast
+     */
+    private function isLineInAuthProtectedMethod(array $ast, string $namespace, int $lineNumber): bool
+    {
+        $enclosing = $this->findEnclosingClassMethod($ast, $lineNumber);
+        if ($enclosing === null) {
+            return false;
+        }
+
+        $className = $enclosing['className'];
+        $methodName = $enclosing['methodName'];
+        $classNode = $enclosing['classNode'];
+
+        $shortKey = "{$className}::{$methodName}";
+        $fqcnKey = $namespace !== '' ? "{$namespace}\\{$className}::{$methodName}" : $shortKey;
+
+        // Intentionally public (guest route, unauthenticated GET) → do not suppress
+        if (isset($this->publicControllerMethods[$fqcnKey])
+                || isset($this->publicControllerMethods[$shortKey])) {
+            return false;
+        }
+
+        // Route-level: every known route to this method is authenticated
+        $stats = $this->routeAuthStats[$fqcnKey] ?? $this->routeAuthStats[$shortKey] ?? null;
+        if ($stats !== null && $stats['total'] > 0
+                && $stats['authenticated'] === $stats['total']) {
+            return true;
+        }
+
+        // Controller-level: constructor $this->middleware('auth') or middleware() method
+        $constructorInfo = $this->getConstructorMiddlewareInfo($classNode);
+        $middlewareMethodInfo = $this->getMiddlewareMethodInfo($classNode);
+
+        return $this->isControllerMethodAuthenticated($methodName, $constructorInfo, $middlewareMethodInfo);
+    }
+
+    /**
+     * Find the class and method that encloses the given (0-indexed) line number.
+     *
+     * @param  array<\PhpParser\Node>  $ast
+     * @return array{className: string, methodName: string, classNode: Node\Stmt\Class_}|null
+     */
+    private function findEnclosingClassMethod(array $ast, int $lineNumber): ?array
+    {
+        // FileParser lines are 0-indexed; AST line numbers are 1-indexed
+        $oneBased = $lineNumber + 1;
+
+        foreach ($this->parser->findClasses($ast) as $class) {
+            $className = $class->name ? $class->name->toString() : 'Unknown';
+
+            foreach ($class->stmts as $stmt) {
+                if (! ($stmt instanceof Node\Stmt\ClassMethod)) {
+                    continue;
+                }
+
+                if ($oneBased >= $stmt->getStartLine() && $oneBased <= $stmt->getEndLine()) {
+                    return [
+                        'className' => $className,
+                        'methodName' => $stmt->name->toString(),
+                        'classNode' => $class,
+                    ];
+                }
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
@@ -1786,6 +1786,133 @@ PHP;
         $this->assertPassed($result);
     }
 
+    public function test_invokable_controller_in_guest_group_not_flagged(): void
+    {
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\Auth\GoogleOneTapController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('guest')->group(function () {
+    Route::post('/auth/google/one-tap', GoogleOneTapController::class)
+        ->name('auth.google.one-tap')
+        ->middleware('throttle:10,1');
+});
+PHP;
+
+        $controller = <<<'PHP'
+<?php
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class GoogleOneTapController extends Controller
+{
+    public function __invoke(Request $request): RedirectResponse
+    {
+        return redirect()->route('dashboard');
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/auth.php' => $routes,
+            'app/Http/Controllers/Auth/GoogleOneTapController.php' => $controller,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']); // Required: ensures checkController() actually scans
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_public_get_invokable_controller_not_flagged(): void
+    {
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\Marketing\PrivacyController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/privacy', PrivacyController::class)->name('privacy');
+PHP;
+
+        $controller = <<<'PHP'
+<?php
+namespace App\Http\Controllers\Marketing;
+
+use App\Http\Controllers\Controller;
+use Inertia\Response;
+
+class PrivacyController extends Controller
+{
+    public function __invoke(): Response
+    {
+        return inertia('marketing/privacy');
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $routes,
+            'app/Http/Controllers/Marketing/PrivacyController.php' => $controller,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_post_invokable_controller_without_auth_flagged(): void
+    {
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\SubmitController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/submit', SubmitController::class);
+PHP;
+
+        $controller = <<<'PHP'
+<?php
+namespace App\Http\Controllers;
+
+class SubmitController extends Controller
+{
+    public function __invoke()
+    {
+        return response()->json(['ok' => true]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $routes,
+            'app/Http/Controllers/SubmitController.php' => $controller,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        // Route-level + controller-level checks both fire for an unprotected POST
+        $this->assertIssueCount(2, $result);
+    }
+
     // ==========================================
     // Auth::user() Safety Tests
     // ==========================================
@@ -2563,6 +2690,8 @@ PHP;
         $routes = <<<'PHP'
 <?php
 
+use App\Http\Controllers\WebhookController;
+
 Route::middleware('auth')->group(function () {
     Route::post('/webhook/callback', WebhookController::class);
 });
@@ -2590,6 +2719,7 @@ PHP;
 
         $analyzer = $this->createAnalyzer();
         $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']); // Ensures checkController() actually scans
 
         $result = $analyzer->analyze();
 

--- a/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
@@ -3003,10 +3003,27 @@ class UpdatePostRequest extends FormRequest
 }
 PHP;
 
+        $controller = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdatePostRequest;
+
+class PostController extends Controller
+{
+    public function update(UpdatePostRequest $request, $id)
+    {
+        // sensitive action — no auth middleware
+    }
+}
+PHP;
+
         $routes = '<?php';
 
         $tempDir = $this->createTempDirectory([
             'app/Http/Requests/UpdatePostRequest.php' => $formRequest,
+            'app/Http/Controllers/PostController.php' => $controller,
             'routes/web.php' => $routes,
         ]);
 
@@ -3016,7 +3033,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFalse($result->isSuccess());
+        $this->assertFailed($result);
         $this->assertHasIssueContaining('UpdatePostRequest::authorize() returns true without authorization checks', $result);
     }
 
@@ -3098,6 +3115,128 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should pass - has proper authorization logic
+        $this->assertPassed($result);
+    }
+
+    public function test_two_factor_challenge_request_not_flagged(): void
+    {
+        $formRequest = <<<'PHP'
+<?php
+namespace App\Http\Requests\Auth;
+use Illuminate\Foundation\Http\FormRequest;
+class TwoFactorChallengeRequest extends FormRequest
+{
+    public function authorize(): bool { return true; }
+    public function rules(): array
+    {
+        return ['code' => 'nullable|string', 'recovery_code' => 'nullable|string'];
+    }
+}
+PHP;
+
+        // No controller — FormRequest is orphaned, cannot determine risk
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => '<?php',
+            'app/Http/Requests/Auth/TwoFactorChallengeRequest.php' => $formRequest,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $result = $analyzer->analyze();
+        $this->assertPassed($result);
+    }
+
+    public function test_form_request_authorize_true_in_unprotected_store_flagged(): void
+    {
+        $routes = <<<'PHP'
+<?php
+use App\Http\Controllers\AccountController;
+use Illuminate\Support\Facades\Route;
+Route::post('/account/delete', [AccountController::class, 'store']);
+PHP;
+
+        $controller = <<<'PHP'
+<?php
+namespace App\Http\Controllers;
+use App\Http\Requests\DeleteAccountRequest;
+class AccountController extends Controller
+{
+    public function store(DeleteAccountRequest $request)
+    {
+        // sensitive action
+    }
+}
+PHP;
+
+        $formRequest = <<<'PHP'
+<?php
+namespace App\Http\Requests;
+use Illuminate\Foundation\Http\FormRequest;
+class DeleteAccountRequest extends FormRequest
+{
+    public function authorize(): bool { return true; }
+    public function rules(): array { return []; }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $routes,
+            'app/Http/Controllers/AccountController.php' => $controller,
+            'app/Http/Requests/DeleteAccountRequest.php' => $formRequest,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+        $result = $analyzer->analyze();
+        $this->assertFailed($result);
+    }
+
+    public function test_form_request_authorize_true_in_auth_protected_route_not_flagged(): void
+    {
+        $routes = <<<'PHP'
+<?php
+use App\Http\Controllers\AccountController;
+use Illuminate\Support\Facades\Route;
+Route::middleware('auth')->group(function () {
+    Route::post('/account/delete', [AccountController::class, 'store']);
+});
+PHP;
+
+        $controller = <<<'PHP'
+<?php
+namespace App\Http\Controllers;
+use App\Http\Requests\DeleteAccountRequest;
+class AccountController extends Controller
+{
+    public function store(DeleteAccountRequest $request)
+    {
+        // sensitive action — but route is auth-protected
+    }
+}
+PHP;
+
+        $formRequest = <<<'PHP'
+<?php
+namespace App\Http\Requests;
+use Illuminate\Foundation\Http\FormRequest;
+class DeleteAccountRequest extends FormRequest
+{
+    public function authorize(): bool { return true; }
+    public function rules(): array { return []; }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $routes,
+            'app/Http/Controllers/AccountController.php' => $controller,
+            'app/Http/Requests/DeleteAccountRequest.php' => $formRequest,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+        $result = $analyzer->analyze();
         $this->assertPassed($result);
     }
 

--- a/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
@@ -3928,4 +3928,107 @@ PHP;
         $this->assertFailed($result);
         $this->assertHasIssueContaining('POST route without authentication middleware', $result);
     }
+
+    // ==========================================
+    // Auth Usage — Middleware-Protected Suppression
+    // ==========================================
+
+    public function test_request_user_not_flagged_in_auth_middleware_route(): void
+    {
+        $routes = <<<'PHP'
+<?php
+use App\Http\Controllers\Auth\EmailVerificationPromptController;
+use Illuminate\Support\Facades\Route;
+Route::middleware('auth')->group(function () {
+    Route::get('verify-email', EmailVerificationPromptController::class)
+        ->name('verification.notice');
+});
+PHP;
+
+        $controller = <<<'PHP'
+<?php
+namespace App\Http\Controllers\Auth;
+use Illuminate\Http\Request;
+class EmailVerificationPromptController
+{
+    public function __invoke(Request $request)
+    {
+        return $request->user()->hasVerifiedEmail()
+            ? redirect('/dashboard')
+            : view('auth.verify-email');
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/auth.php' => $routes,
+            'app/Http/Controllers/Auth/EmailVerificationPromptController.php' => $controller,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+        $result = $analyzer->analyze();
+        $this->assertPassed($result);
+    }
+
+    public function test_auth_user_not_flagged_in_constructor_auth_controller(): void
+    {
+        $controller = <<<'PHP'
+<?php
+namespace App\Http\Controllers;
+use Illuminate\Support\Facades\Auth;
+class ProfileController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+    public function show()
+    {
+        $name = Auth::user()->name;
+        return view('profile', compact('name'));
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => '<?php',
+            'app/Http/Controllers/ProfileController.php' => $controller,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+        $result = $analyzer->analyze();
+        $this->assertPassed($result);
+    }
+
+    public function test_request_user_still_flagged_when_unprotected(): void
+    {
+        $controller = <<<'PHP'
+<?php
+namespace App\Http\Controllers;
+use Illuminate\Http\Request;
+class GuestController extends Controller
+{
+    public function show(Request $request)
+    {
+        return $request->user()->name;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => '<?php',
+            'app/Http/Controllers/GuestController.php' => $controller,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+        $result = $analyzer->analyze();
+        $this->assertFalse($result->isSuccess());
+        $this->assertHasIssueContaining('$request->user()', $result);
+    }
 }


### PR DESCRIPTION
## Problem

Three related false-positive patterns in `AuthenticationAnalyzer`:

1. **Invokable controllers on public GET routes** — controllers routed via a top-level `Route::get()` were flagged as missing authentication. These are intentionally public, read-only pages.

2. **`FormRequest::authorize() => true` in protected actions** — a `FormRequest` returning `true` from `authorize()` was flagged even when the action it is injected into is already guarded by auth middleware at the route or controller level.

3. **`Auth::user()->` / `\$request->user()->` in auth-protected methods** — direct property/method access on the user object was flagged as missing a null check, even when the enclosing controller method is guaranteed to receive only authenticated requests.

## Fix

### 1. GET invokable controllers
In `buildPublicControllerMap()`, an `elseif` branch marks the resolved controller method as intentionally public when the route is a plain `Route::get()` with no auth middleware:

```php
} elseif (preg_match('/Route::get\s*\(/i', $line)) {
    $this->publicControllerMethods[$method] = true;
}
```

Consistent with `index`/`show` being absent from `sensitiveControllerMethods`. GET routes inside an auth group take the `if ($isAuthenticated)` branch and are never affected.

### 2. FormRequest context-awareness
`checkFormRequestAuthorize()` now resolves which controller action injects the `FormRequest` and checks whether that action is auth-gated (route middleware, constructor middleware, or `middleware()` method) before flagging.

### 3. Auth::user() suppression
`checkAuthUsageWithNullSafety()` gains a suppression gate: before creating an issue it calls `isLineInAuthProtectedMethod()`, which uses the already-computed `routeAuthStats` / `publicControllerMethods` maps (route-level) or `getConstructorMiddlewareInfo()` / `getMiddlewareMethodInfo()` (controller-level) to determine whether the enclosing method is auth-protected.