### PR TITLE
fix: suppress LoginThrottlingAnalyzer false positives for throttle-protected route groups and GET token endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.5.6 - 2026-03-08
+
+### Fixed
+- `LoginThrottlingAnalyzer` no longer false-positives on route files registered with a throttle middleware directly on their group in `bootstrap/app.php` (e.g. `Route::prefix('api/v1')->middleware(['api', 'throttle:api.rest'])->group(base_path('routes/api-v1.php'))`) — these files now correctly inherit their rate-limiting protection and are skipped
+- `LoginThrottlingAnalyzer` no longer false-positives on `GET /token/verify` and similar token management endpoints in `routes/api.php` — `token`/`oauth` URL keywords now only trigger a check on `POST`, `any`, and `match` routes (credential submission methods); `GET`, `resource`, and `controller` routes only match the `login`/`signin`/`auth`/`authenticate` keywords
+
+### Added
+- `BootstrapRouteParser::getThrottleProtectedRouteFiles()` — detects route files registered with any `throttle:*` middleware (string or array form) on their group in `bootstrap/app.php`; used by `LoginThrottlingAnalyzer` to suppress false positives on externally throttled route groups
+
 ## v1.5.5 - 2026-03-07
 
 ### Fixed

--- a/src/Analyzers/Security/LoginThrottlingAnalyzer.php
+++ b/src/Analyzers/Security/LoginThrottlingAnalyzer.php
@@ -617,10 +617,12 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
             return;
         }
 
