### PR TITLE
fix: CustomErrorPageAnalyzer dynamic recommendation + config override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.5.8 - 2026-03-09
+
+### Fixed
+- `CustomErrorPageAnalyzer` recommendation now lists only the templates that are actually missing instead of always enumerating all 7 — if a project already has `404.blade.php`, it will no longer appear in the recommendation text
+
+### Changed
+- `CustomErrorPageAnalyzer` reads the required template list from `shieldci.analyzers.reliability.custom-error-pages.required_templates` config (falling back to the default 7 templates) — advanced users can override this list without modifying the published config file
+
 ## v1.5.7 - 2026-03-09
 
 ### Fixed

--- a/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
+++ b/src/Analyzers/Reliability/CustomErrorPageAnalyzer.php
@@ -64,7 +64,7 @@ class CustomErrorPageAnalyzer extends AbstractAnalyzer
         return new AnalyzerMetadata(
             id: 'custom-error-pages',
             name: 'Custom Error Pages Analyzer',
-            description: 'Checks for conventional file-based error page templates (401, 403, 404, 419, 429, 500, 503) in resources/views/errors/.',
+            description: 'Checks for conventional file-based error page templates in resources/views/errors/.',
             category: Category::Reliability,
             severity: Severity::Low,
             tags: ['errors', 'ux', 'reliability', 'security', 'fingerprinting'],
@@ -108,7 +108,7 @@ class CustomErrorPageAnalyzer extends AbstractAnalyzer
                 message: 'Custom error pages not configured for: '.implode(', ', $missing),
                 location: new Location($this->getRelativePath($resourcesViewsPath)),
                 severity: $this->metadata()->severity,
-                recommendation: $this->getCustomErrorPagesRecommendation(),
+                recommendation: $this->getCustomErrorPagesRecommendation($missing),
                 metadata: [
                     'missing_templates' => $missing,
                     'view_paths_checked' => $this->getViewPaths(),
@@ -144,17 +144,32 @@ class CustomErrorPageAnalyzer extends AbstractAnalyzer
 
     /**
      * Get recommendation message for custom error pages.
+     *
+     * @param  array<string>  $missing
      */
-    private function getCustomErrorPagesRecommendation(): string
+    private function getCustomErrorPagesRecommendation(array $missing): string
     {
-        return 'Create custom error pages for better user experience and security. '.
-               'Default Laravel error pages may reveal framework-specific branding or structure, '.
-               'allowing potential attackers to identify Laravel as your framework. '.
-               'Run "php artisan vendor:publish --tag=laravel-errors" to publish the default error views, '.
-               'then customize them. Create the following templates in resources/views/errors/: '.
-               '401.blade.php (Unauthorized), 403.blade.php (Forbidden), 404.blade.php (Not Found), '.
-               '419.blade.php (Page Expired/CSRF), 429.blade.php (Too Many Requests), '.
-               '500.blade.php (Server Error), 503.blade.php (Service Unavailable)';
+        $descriptions = [
+            '401.blade.php' => '401.blade.php (Unauthorized)',
+            '403.blade.php' => '403.blade.php (Forbidden)',
+            '404.blade.php' => '404.blade.php (Not Found)',
+            '419.blade.php' => '419.blade.php (Page Expired/CSRF)',
+            '429.blade.php' => '429.blade.php (Too Many Requests)',
+            '500.blade.php' => '500.blade.php (Server Error)',
+            '503.blade.php' => '503.blade.php (Service Unavailable)',
+        ];
+
+        $missingDescriptions = array_map(
+            fn ($t) => $descriptions[$t] ?? $t,
+            $missing
+        );
+
+        return 'Create custom error pages for better user experience and security. '
+            .'Default Laravel error pages may reveal framework-specific branding or structure, '
+            .'allowing potential attackers to identify Laravel as your framework. '
+            .'Run "php artisan vendor:publish --tag=laravel-errors" to publish the default error views, '
+            .'then customize them. Create the following missing templates in resources/views/errors/: '
+            .implode(', ', $missingDescriptions);
     }
 
     public function setStatelessOverride(?bool $stateless): void
@@ -167,16 +182,19 @@ class CustomErrorPageAnalyzer extends AbstractAnalyzer
      */
     private function missingErrorTemplates(): array
     {
-        // Common Laravel HTTP error codes that should have custom templates
-        $required = [
-            '401.blade.php', // Unauthorized (authentication required)
-            '403.blade.php', // Forbidden (authorization failed)
-            '404.blade.php', // Not Found
-            '419.blade.php', // Page Expired (CSRF token mismatch)
-            '429.blade.php', // Too Many Requests (rate limiting)
-            '500.blade.php', // Internal Server Error
-            '503.blade.php', // Service Unavailable (maintenance mode)
-        ];
+        $configured = config('shieldci.analyzers.reliability.custom-error-pages.required_templates', [
+            '401.blade.php',
+            '403.blade.php',
+            '404.blade.php',
+            '419.blade.php',
+            '429.blade.php',
+            '500.blade.php',
+            '503.blade.php',
+        ]);
+
+        $required = is_array($configured)
+            ? array_filter($configured, fn ($t) => is_string($t))
+            : [];
 
         $paths = $this->collectErrorDirectories();
 

--- a/tests/Unit/Analyzers/Reliability/CustomErrorPageAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/CustomErrorPageAnalyzerTest.php
@@ -356,6 +356,61 @@ class CustomErrorPageAnalyzerTest extends AnalyzerTestCase
     }
 
     // =========================================================================
+    // Config Override & Dynamic Recommendation Tests
+    // =========================================================================
+
+    public function test_respects_custom_required_templates_config(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            'resources/views/errors/403.blade.php' => '<html>403</html>',
+            'resources/views/errors/404.blade.php' => '<html>404</html>',
+            'resources/views/errors/500.blade.php' => '<html>500</html>',
+            'resources/views/errors/503.blade.php' => '<html>503</html>',
+        ]);
+
+        config([
+            'view.paths' => [$tempDir.'/resources/views'],
+            'shieldci.analyzers.reliability.custom-error-pages.required_templates' => [
+                '403.blade.php',
+                '404.blade.php',
+                '500.blade.php',
+                '503.blade.php',
+            ],
+        ]);
+
+        /** @var CustomErrorPageAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false);
+        $this->assertPassed($analyzer->analyze());
+    }
+
+    public function test_recommendation_lists_only_missing_templates(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            'resources/views/errors/404.blade.php' => '<html>404</html>',
+        ]);
+
+        config(['view.paths' => [$tempDir.'/resources/views']]);
+
+        /** @var CustomErrorPageAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false);
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issue = $result->getIssues()[0];
+        $recommendation = $issue->recommendation;
+
+        $this->assertStringContainsString('401.blade.php', $recommendation);
+        $this->assertStringContainsString('403.blade.php', $recommendation);
+        $this->assertStringContainsString('419.blade.php', $recommendation);
+        $this->assertStringContainsString('429.blade.php', $recommendation);
+        $this->assertStringContainsString('500.blade.php', $recommendation);
+        $this->assertStringContainsString('503.blade.php', $recommendation);
+        $this->assertStringNotContainsString('404.blade.php', $recommendation);
+    }
+
+    // =========================================================================
     // Location Validation Tests
     // =========================================================================
 


### PR DESCRIPTION
## Summary

- `CustomErrorPageAnalyzer` recommendation now lists only the templates that are actually missing — projects that already have some error pages no longer see them repeated in the fix guidance
- Required template list is now read from `shieldci.analyzers.reliability.custom-error-pages.required_templates` config (undocumented power-user override), falling back to the default 7 templates; guarded with `is_array` + `array_filter(fn($t) => is_string($t))` for PHPStan Level 9 compliance
- Analyzer metadata description no longer hardcodes the full template list