### PR TITLE
fix: eliminate ChunkMissingAnalyzer false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.10 - 2026-03-09
+
+### Fixed
+- `ChunkMissingAnalyzer` no longer false-positives when a variable name used in a `foreach` in one method matches a query-assigned variable from a different method in the same class — `$variableAssignments` is now reset on entry to each `ClassMethod`, `Function_`, `Closure`, and `ArrowFunction` scope
+- `ChunkMissingAnalyzer` no longer false-positives on `->pluck(...)->all()` chains — `pluck()` executes the query and returns an in-memory `Collection`; the subsequent `->all()` is `Collection::all()` (array conversion), not `Builder::all()`, and is now correctly treated as safe
+
 ## v1.5.9 - 2026-03-09
 
 ### Added

--- a/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
+++ b/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
@@ -92,6 +92,14 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
 
     public function enterNode(Node $node): ?Node
     {
+        // Reset variable tracking when entering a new function scope
+        if ($node instanceof Node\Stmt\ClassMethod ||
+            $node instanceof Node\Stmt\Function_ ||
+            $node instanceof Node\Expr\Closure ||
+            $node instanceof Node\Expr\ArrowFunction) {
+            $this->variableAssignments = [];
+        }
+
         // Track variable assignments with ->all() or ->get()
         if ($node instanceof Node\Expr\Assign) {
             if ($node->var instanceof Node\Expr\Variable && is_string($node->var->name)) {
@@ -180,6 +188,12 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
             'find', 'findOrFail', 'findOr', 'sole', 'soleOrFail', 'value',
         ];
         $hasSmallDatasetModifier = ! empty(array_intersect($methods, $smallDatasetMethods));
+
+        // pluck() returns an in-memory Collection; ->all() after it is Collection::all(), not a DB fetch
+        $hasPluck = in_array('pluck', $methods, true);
+        if ($hasPluck && in_array('all', $methods, true) && ! in_array('get', $methods, true)) {
+            return false;
+        }
 
         return ! $hasChunking && ! $hasSmallDatasetModifier;
     }

--- a/tests/Unit/Analyzers/BestPractices/ChunkMissingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ChunkMissingAnalyzerTest.php
@@ -768,6 +768,86 @@ PHP;
         $this->assertFailed($result);
     }
 
+    public function test_no_scope_leak_between_methods(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Project;
+
+class DashboardStatsService
+{
+    public function methodA(): void
+    {
+        // This assigns $projects from a DB query in method A
+        $projects = Project::all();
+        foreach ($projects as $project) {
+            // process
+        }
+    }
+
+    public function methodB(array $projects): void
+    {
+        // $projects here is a parameter (Collection/array), not a DB query result.
+        // The analyzer must NOT flag this foreach because methodA's assignment
+        // should not bleed into methodB's scope.
+        foreach ($projects as $project) {
+            // process
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/DashboardStatsService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // Only methodA's foreach should be flagged (the direct User::all() in the loop).
+        // methodB's foreach must NOT be flagged.
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+    }
+
+    public function test_passes_with_pluck_then_all(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Report;
+
+class ReportController
+{
+    public function index(): void
+    {
+        // pluck() executes the query and returns a Collection in memory.
+        // ->all() here is Collection::all() — converts to array, no extra DB call.
+        foreach (Report::orderBy('analyzed_at')->pluck('score', 'id')->all() as $id => $score) {
+            // process
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/ReportController.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
     public function test_grammar_singular_vs_plural(): void
     {
         // Test singular


### PR DESCRIPTION
## Summary

- **Scope leak bug**: `ChunkMissingVisitor::$variableAssignments` persisted across all methods in a file. If method A assigned `$projects = Team::with(...)->get()`, method B's `foreach ($projects as $project)` was incorrectly flagged even when `$projects` was a parameter there. Fixed by resetting `$variableAssignments = []` on entry to any function-like scope node (`ClassMethod`, `Function_`, `Closure`, `ArrowFunction`).
- **`pluck()->all()` misidentification**: A chain like `->pluck('score', 'id')->all()` was treated as `Builder::all()` because `all` appeared in the method chain. `pluck()` already executes the query and returns an in-memory `Collection`; the subsequent `->all()` is `Collection::all()` (array conversion), not a DB fetch. Fixed by returning `false` in `isFetchCollectionCall()` when `pluck` is present, `all` is present, and `get` is absent.