### PR TITLE
fix: suppress UnusedGlobalMiddlewareAnalyzer false positives on Laravel 11+

### DIFF
--- a/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
+++ b/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
@@ -77,7 +77,7 @@ class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
             return $this->passed('No unused global middleware detected');
         }
 
-        $kernelPath = $this->getKernelPath();
+        $kernelPath = $this->getMiddlewareFilePath();
         $middlewareLine = $this->findMiddlewareArrayLine($kernelPath);
 
         $issues = [];
@@ -104,7 +104,13 @@ class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
 
     private function checkTrustProxiesMiddleware(): void
     {
-        // Check if TrustProxies middleware is registered (Laravel 9+ or Fideloper package)
+        // In Laravel 11+, TrustProxies is a framework-level default (not user-registered).
+        // Flagging it would be a false positive for every Laravel 11+ application.
+        if ($this->isLaravel11OrNewer()) {
+            return;
+        }
+
+        // Check if TrustProxies middleware is registered (Laravel 9/10 or Fideloper package)
         $isFideloper = class_exists(FideloperTrustProxies::class)
             && $this->appUsesGlobalMiddleware(FideloperTrustProxies::class);
         $isLaravel = class_exists(TrustProxies::class)
@@ -162,6 +168,12 @@ class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
 
     private function checkTrustHostsMiddleware(): void
     {
+        // In Laravel 11+, TrustHosts is managed via the framework's withMiddleware()->trustHosts()
+        // method, not as a user-registered global middleware. Skip to avoid false positives.
+        if ($this->isLaravel11OrNewer()) {
+            return;
+        }
+
         // Only check if TrustHosts is registered
         if (! $this->appUsesGlobalMiddleware(TrustHosts::class)) {
             return;
@@ -210,11 +222,15 @@ class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
             /** @phpstan-ignore-next-line Class may not exist (optional dependency) */
             $middlewareClass = class_exists(HandleCors::class) ? HandleCors::class : FruitcakeHandleCors::class;
 
+            $recommendation = $this->isLaravel11OrNewer()
+                ? 'Remove HandleCors from the withMiddleware() callback in bootstrap/app.php, as no CORS paths are configured. This middleware runs on every request unnecessarily. Only add it back when you configure specific paths in config/cors.php.'
+                : 'Remove HandleCors middleware from app/Http/Kernel.php $middleware array, as no CORS paths are configured. This middleware runs on every request unnecessarily. Only add it back when you configure specific paths that require CORS handling in config/cors.php.';
+
             $this->addUnusedMiddleware(
                 class_basename($middlewareClass),
                 $middlewareClass,
                 'No CORS paths are configured',
-                'Remove HandleCors middleware from app/Http/Kernel.php $middleware array, as no CORS paths are configured. This middleware runs on every request unnecessarily. Only add it back when you configure specific paths that require CORS handling in config/cors.php.'
+                $recommendation
             );
         }
     }
@@ -280,31 +296,61 @@ class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
     }
 
     /**
-     * Get the path to the HTTP Kernel file.
+     * Get the path to the middleware configuration file.
+     * Returns bootstrap/app.php for Laravel 11+, otherwise app/Http/Kernel.php.
      */
-    private function getKernelPath(): string
+    private function getMiddlewareFilePath(): string
     {
         $basePath = $this->getBasePath();
+
+        if ($this->isLaravel11OrNewer()) {
+            return $basePath.DIRECTORY_SEPARATOR.'bootstrap'.DIRECTORY_SEPARATOR.'app.php';
+        }
 
         return $basePath.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'Http'.DIRECTORY_SEPARATOR.'Kernel.php';
     }
 
     /**
-     * Find the line number of the $middleware array in Kernel.php.
+     * Determine if the application uses Laravel 11+.
+     *
+     * Detected via the presence of Illuminate\Foundation\Configuration\Middleware,
+     * which was introduced in Laravel 11 as part of the new bootstrap/app.php API.
+     * This is more reliable than filesystem checks since the laravel/framework
+     * package is always present and its version reflects the actual Laravel version.
+     */
+    private function isLaravel11OrNewer(): bool
+    {
+        return class_exists(\Illuminate\Foundation\Configuration\Middleware::class);
+    }
+
+    /**
+     * Find the relevant line number in the middleware configuration file.
+     * For bootstrap/app.php, finds withMiddleware(). For Kernel.php, finds $middleware property.
      * Falls back to line 1 if not found.
      */
