### PR TITLE
fix: report issues at child AST node line, not parent declaration line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.5.4 - 2026-03-07
+
+### Fixed
+- `FillableForeignKeyAnalyzer` now reports each issue at the specific `$fillable` array item line (e.g. `'user_id',`) instead of the `protected $fillable = [` declaration line — fixes `@shieldci-ignore` comments placed on the offending entry being silently ignored
+- `NamingConventionAnalyzer` now reports property violations at the individual property line (`$prop->getStartLine()`) and constant violations at the individual constant line (`$const->getStartLine()`) instead of the parent statement line — same inline-suppression fix applies
+- `PasswordSecurityAnalyzer` now reports weak `password_hash()` option issues (`bcrypt cost`, `argon2 memory_cost`, `time_cost`, `threads`) at the offending array item line instead of the `password_hash(` call line
+
 ## v1.5.3 - 2026-03-07
 
 ### Fixed

--- a/src/Analyzers/CodeQuality/NamingConventionAnalyzer.php
+++ b/src/Analyzers/CodeQuality/NamingConventionAnalyzer.php
@@ -178,7 +178,7 @@ class NamingConventionVisitor extends NodeVisitorAbstract
                     $suggestion = $this->toCamelCase($propertyName);
                     $this->issues[] = [
                         'message' => "Property '{$propertyName}' does not follow camelCase convention",
-                        'line' => $node->getStartLine(),
+                        'line' => $prop->getStartLine(),
                         'type' => 'property',
                         'name' => $propertyName,
                         'suggestion' => $suggestion,
@@ -199,7 +199,7 @@ class NamingConventionVisitor extends NodeVisitorAbstract
                         $suggestion = $this->toScreamingSnakeCase($constName);
                         $this->issues[] = [
                             'message' => "Public constant '{$constName}' does not follow SCREAMING_SNAKE_CASE convention",
-                            'line' => $node->getStartLine(),
+                            'line' => $const->getStartLine(),
                             'type' => 'constant',
                             'name' => $constName,
                             'suggestion' => $suggestion,

--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -225,7 +225,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                 foreach ($prop->default->items as $item) {
                     if ($item->value instanceof Node\Scalar\String_) {
                         $fieldName = $item->value->value;
-                        $this->checkField($file, $stmt, $modelName, $fieldName, $issues);
+                        $this->checkField($file, $item->getLine(), $modelName, $fieldName, $issues);
                     }
                 }
             }
@@ -281,7 +281,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
     /**
      * Check a single field for foreign key patterns.
      */
-    private function checkField(string $file, Node\Stmt\Property $stmt, string $modelName, string $fieldName, array &$issues): void
+    private function checkField(string $file, int $itemLine, string $modelName, string $fieldName, array &$issues): void
     {
         // Check dangerous patterns FIRST (prevents duplicates)
         if (array_key_exists($fieldName, $this->dangerousPatterns)) {
@@ -295,7 +295,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                     $modelName
                 ),
                 filePath: $file,
-                lineNumber: $stmt->getLine(),
+                lineNumber: $itemLine,
                 severity: Severity::Critical,
                 recommendation: sprintf(
                     'IMMEDIATELY remove "%s" from $fillable. Set this value server-side based on the authenticated context.',
@@ -307,7 +307,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                     'model_file' => $this->getRelativePath($file),
                     'is_dangerous_pattern' => true,
                     'pattern_type' => $relationship,
-                    'line' => $stmt->getLine(),
+                    'line' => $itemLine,
                 ]
             );
 
@@ -323,7 +323,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                     $modelName
                 ),
                 filePath: $file,
-                lineNumber: $stmt->getLine(),
+                lineNumber: $itemLine,
                 severity: Severity::High,
                 recommendation: sprintf(
                     'Remove "%s" from $fillable or validate that users should be able to set this relationship. '.
@@ -336,7 +336,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                     'model_file' => $this->getRelativePath($file),
                     'is_dangerous_pattern' => false,
                     'pattern_type' => 'foreign_key',
-                    'line' => $stmt->getLine(),
+                    'line' => $itemLine,
                 ]
             );
         }