-        // Compute route files covered by 'web' middleware via external registration
-        // (require from web.php, or Route::middleware('web')->group() in bootstrap/app.php)
-        $webProtectedFiles = (new BootstrapRouteParser($this->getBasePath(), $this->parser))
-            ->getWebProtectedRouteFiles();
+        // Compute route files covered by 'web' or throttle middleware via external registration
+        $bootstrapParser = new BootstrapRouteParser($this->getBasePath(), $this->parser);
+        $skipFiles = array_merge(
+            $bootstrapParser->getWebProtectedRouteFiles(),
+            $bootstrapParser->getThrottleProtectedRouteFiles(),
+        );
 
         try {
             foreach (new \DirectoryIterator($routePath) as $file) {
@@ -631,8 +633,8 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
                 $filePath = $file->getPathname();
                 $normalizedPath = str_replace('\\', '/', $filePath);
 
-                // Skip files covered by 'web' middleware via external registration
-                if (in_array($normalizedPath, $webProtectedFiles, true)) {
+                // Skip files covered by 'web' or throttle middleware via external registration
+                if (in_array($normalizedPath, $skipFiles, true)) {
                     continue;
                 }
 
@@ -698,13 +700,20 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
                     // Check for login-related routes
                     // Web routes: /login, /signin, /auth, /authenticate
                     // API routes: /api/login, /api/auth, /api/token, /oauth/token, /sanctum/token
-                    $loginPattern = $isApiRoute
-                        ? '/Route::(post|get|any|match|resource|controller)\s*\(["\']([^"\']*(?:login|signin|auth|authenticate|token|oauth)[^"\']*)["\']/'
-                        : '/Route::(post|get|any|match|resource|controller)\s*\(["\']([^"\']*(?:login|signin|auth|authenticate)[^"\']*)["\']/';
+                    // For API files: token/oauth only match on POST/any/match (not GET — those
+                    // are management endpoints like /token/verify, not credential submission).
+                    $routeUri = null;
+                    if ($isApiRoute) {
+                        if (preg_match('/Route::(post|any|match)\s*\(["\']([^"\']*(?:login|signin|auth|authenticate|token|oauth)[^"\']*)["\']/', $line, $m)) {
+                            $routeUri = $m[2];
+                        } elseif (preg_match('/Route::(get|resource|controller)\s*\(["\']([^"\']*(?:login|signin|auth|authenticate)[^"\']*)["\']/', $line, $m)) {
+                            $routeUri = $m[2];
+                        }
+                    } elseif (preg_match('/Route::(post|get|any|match|resource|controller)\s*\(["\']([^"\']*(?:login|signin|auth|authenticate)[^"\']*)["\']/', $line, $m)) {
+                        $routeUri = $m[2];
+                    }
 
-                    if (preg_match($loginPattern, $line, $matches)) {
-                        $routeUri = $matches[2];
-
+                    if ($routeUri !== null) {
                         // Check if this route or surrounding lines have throttle middleware
                         $hasThrottle = $this->checkRouteHasThrottling($lines, $lineNumber) || $inWebGroup;
 

--- a/src/Support/BootstrapRouteParser.php
+++ b/src/Support/BootstrapRouteParser.php
@@ -115,6 +115,21 @@ class BootstrapRouteParser
     }
 
     /**
+     * Returns absolute paths of route files registered with a throttle middleware
+     * directly on their group in bootstrap/app.php.
+     *
+     * Matches any throttle variant: 'throttle:5,1', 'throttle:api.rest', etc.
+     *
+     * @return array<string>
+     */
+    public function getThrottleProtectedRouteFiles(): array
+    {
+        return array_values(array_unique(
+            $this->getFilesRegisteredWithThrottleMiddlewareInBootstrap()
+        ));
+    }
+
+    /**
      * Finds route files registered via Route::middleware('web')->group(base_path('...'))
      * inside bootstrap/app.php's withRouting(then: ...) callback.
      *
@@ -186,6 +201,50 @@ class BootstrapRouteParser
     }
 
     /**
+     * Finds route files registered with a throttle middleware on their group
+     * inside bootstrap/app.php.
+     *
+     * @return array<string>
+     */
+    private function getFilesRegisteredWithThrottleMiddlewareInBootstrap(): array
+    {
+        $bootstrapPath = $this->basePath.'/bootstrap/app.php';
+        if (! file_exists($bootstrapPath)) {
+            return [];
+        }
+
+        $ast = $this->parser->parseFile($bootstrapPath);
+        if (empty($ast)) {
+            return [];
+        }
+
+        $found = [];
+        $groupCalls = $this->parser->findMethodCalls($ast, 'group');
+
+        foreach ($groupCalls as $call) {
+            if (! ($call instanceof MethodCall)) {
+                continue;
+            }
+
+            $firstArg = $call->args[0] ?? null;
+            if (! ($firstArg instanceof Node\Arg)) {
+                continue;
+            }
+
+            $filePath = $this->extractBasePathArgument($firstArg->value);
+            if ($filePath === null) {
+                continue;
+            }
+
+            if ($this->chainContainsThrottleMiddleware($call->var)) {
+                $found[] = $filePath;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
      * Walks a method-call chain (right to left) looking for ->middleware(name)
      * or Route::middleware(name) anywhere in the chain.
      *
@@ -218,6 +277,45 @@ class BootstrapRouteParser
             }
             if ($node instanceof MethodCall) {
                 return $this->chainContainsMiddleware($node->var, $middlewareName);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Walks a method-call chain (right to left) looking for ->middleware(...)
+     * where any value starts with 'throttle' (matches 'throttle:5,1', 'throttle:api.rest', etc.).
+     *
+     * Supports both string and array forms:
+     *   ->middleware('throttle:5,1')
+     *   ->middleware(['api', 'throttle:api.rest'])
+     */
+    private function chainContainsThrottleMiddleware(Node $node): bool
+    {
+        if ($node instanceof StaticCall || $node instanceof MethodCall) {
+            if ($node->name instanceof Identifier && $node->name->name === 'middleware') {
+                $firstArg = $node->args[0] ?? null;
+                if ($firstArg instanceof Node\Arg) {
+                    $arg = $firstArg->value;
+                    // ->middleware('throttle:5,1')
+                    if ($arg instanceof String_ && str_starts_with($arg->value, 'throttle')) {
+                        return true;
+                    }
+                    // ->middleware(['api', 'throttle:api.rest'])
+                    if ($arg instanceof Node\Expr\Array_) {
+                        foreach ($arg->items as $item) {
+                            if ($item instanceof Node\Expr\ArrayItem
+                                && $item->value instanceof String_
+                                && str_starts_with($item->value->value, 'throttle')) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            if ($node instanceof MethodCall) {
+                return $this->chainContainsThrottleMiddleware($node->var);
             }
         }
 

--- a/tests/Unit/Analyzers/Security/LoginThrottlingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/LoginThrottlingAnalyzerTest.php
@@ -1284,4 +1284,89 @@ PHP;
         // throttle is applied to the whole 'web' group globally
         $this->assertPassed($result);
     }
+
+    public function test_skips_route_file_registered_with_throttle_in_bootstrap(): void
+    {
+        // api-v1.php registered with throttle middleware directly on its group
+        $bootstrapApp = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        then: function () {
+            Route::prefix('api/v1')
+                ->middleware(['api', 'throttle:api.rest'])
+                ->group(base_path('routes/api-v1.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $apiV1Php = <<<'PHP'
+<?php
+Route::post('/auth/login', [AuthController::class, 'login']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/web.php' => '<?php // main routes',
+            'routes/api-v1.php' => $apiV1Php,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass — api-v1.php has throttle applied at group level in bootstrap/app.php
+        $this->assertPassed($result);
+    }
+
+    public function test_get_token_verify_does_not_trigger_false_positive(): void
+    {
+        // GET /token/verify is a management endpoint, not a credential submission endpoint
+        $apiPhp = <<<'PHP'
+<?php
+Route::get('/token/verify', [TokenVerificationController::class, 'verify']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/api.php' => $apiPhp,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass — GET /token/verify is not a credential submission endpoint
+        $this->assertPassed($result);
+    }
+
+    public function test_post_token_in_api_route_still_flagged_without_throttle(): void
+    {
+        // POST /token is a credential/token issuance endpoint — should still be checked
+        $apiPhp = <<<'PHP'
+<?php
+Route::post('/token', [TokenController::class, 'issue']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/api.php' => $apiPhp,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        // Should fail — POST /token is a credential submission endpoint without throttling
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('API authentication route "/token" lacks rate limiting', $result);
+    }
 }

--- a/tests/Unit/Support/BootstrapRouteParserTest.php
+++ b/tests/Unit/Support/BootstrapRouteParserTest.php
@@ -570,6 +570,178 @@ PHP;
         }
     }
 
+    // ==================== getThrottleProtectedRouteFiles Tests ====================
+
+    public function test_detects_throttle_string_middleware_group_in_bootstrap(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        then: function () {
+            Route::prefix('api/v1')
+                ->middleware('throttle:5,1')
+                ->group(base_path('routes/api-v1.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/api-v1.php' => '<?php // v1 api routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getThrottleProtectedRouteFiles();
+
+            $this->assertCount(1, $result);
+            $this->assertStringEndsWith('/routes/api-v1.php', $result[0]);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_detects_throttle_in_array_middleware_group_in_bootstrap(): void
+    {
+        // Platform's exact pattern: ->middleware(['api', 'throttle:api.rest'])
+        $bootstrapApp = <<<'PHP'
+<?php
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        then: function () {
+            Route::prefix('api/v1')
+                ->middleware(['api', 'throttle:api.rest'])
+                ->group(base_path('routes/api-v1.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/api-v1.php' => '<?php // v1 api routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getThrottleProtectedRouteFiles();
+
+            $this->assertCount(1, $result);
+            $this->assertStringEndsWith('/routes/api-v1.php', $result[0]);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_ignores_files_without_throttle_middleware(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        then: function () {
+            Route::prefix('api/v1')
+                ->middleware(['api'])
+                ->group(base_path('routes/api-v1.php'));
+        },
+    )
+    ->create();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/api-v1.php' => '<?php // v1 api routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getThrottleProtectedRouteFiles();
+
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_throttle_returns_empty_when_no_bootstrap_exists(): void
+    {
+        $tempDir = $this->createTempDir(['routes/api-v1.php' => '<?php // empty']);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getThrottleProtectedRouteFiles();
+
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_throttle_returns_empty_when_bootstrap_is_unparseable(): void
+    {
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => '<?php = = invalid syntax',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getThrottleProtectedRouteFiles();
+
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_throttle_ignores_group_call_with_no_arguments(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+Route::middleware('throttle:5,1')->group();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getThrottleProtectedRouteFiles();
+
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_throttle_ignores_group_call_with_non_base_path_function(): void
+    {
+        $bootstrapApp = <<<'PHP'
+<?php
+Route::middleware('throttle:5,1')->group(app_path('routes/api-v1.php'));
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/api-v1.php' => '<?php // v1 api routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getThrottleProtectedRouteFiles();
+
+            // app_path() is not base_path() — should not be detected
+            $this->assertSame([], $result);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
     public function test_api_list_does_not_include_web_registered_files(): void
     {
         $bootstrapApp = <<<'PHP'


### PR DESCRIPTION
## Summary

- **Root cause 1:** `BootstrapRouteParser` had no way to detect route files registered with `throttle:*` middleware directly on their group in `bootstrap/app.php`. `LoginThrottlingAnalyzer` only skipped web-protected files, so `routes/api-v1.php` (protected via `->middleware(['api', 'throttle:api.rest'])->group(base_path(...))`) was incorrectly flagged.
- **Root cause 2:** The API login regex matched any HTTP method for URLs containing `token` or `oauth`, causing `GET /token/verify` (a token verification/management endpoint) to be flagged as a missing-throttle issue.

## Changes

- **`BootstrapRouteParser`**: Add `getThrottleProtectedRouteFiles()` (public) + `getFilesRegisteredWithThrottleMiddlewareInBootstrap()` + `chainContainsThrottleMiddleware()` — scans `bootstrap/app.php` for groups with any `throttle:*` middleware (string or array form)
- **`LoginThrottlingAnalyzer::checkRouteFiles()`**: Merge throttle-protected files into the skip list alongside web-protected files
- **API login regex**: Split into two patterns — `token`/`oauth` now only trigger on `POST/any/match`; `GET /token/verify` is no longer a false positive while `POST /token` still correctly flags missing throttling