-    private function findMiddlewareArrayLine(string $kernelPath): int
+    private function findMiddlewareArrayLine(string $filePath): int
     {
-        if (! file_exists($kernelPath)) {
+        if (! file_exists($filePath)) {
             return 1;
         }
 
-        // Try to find the $middleware property declaration
-        $lineNumber = ConfigFileHelper::findKeyLine($kernelPath, 'middleware');
+        // Laravel 11+: look for withMiddleware callback in bootstrap/app.php
+        if (str_ends_with($filePath, 'app.php')) {
+            $lines = FileParser::getLines($filePath);
+            foreach ($lines as $lineNum => $line) {
+                if (preg_match('/withMiddleware\s*\(/', $line) === 1) {
+                    return $lineNum + 1;
+                }
+            }
+
+            return 1;
+        }
+
+        // Laravel 9/10: look for protected $middleware property in Kernel.php
+        $lineNumber = ConfigFileHelper::findKeyLine($filePath, 'middleware');
 
         if ($lineNumber < 1) {
-            // Fallback: try to find any line containing 'protected $middleware'
-            $lines = FileParser::getLines($kernelPath);
+            $lines = FileParser::getLines($filePath);
             foreach ($lines as $lineNum => $line) {
                 if (preg_match('/protected\s+\$middleware\s*=/', $line) === 1) {
                     return $lineNum + 1;

--- a/tests/Unit/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzerTest.php
@@ -131,6 +131,19 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
         // we'll just ensure the kernel is set up properly by extending the real kernel
     }
 
+    /**
+     * Skip the test if running on Laravel 11+, where TrustProxies/TrustHosts checks
+     * are intentionally suppressed (they are framework defaults, not user-registered middleware).
+     */
+    private function skipOnLaravel11(string $reason = ''): void
+    {
+        if (class_exists(\Illuminate\Foundation\Configuration\Middleware::class)) {
+            $this->markTestSkipped(
+                'TrustProxies/TrustHosts checks are suppressed on Laravel 11+'.($reason ? ": $reason" : '.')
+            );
+        }
+    }
+
     public function test_passes_when_no_unused_middleware(): void
     {
         $app = Mockery::mock(Application::class);
@@ -163,6 +176,7 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
     public function test_warns_when_trust_proxies_without_configuration(): void
     {
+        $this->skipOnLaravel11();
         $app = Mockery::mock(Application::class);
         $config = Mockery::mock(ConfigRepository::class);
         $router = Mockery::mock(Router::class);
@@ -256,6 +270,7 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
     public function test_warns_when_trust_hosts_without_trust_proxies(): void
     {
+        $this->skipOnLaravel11();
         $app = Mockery::mock(Application::class);
         $config = Mockery::mock(ConfigRepository::class);
         $router = Mockery::mock(Router::class);
@@ -316,6 +331,7 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
     public function test_warns_about_trust_hosts_only_when_trust_proxies_unused(): void
     {
+        $this->skipOnLaravel11();
         $app = Mockery::mock(Application::class);
         $config = Mockery::mock(ConfigRepository::class);
         $router = Mockery::mock(Router::class);
@@ -559,6 +575,7 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
     public function test_handles_invalid_config_types_gracefully(): void
     {
+        $this->skipOnLaravel11();
         $app = Mockery::mock(Application::class);
         $config = Mockery::mock(ConfigRepository::class);
         $router = Mockery::mock(Router::class);
@@ -605,6 +622,7 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
     public function test_warns_when_multiple_middleware_unused(): void
     {
+        $this->skipOnLaravel11();
         $app = Mockery::mock(Application::class);
         $config = Mockery::mock(ConfigRepository::class);
         $router = Mockery::mock(Router::class);
@@ -651,6 +669,7 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
     public function test_warns_when_all_three_middleware_types_unused(): void
     {
+        $this->skipOnLaravel11();
         $app = Mockery::mock(Application::class);
         $config = Mockery::mock(ConfigRepository::class);
         $router = Mockery::mock(Router::class);
@@ -702,6 +721,7 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
     public function test_trust_hosts_appears_only_once_when_trust_proxies_unused(): void
     {
+        $this->skipOnLaravel11();
         $app = Mockery::mock(Application::class);
         $config = Mockery::mock(ConfigRepository::class);
         $router = Mockery::mock(Router::class);
@@ -752,6 +772,7 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
     public function test_issue_metadata_includes_all_required_fields(): void
     {
+        $this->skipOnLaravel11();
         $app = Mockery::mock(Application::class);
         $config = Mockery::mock(ConfigRepository::class);
         $router = Mockery::mock(Router::class);
@@ -805,6 +826,7 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
     public function test_result_message_format_includes_count(): void
     {
+        $this->skipOnLaravel11();
         $app = Mockery::mock(Application::class);
         $config = Mockery::mock(ConfigRepository::class);
         $router = Mockery::mock(Router::class);
@@ -890,6 +912,84 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
         foreach ($issues as $issue) {
             $this->assertEquals(\ShieldCI\AnalyzersCore\Enums\Severity::Low, $issue->severity);
         }
+    }
+
+    public function test_reports_bootstrap_app_path_on_laravel_11(): void
+    {
+        // Create a temp dir that mimics a Laravel 11+ project (no Kernel.php, has bootstrap/app.php)
+        $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'shieldci_test_'.uniqid();
+        mkdir($tempDir.DIRECTORY_SEPARATOR.'bootstrap', 0777, true);
+
+        $bootstrapAppContent = <<<'PHP'
+<?php
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(web: __DIR__.'/../routes/web.php')
+    ->withMiddleware(function (Middleware $middleware) {
+        //
+    })
+    ->create();
+PHP;
+        file_put_contents($tempDir.DIRECTORY_SEPARATOR.'bootstrap'.DIRECTORY_SEPARATOR.'app.php', $bootstrapAppContent);
+
+        $app = Mockery::mock(Application::class);
+        $config = Mockery::mock(ConfigRepository::class);
+        $router = Mockery::mock(Router::class);
+
+        $kernel = new class extends \Illuminate\Foundation\Http\Kernel
+        {
+            public function __construct() {}
+
+            /** @var array<int, string> */
+            protected $middleware = [
+                HandleCors::class,
+            ];
+        };
+
+        /** @phpstan-ignore-next-line */
+        $config->shouldReceive('get')
+            ->with('cors.paths', [])
+            ->andReturn([]);
+
+        // Use an anonymous subclass to override getBasePath() since AbstractAnalyzer
+        // doesn't expose setBasePath() — only AbstractFileAnalyzer does.
+        /** @phpstan-ignore-next-line Anonymous class with dynamic base path */
+        $analyzer = new class($app, $config, $router, $kernel, $tempDir) extends UnusedGlobalMiddlewareAnalyzer
+        {
+            public function __construct(
+                Application $app,
+                ConfigRepository $config,
+                Router $router,
+                Kernel $kernel,
+                private string $testBasePath
+            ) {
+                parent::__construct($app, $config, $router, $kernel);
+            }
+
+            protected function getBasePath(): string
+            {
+                return $this->testBasePath;
+            }
+        };
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+
+        $issue = $issues[0];
+        // File path should point to bootstrap/app.php, not a non-existent Kernel.php
+        $this->assertNotNull($issue->location);
+        $this->assertStringEndsWith('bootstrap'.DIRECTORY_SEPARATOR.'app.php', $issue->location->file);
+        // Recommendation should mention withMiddleware, not Kernel.php
+        $this->assertStringContainsString('withMiddleware', $issue->recommendation);
+        $this->assertStringNotContainsString('Kernel.php', $issue->recommendation);
+
+        // Cleanup
+        unlink($tempDir.DIRECTORY_SEPARATOR.'bootstrap'.DIRECTORY_SEPARATOR.'app.php');
+        rmdir($tempDir.DIRECTORY_SEPARATOR.'bootstrap');
+        rmdir($tempDir);
     }
 
     public function test_passes_when_mixed_used_and_unused_middleware(): void

--- a/tests/Unit/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzerTest.php
@@ -916,6 +916,10 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
     public function test_reports_bootstrap_app_path_on_laravel_11(): void
     {
+        if (! class_exists(\Illuminate\Foundation\Configuration\Middleware::class)) {
+            $this->markTestSkipped('bootstrap/app.php path and withMiddleware() recommendations only apply to Laravel 11+.');
+        }
+
         // Create a temp dir that mimics a Laravel 11+ project (no Kernel.php, has bootstrap/app.php)
         $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'shieldci_test_'.uniqid();
         mkdir($tempDir.DIRECTORY_SEPARATOR.'bootstrap', 0777, true);


### PR DESCRIPTION
## Summary

- In Laravel 11+, `TrustProxies` and `TrustHosts` are **framework-level defaults** (injected by `Illuminate\Foundation\Configuration\Middleware`), not user-registered middleware — skip those checks entirely on Laravel 11+ to eliminate false positives
- Detect Laravel 11+ via `class_exists(Illuminate\Foundation\Configuration\Middleware::class)` rather than filesystem checks (reliable across all environments including tests)
- Report issues against `bootstrap/app.php` on Laravel 11+ (not the non-existent `app/Http/Kernel.php`); fix `findMiddlewareArrayLine()` to find `withMiddleware(` in `bootstrap/app.php`
- Fix `HandleCors` recommendation text to reference `bootstrap/app.php` / `withMiddleware()` on Laravel 11+