--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -486,7 +486,7 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
                         $config['bcrypt_min_rounds']
                     ),
                     filePath: $file,
-                    lineNumber: $call->getStartLine(),
+                    lineNumber: $item->getStartLine(),
                     severity: Severity::Critical,
                     recommendation: sprintf(
                         'Set bcrypt cost to at least %d for better protection against brute-force attacks',
@@ -504,7 +504,7 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
                         $config['argon2_min_memory']
                     ),
                     filePath: $file,
-                    lineNumber: $call->getStartLine(),
+                    lineNumber: $item->getStartLine(),
                     severity: Severity::Critical,
                     recommendation: sprintf(
                         'Set argon2 memory_cost to at least %d KB',
@@ -522,7 +522,7 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
                         $config['argon2_min_time']
                     ),
                     filePath: $file,
-                    lineNumber: $call->getStartLine(),
+                    lineNumber: $item->getStartLine(),
                     severity: Severity::Medium,
                     recommendation: sprintf(
                         'Set argon2 time_cost to at least %d',
@@ -540,7 +540,7 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
                         $config['argon2_min_threads']
                     ),
                     filePath: $file,
-                    lineNumber: $call->getStartLine(),
+                    lineNumber: $item->getStartLine(),
                     severity: Severity::Low,
                     recommendation: sprintf(
                         'Set argon2 threads to at least %d',

--- a/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
@@ -821,6 +821,83 @@ PHP;
         $this->assertStringContainsString('impersonate', $issue->message);
     }
 
+    // ==================== Line Number Tests ====================
+    // Note: @shieldci-ignore suppression is applied by AnalyzeCommand, not the analyzer.
+    // These tests verify that issues are reported at the array item line (not the property
+    // declaration line), which is what allows per-item inline suppression to work correctly.
+
+    public function test_issue_is_reported_at_array_item_line_not_property_line(): void
+    {
+        // 'post_id' is on line 11, 'protected $fillable' is on line 9
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    protected $fillable = [
+        'title',
+        'post_id',
+    ];
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Models/Post.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+
+        // Issue must report at line 11 ('post_id'), not line 9 ('protected $fillable = [')
+        $this->assertNotNull($issues[0]->location);
+        $this->assertEquals(11, $issues[0]->location->line);
+    }
+
+    public function test_dangerous_pattern_issue_is_reported_at_array_item_line(): void
+    {
+        // 'user_id' is on line 11, 'protected $fillable' is on line 9
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    protected $fillable = [
+        'title',
+        'user_id',
+    ];
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Models/Post.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+
+        // Issue must report at line 11 ('user_id'), not line 9 ('protected $fillable = [')
+        $this->assertNotNull($issues[0]->location);
+        $this->assertEquals(11, $issues[0]->location->line);
+    }
+
     // ==================== Analyzer Metadata Test ====================
 
     public function test_analyzer_runs_successfully(): void


### PR DESCRIPTION
## Summary

- **`FillableForeignKeyAnalyzer`**: `checkField()` was using `$stmt->getLine()` (the `protected $fillable = [` line) for every array item. Now passes `$item->getLine()` from the call site so each entry reports at its own line.
- **`NamingConventionAnalyzer`**: Property violations used `$node->getStartLine()` (the `Property` statement) instead of `$prop->getStartLine()` (the specific property). Same for constants: `$node->getStartLine()` → `$const->getStartLine()`.
- **`PasswordSecurityAnalyzer`**: Four `password_hash()` option checks (`bcrypt cost`, `argon2 memory_cost`, `time_cost`, `threads`) all used `$call->getStartLine()` while iterating `$optionsArray->items`. Now uses `$item->getStartLine()`.

**Root cause pattern**: iterating child AST nodes but reporting the line of the parent node. This causes two bugs: wrong line numbers in output, and per-item `@shieldci-ignore` comments that are never matched (forcing annotation on the parent declaration line).