### PR TITLE
feat: support @shieldci-ignore inside multi-line docblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.9 - 2026-03-09
+
+### Added
+- `InlineSuppressionParser` now recognises `@shieldci-ignore` inside multi-line docblocks — when the line immediately above a flagged issue ends with the block-comment closing marker, the parser scans backward through the block for a matching suppression tag; this covers both standalone suppress docblocks and `@shieldci-ignore` placed inside an existing `@param`/`@return` docblock
+
 ## v1.5.8 - 2026-03-09
 
 ### Fixed

--- a/src/Support/InlineSuppressionParser.php
+++ b/src/Support/InlineSuppressionParser.php
@@ -7,9 +7,10 @@ namespace ShieldCI\Support;
 /**
  * Parses @shieldci-ignore inline comments from source files.
  *
- * Supports two placement styles (matching PHPStan conventions):
+ * Supports three placement styles (matching PHPStan conventions):
  *   - Previous line: `// @shieldci-ignore [analyzer-id,...]`
  *   - Same line:     `$code; // @shieldci-ignore [analyzer-id,...]`
+ *   - Docblock:      Multi-line block comment with @shieldci-ignore anywhere inside it
  *
  * When no analyzer IDs are specified, the suppression applies to all analyzers.
  * Multiple IDs can be comma-separated: `@shieldci-ignore sql-injection,xss-detection`
@@ -29,6 +30,9 @@ class InlineSuppressionParser
      * Checks the issue line itself and the line immediately above it for
      * a @shieldci-ignore comment that either targets all analyzers (bare)
      * or specifically names the given analyzer ID.
+     *
+     * Also handles multi-line docblocks: when the line immediately above ends
+     * with the block-comment closing marker, scans backward for @shieldci-ignore.
      */
     public function isLineSuppressed(string $filePath, int $line, string $analyzerId): bool
     {
@@ -50,6 +54,19 @@ class InlineSuppressionParser
 
             if ($this->lineHasSuppression($lines[$index], $analyzerId)) {
                 return true;
+            }
+        }
+
+        // If the line immediately above ends with */, scan backward through the block comment
+        $prevIdx = $line - 2; // 0-based index of the line immediately above the issue
+        if ($prevIdx >= 0 && isset($lines[$prevIdx]) && str_ends_with(rtrim($lines[$prevIdx]), '*/')) {
+            for ($i = $prevIdx - 1; $i >= 0 && $i >= $prevIdx - 50; $i--) {
+                if ($this->lineHasSuppression($lines[$i], $analyzerId)) {
+                    return true;
+                }
+                if (str_contains($lines[$i], '/*')) {
+                    break;
+                }
             }
         }
 

--- a/tests/Unit/Support/InlineSuppressionParserTest.php
+++ b/tests/Unit/Support/InlineSuppressionParserTest.php
@@ -257,6 +257,68 @@ PHP);
         $this->assertTrue($this->parser->isLineSuppressed($file, 3, 'sql-injection'));
     }
 
+    #[Test]
+    public function multiline_docblock_bare_suppress_works(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+/**
+ * @shieldci-ignore
+ */
+public function boot(): void {}
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 5, 'sql-injection'));
+        $this->assertTrue($this->parser->isLineSuppressed($file, 5, 'xss-detection'));
+    }
+
+    #[Test]
+    public function multiline_docblock_specific_id_suppresses_only_that_analyzer(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+/**
+ * @param string $name
+ * @return User
+ * @shieldci-ignore sql-injection
+ */
+public function getUser(string $name): User {}
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 7, 'sql-injection'));
+        $this->assertFalse($this->parser->isLineSuppressed($file, 7, 'xss-detection'));
+    }
+
+    #[Test]
+    public function multiline_docblock_non_matching_id_does_not_suppress(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+/**
+ * @shieldci-ignore sql-injection
+ */
+$result = DB::select("SELECT 1");
+PHP);
+
+        $this->assertFalse($this->parser->isLineSuppressed($file, 5, 'xss-detection'));
+    }
+
+    #[Test]
+    public function multiline_docblock_with_extra_lines_works(): void
+    {
+        $file = $this->createTempFile(<<<'PHP'
+<?php
+/**
+ * Some description here.
+ * @shieldci-ignore xss-detection
+ */
+echo $userInput;
+PHP);
+
+        $this->assertTrue($this->parser->isLineSuppressed($file, 6, 'xss-detection'));
+        $this->assertFalse($this->parser->isLineSuppressed($file, 6, 'sql-injection'));
+    }
+
     // ==========================================
     // Additional edge cases
     // ==========================================


### PR DESCRIPTION
## Summary

- `InlineSuppressionParser::isLineSuppressed` now scans backward through a multi-line block comment when the line immediately above the flagged issue ends with the closing marker (`*/`)
- Handles both standalone suppress docblocks and `@shieldci-ignore` placed anywhere inside an existing `@param`/`@return` docblock — consistent with the `@psalm-suppress` convention
- Backward scan is bounded to 50 lines and exits early on `/*` (the opening delimiter), so normal docblocks exit after 2–4 iterations