### PR TITLE
fix: suppress false positives for routes registered via withRouting(then: ...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.5.3 - 2026-03-07
+
+### Fixed
+- `CsrfAnalyzer` no longer false-positives on route files registered with `web` middleware externally via `withRouting(then: ...)` in `bootstrap/app.php` (e.g. `Route::middleware('web')->group(base_path('routes/auth.php'))`) — these files inherit CSRF protection from the middleware group and are now correctly skipped
+- `LoginThrottlingAnalyzer` no longer false-positives on login routes in the same externally-registered route files — throttle applied globally to the `web` group is now respected
+
+### Added
+- `BootstrapRouteParser` support class (`ShieldCI\Support`) — AST-based utility that detects route files covered by the `web` middleware group through external registration; checks both `require`/`include` statements in `routes/web.php` and `Route::middleware('web')->...->group(base_path(...))` chains in `bootstrap/app.php`; used by `CsrfAnalyzer` and `LoginThrottlingAnalyzer`
+
 ## v1.5.2 - 2026-03-06
 
 ### Fixed

--- a/src/Analyzers/Security/CsrfAnalyzer.php
+++ b/src/Analyzers/Security/CsrfAnalyzer.php
@@ -8,8 +8,10 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Support\BootstrapRouteParser;
 
 /**
  * Detects missing CSRF protection vulnerabilities.
@@ -88,10 +90,15 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
         // Check VerifyCsrfToken middleware registration
         $this->checkCsrfMiddlewareRegistration($issues);
 
+        // Compute route files covered by 'web' middleware via external registration
+        // (require from web.php, or Route::middleware('web')->group() in bootstrap/app.php)
+        $webProtectedFiles = (new BootstrapRouteParser($this->getBasePath(), new AstParser))
+            ->getWebProtectedRouteFiles();
+
         // Check route files for routes that should have CSRF protection
         $routeFiles = $this->getRouteFiles();
         foreach ($routeFiles as $file) {
-            $this->checkRoutesForCsrfMiddleware($file, $issues);
+            $this->checkRoutesForCsrfMiddleware($file, $issues, $webProtectedFiles);
         }
 
         $summary = empty($issues)
@@ -790,8 +797,10 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
      * - 'auth' middleware (doesn't include CSRF)
      * - Just ->middleware( without 'web'
      * - Assumed middleware from elsewhere
+     *
+     * @param  array<string>  $webProtectedFiles  Files covered by 'web' middleware via external registration
      */
-    private function checkRoutesForCsrfMiddleware(string $file, array &$issues): void
+    private function checkRoutesForCsrfMiddleware(string $file, array &$issues, array $webProtectedFiles = []): void
     {
         $content = FileParser::readFile($file);
         if ($content === null) {
@@ -808,6 +817,11 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
         // Skip web.php - routes in web.php automatically get 'web' middleware applied globally
         // via RouteServiceProvider (Laravel 10) or bootstrap/app.php (Laravel 11+)
         if (str_ends_with($normalizedPath, '/routes/web.php')) {
+            return;
+        }
+
+        // Skip files registered with 'web' middleware externally (e.g. withRouting(then: ...))
+        if (in_array($normalizedPath, $webProtectedFiles, true)) {
             return;
         }
 

--- a/src/Analyzers/Security/LoginThrottlingAnalyzer.php
+++ b/src/Analyzers/Security/LoginThrottlingAnalyzer.php
@@ -12,6 +12,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Support\BootstrapRouteParser;
 
 /**
  * Detects missing login throttling/rate limiting.
@@ -616,6 +617,11 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
             return;
         }
 
+        // Compute route files covered by 'web' middleware via external registration
+        // (require from web.php, or Route::middleware('web')->group() in bootstrap/app.php)
+        $webProtectedFiles = (new BootstrapRouteParser($this->getBasePath(), $this->parser))
+            ->getWebProtectedRouteFiles();
+
         try {
             foreach (new \DirectoryIterator($routePath) as $file) {
                 if (! $file->isFile() || $file->getExtension() !== 'php') {
@@ -623,6 +629,13 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
                 }
 
                 $filePath = $file->getPathname();
+                $normalizedPath = str_replace('\\', '/', $filePath);
+
+                // Skip files covered by 'web' middleware via external registration
+                if (in_array($normalizedPath, $webProtectedFiles, true)) {
+                    continue;
+                }
+
                 $isApiRoute = $file->getFilename() === 'api.php';
                 $content = FileParser::readFile($filePath);
                 if ($content === null || ! is_string($content)) {

--- a/src/Support/BootstrapRouteParser.php
+++ b/src/Support/BootstrapRouteParser.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Include_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\MagicConst\Dir;
+use PhpParser\Node\Scalar\String_;
+use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
+
+/**
+ * Detects route files that are covered by web middleware through external registration.
+ *
+ * Two sources are checked:
+ *   1. Files require'd/include'd from routes/web.php (inherit web middleware automatically)
+ *   2. Files registered via Route::middleware('web')->...->group(base_path('...'))
+ *      in bootstrap/app.php's withRouting(then: ...) callback
+ */
+class BootstrapRouteParser
+{
+    public function __construct(
+        private readonly string $basePath,
+        private readonly ParserInterface $parser,
+    ) {}
+
+    /**
+     * Returns absolute paths of route files covered by 'web' middleware
+     * through external registration (not declared inside the file).
+     *
+     * @return array<string>
+     */
+    public function getWebProtectedRouteFiles(): array
+    {
+        return array_values(array_unique(array_merge(
+            $this->getFilesRequiredFromWebPhp(),
+            $this->getFilesRegisteredWithWebMiddlewareInBootstrap(),
+        )));
+    }
+
+    /**
+     * Finds route files require'd/include'd from routes/web.php.
+     * These inherit the 'web' middleware group automatically.
+     *
+     * @return array<string>
+     */
+    private function getFilesRequiredFromWebPhp(): array
+    {
+        $webPhpPath = $this->basePath.'/routes/web.php';
+        if (! file_exists($webPhpPath)) {
+            return [];
+        }
+
+        $ast = $this->parser->parseFile($webPhpPath);
+        if (empty($ast)) {
+            return [];
+        }
+
+        $protected = [];
+        $includes = $this->parser->findNodes($ast, Include_::class);
+
+        foreach ($includes as $include) {
+            if (! ($include instanceof Include_)) {
+                continue;
+            }
+            $path = $this->resolveIncludePath($include->expr, dirname($webPhpPath));
+            if ($path !== null && file_exists($path)) {
+                $protected[] = $path;
+            }
+        }
+
+        return $protected;
+    }
+
+    /**
+     * Finds route files registered via Route::middleware('web')->group(base_path('...'))
+     * inside bootstrap/app.php's withRouting(then: ...) callback.
+     *
+     * @return array<string>
+     */
+    private function getFilesRegisteredWithWebMiddlewareInBootstrap(): array
+    {
+        $bootstrapPath = $this->basePath.'/bootstrap/app.php';
+        if (! file_exists($bootstrapPath)) {
+            return [];
+        }
+
+        $ast = $this->parser->parseFile($bootstrapPath);
+        if (empty($ast)) {
+            return [];
+        }
+
+        $protected = [];
+        $groupCalls = $this->parser->findMethodCalls($ast, 'group');
+
+        foreach ($groupCalls as $call) {
+            if (! ($call instanceof MethodCall)) {
+                continue;
+            }
+
+            $firstArg = $call->args[0] ?? null;
+            if (! ($firstArg instanceof Node\Arg)) {
+                continue;
+            }
+
+            // Arg must be base_path('routes/X.php')
+            $filePath = $this->extractBasePathArgument($firstArg->value);
+            if ($filePath === null) {
+                continue;
+            }
+
+            // Walk the chain to check Route::middleware('web') is present
+            if ($this->chainContainsWebMiddleware($call->var)) {
+                $protected[] = $filePath;
+            }
+        }
+
+        return $protected;
+    }
+
+    /**
+     * Walks a method-call chain (right to left) looking for ->middleware('web')
+     * or Route::middleware('web') anywhere in the chain.
+     */
+    private function chainContainsWebMiddleware(Node $node): bool
+    {
+        if ($node instanceof StaticCall || $node instanceof MethodCall) {
+            if ($node->name instanceof Identifier && $node->name->name === 'middleware') {
+                $firstArg = $node->args[0] ?? null;
+                if ($firstArg instanceof Node\Arg) {
+                    $arg = $firstArg->value;
+                    if ($arg instanceof String_ && $arg->value === 'web') {
+                        return true;
+                    }
+                }
+            }
+            if ($node instanceof MethodCall) {
+                return $this->chainContainsWebMiddleware($node->var);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Extracts the file path from a base_path('routes/X.php') expression.
+     */
+    private function extractBasePathArgument(Node $node): ?string
+    {
+        if (! ($node instanceof FuncCall)) {
+            return null;
+        }
+
+        $name = $node->name;
+        if (! ($name instanceof Node\Name) || (string) $name !== 'base_path') {
+            return null;
+        }
+
+        $firstArg = $node->args[0] ?? null;
+        if (! ($firstArg instanceof Node\Arg)) {
+            return null;
+        }
+
+        $arg = $firstArg->value;
+        if (! ($arg instanceof String_)) {
+            return null;
+        }
+
+        return $this->basePath.'/'.ltrim($arg->value, '/');
+    }
+
+    /**
+     * Resolves a require/include expression to an absolute path.
+     * Handles __DIR__ . '/file.php' and bare 'file.php' patterns.
+     */
+    private function resolveIncludePath(Node $expr, string $dir): ?string
+    {
+        // __DIR__ . '/auth.php'
+        if ($expr instanceof Concat && $expr->left instanceof Dir && $expr->right instanceof String_) {
+            return $dir.$expr->right->value;
+        }
+
+        // 'auth.php' (bare relative string)
+        if ($expr instanceof String_) {
+            $value = $expr->value;
+
+            return str_starts_with($value, '/') ? $value : $dir.'/'.$value;
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Analyzers/Security/CsrfAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/CsrfAnalyzerTest.php
@@ -2012,4 +2012,114 @@ PHP;
         $this->assertArrayHasKey('file', $metadata);
         $this->assertArrayHasKey('line', $metadata);
     }
+
+    // ==================== withRouting(then: ...) False Positive Tests ====================
+
+    public function test_skips_route_file_required_from_web_php(): void
+    {
+        // auth.php has a POST route with no 'web' middleware — but it's require'd from
+        // web.php, so it inherits web middleware (including CSRF) automatically.
+        $webPhp = <<<'PHP'
+<?php
+require __DIR__.'/auth.php';
+PHP;
+
+        $authPhp = <<<'PHP'
+<?php
+Route::post('/login', [LoginController::class, 'store']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $webPhp,
+            'routes/auth.php' => $authPhp,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass — auth.php inherits web middleware from the require in web.php
+        $this->assertPassed($result);
+    }
+
+    public function test_skips_route_file_registered_with_web_middleware_in_bootstrap(): void
+    {
+        // auth.php registered via Route::middleware('web')->group(...) in bootstrap/app.php
+        $bootstrapApp = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        then: function () {
+            Route::middleware('web')
+                ->group(base_path('routes/auth.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $authPhp = <<<'PHP'
+<?php
+Route::post('/login', [LoginController::class, 'store']);
+Route::post('/register', [RegisterController::class, 'store']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/web.php' => '<?php // main web routes',
+            'routes/auth.php' => $authPhp,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass — auth.php is registered with 'web' middleware externally
+        $this->assertPassed($result);
+    }
+
+    public function test_still_flags_route_file_with_non_web_middleware_in_bootstrap(): void
+    {
+        // auth.php registered via Route::middleware('api')->group(...) — not 'web'
+        $bootstrapApp = <<<'PHP'
+<?php
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        then: function () {
+            Route::middleware('api')
+                ->group(base_path('routes/auth.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $authPhp = <<<'PHP'
+<?php
+Route::post('/login', [LoginController::class, 'store']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/web.php' => '<?php // main web routes',
+            'routes/auth.php' => $authPhp,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        // Should fail — 'api' middleware does not include CSRF protection
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('CSRF', $result);
+    }
 }

--- a/tests/Unit/Analyzers/Security/LoginThrottlingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/LoginThrottlingAnalyzerTest.php
@@ -1211,4 +1211,77 @@ PHP;
         // Should fail - __invoke in Auth directory without throttle
         $this->assertFailed($result);
     }
+
+    // ==================== withRouting(then: ...) False Positive Tests ====================
+
+    public function test_skips_login_route_in_web_required_file(): void
+    {
+        // auth.php has a login route, but it's require'd from web.php.
+        // Throttle may be applied globally via withMiddleware(); no false positive expected.
+        $webPhp = <<<'PHP'
+<?php
+require __DIR__.'/auth.php';
+PHP;
+
+        $authPhp = <<<'PHP'
+<?php
+Route::post('/login', [LoginController::class, 'authenticate']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $webPhp,
+            'routes/auth.php' => $authPhp,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass — auth.php is web-protected via require from web.php;
+        // the global throttle check applies to all web routes
+        $this->assertPassed($result);
+    }
+
+    public function test_skips_login_route_in_bootstrap_registered_file(): void
+    {
+        // auth.php registered via Route::middleware('web')->group() in bootstrap/app.php
+        $bootstrapApp = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        then: function () {
+            Route::middleware('web')
+                ->group(base_path('routes/auth.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $authPhp = <<<'PHP'
+<?php
+Route::post('/login', [LoginController::class, 'authenticate']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/web.php' => '<?php // main routes',
+            'routes/auth.php' => $authPhp,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass — auth.php is web-protected via external registration;
+        // throttle is applied to the whole 'web' group globally
+        $this->assertPassed($result);
+    }
 }

--- a/tests/Unit/Support/BootstrapRouteParserTest.php
+++ b/tests/Unit/Support/BootstrapRouteParserTest.php
@@ -1,0 +1,478 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use PHPUnit\Framework\TestCase;
+use ShieldCI\AnalyzersCore\Support\AstParser;
+use ShieldCI\Support\BootstrapRouteParser;
+
+class BootstrapRouteParserTest extends TestCase
+{
+    private AstParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new AstParser;
+    }
+
+    /**
+     * Create a temporary directory with the given files and return the path.
+     *
+     * @param  array<string, string>  $files
+     */
+    private function createTempDir(array $files = []): string
+    {
+        $tempDir = sys_get_temp_dir().'/bootstrap_route_parser_test_'.uniqid();
+        mkdir($tempDir, 0755, true);
+
+        foreach ($files as $filename => $content) {
+            $filepath = $tempDir.'/'.$filename;
+            $dirname = dirname($filepath);
+            if (! is_dir($dirname)) {
+                mkdir($dirname, 0755, true);
+            }
+            file_put_contents($filepath, $content);
+        }
+
+        return $tempDir;
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir.'/'.$file;
+            is_dir($path) ? $this->removeDir($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        // Cleanup happens per-test via reference
+    }
+
+    public function test_returns_empty_when_no_web_php_or_bootstrap_exists(): void
+    {
+        $tempDir = $this->createTempDir(['routes/auth.php' => '<?php // empty']);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_detects_require_from_web_php(): void
+    {
+        $webPhp = <<<'PHP'
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', function () {
+    return view('welcome');
+});
+
+require __DIR__.'/auth.php';
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'routes/web.php' => $webPhp,
+            'routes/auth.php' => '<?php // auth routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            $this->assertCount(1, $result);
+            $this->assertStringEndsWith('/routes/auth.php', $result[0]);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_detects_require_once_from_web_php(): void
+    {
+        $webPhp = <<<'PHP'
+<?php
+
+require_once __DIR__.'/auth.php';
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'routes/web.php' => $webPhp,
+            'routes/auth.php' => '<?php // auth routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            $this->assertCount(1, $result);
+            $this->assertStringEndsWith('/routes/auth.php', $result[0]);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_detects_chained_web_middleware_group_in_bootstrap(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        commands: __DIR__.'/../routes/console.php',
+        health: '/up',
+        then: function () {
+            Route::middleware('web')
+                ->prefix('auth')
+                ->group(base_path('routes/auth.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/auth.php' => '<?php // auth routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            $this->assertCount(1, $result);
+            $this->assertStringEndsWith('/routes/auth.php', $result[0]);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_ignores_api_middleware_group_in_bootstrap(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        then: function () {
+            Route::middleware('api')
+                ->group(base_path('routes/auth.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/auth.php' => '<?php // auth routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            // 'api' middleware should NOT be considered web-protected
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_handles_multi_segment_chain_in_bootstrap(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        then: function () {
+            Route::middleware('web')
+                ->prefix('admin')
+                ->name('admin.')
+                ->group(base_path('routes/admin.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/admin.php' => '<?php // admin routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            $this->assertCount(1, $result);
+            $this->assertStringEndsWith('/routes/admin.php', $result[0]);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_deduplicates_files_found_in_both_sources(): void
+    {
+        // auth.php is both require'd from web.php AND registered in bootstrap/app.php
+        $webPhp = <<<'PHP'
+<?php
+require __DIR__.'/auth.php';
+PHP;
+
+        $bootstrapApp = <<<'PHP'
+<?php
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        then: function () {
+            Route::middleware('web')
+                ->group(base_path('routes/auth.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'routes/web.php' => $webPhp,
+            'routes/auth.php' => '<?php // auth routes',
+            'bootstrap/app.php' => $bootstrapApp,
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            // Should not duplicate the same file
+            $this->assertCount(1, $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_does_not_include_nonexistent_required_file(): void
+    {
+        $webPhp = <<<'PHP'
+<?php
+require __DIR__.'/nonexistent.php';
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'routes/web.php' => $webPhp,
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            // File doesn't exist — should not be included
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_returns_empty_when_web_php_is_unparseable(): void
+    {
+        $tempDir = $this->createTempDir([
+            'routes/web.php' => '<?php = = invalid syntax',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_returns_empty_when_bootstrap_is_unparseable(): void
+    {
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => '<?php = = invalid syntax',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_ignores_group_call_with_no_arguments(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+Route::middleware('web')->group();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_ignores_group_call_with_bare_string_argument(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+Route::middleware('web')->group('routes/auth.php');
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/auth.php' => '<?php // auth routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            // Bare string (not base_path()) — should not be detected
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_ignores_group_call_with_non_base_path_function(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+Route::middleware('web')->group(app_path('routes/auth.php'));
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/auth.php' => '<?php // auth routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            // app_path() is not base_path() — should not be detected
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_ignores_group_with_base_path_and_no_arguments(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+Route::middleware('web')->group(base_path());
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            // base_path() with no args — unresolvable
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_ignores_group_with_base_path_and_variable_argument(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+Route::middleware('web')->group(base_path($routeFile));
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            // base_path($var) — dynamic path, unresolvable statically
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_detects_require_with_bare_relative_string(): void
+    {
+        $webPhp = <<<'PHP'
+<?php
+require 'auth.php';
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'routes/web.php' => $webPhp,
+            'routes/auth.php' => '<?php // auth routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            $this->assertCount(1, $result);
+            $this->assertStringEndsWith('/routes/auth.php', $result[0]);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_ignores_dynamic_variable_require(): void
+    {
+        $webPhp = <<<'PHP'
+<?php
+require $file;
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'routes/web.php' => $webPhp,
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            // Variable require — cannot be resolved statically
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BootstrapRouteParser` utility (`src/Support/`) that uses PHP-Parser AST to detect route files covered by the `web` middleware group through external registration
- `CsrfAnalyzer` and `LoginThrottlingAnalyzer` now skip these externally-protected files, eliminating false positives on Laravel 11+ apps using `withRouting(then: ...)`

## Problem

In Laravel 11+, custom route files can be registered with middleware applied externally in `bootstrap/app.php`:

```php
->withRouting(
    web: __DIR__.'/../routes/web.php',
    then: function () {
        Route::middleware('web')
            ->group(base_path('routes/auth.php'));
    },
)
```

Both `CsrfAnalyzer` and `LoginThrottlingAnalyzer` were flagging `auth.php` as missing CSRF/throttle protection, because they only skip `web.php` and `api.php` by name — they couldn't detect that `auth.php` inherits the `web` middleware externally.

## Solution

`BootstrapRouteParser` detects web-protected route files from two sources:

| Source | Pattern |
|--------|---------|
| `routes/web.php` | `require __DIR__.'/auth.php'` (inherits web middleware) |
| `bootstrap/app.php` | `Route::middleware('web')->...->group(base_path('routes/auth.php'))` |

Uses `ParserInterface` (AST, not regex) and walks method-call chains right-to-left to detect the middleware. Only `'web'` middleware qualifies — `'api'` and others are ignored.