### PR TITLE
fix: count unique helper functions instead of total calls

### DIFF
--- a/src/Analyzers/BestPractices/HelperFunctionAbuseAnalyzer.php
+++ b/src/Analyzers/BestPractices/HelperFunctionAbuseAnalyzer.php
@@ -203,7 +203,7 @@ class HelperFunctionAbuseAnalyzer extends AbstractFileAnalyzer
 
             foreach ($visitor->getIssues() as $issue) {
                 $issues[] = $this->createIssueWithSnippet(
-                    message: "Class '{$issue['class']}' uses {$issue['count']} helper function calls (threshold: {$threshold})",
+                    message: "Class '{$issue['class']}' uses {$issue['count']} unique helper functions (threshold: {$threshold})",
                     filePath: $file,
                     lineNumber: $issue['line'],
                     severity: $this->getSeverityForCount($issue['count'], $threshold),
@@ -238,13 +238,13 @@ class HelperFunctionAbuseAnalyzer extends AbstractFileAnalyzer
     {
         $excess = $count - $threshold;
 
-        // 20+ helpers over threshold is a serious issue
-        if ($excess >= 20) {
+        // 10+ unique helpers over threshold is a serious issue
+        if ($excess >= 10) {
             return Severity::High;
         }
 
-        // 10-19 helpers over threshold is moderate
-        if ($excess >= 10) {
+        // 5-9 unique helpers over threshold is moderate
+        if ($excess >= 5) {
             return Severity::Medium;
         }
 
@@ -266,7 +266,7 @@ class HelperFunctionAbuseAnalyzer extends AbstractFileAnalyzer
         }
         $helperString = implode(', ', $helperList);
 
-        return "Class '{$class}' uses {$count} helper function calls: {$helperString}. "
+        return "Class '{$class}' uses {$count} unique helper functions: {$helperString}. "
             .'While Laravel helpers are convenient, excessive use hides dependencies and makes unit testing difficult. '
             .'Consider injecting dependencies via constructor (e.g., Config, Request, Session contracts) instead of using global helpers.';
     }
@@ -392,7 +392,7 @@ class HelperFunctionVisitor extends NodeVisitorAbstract
                 return null;
             }
 
-            $helperCount = array_sum($context['helpers']);
+            $helperCount = count($context['helpers']);
 
             if ($helperCount > $this->threshold) {
                 $this->issues[] = [

--- a/tests/Unit/Analyzers/BestPractices/HelperFunctionAbuseAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/HelperFunctionAbuseAnalyzerTest.php
@@ -177,7 +177,7 @@ class OrderService
 {
     public function store()
     {
-        // All dependency-hiding helpers (counted by default)
+        // 10 unique dependency-hiding helpers = 5 over threshold (Medium severity)
         auth()->user();
         request()->all();
         cache()->put('a', 'b');
@@ -188,12 +188,6 @@ class OrderService
         view('home');
         redirect()->back();
         response()->json([]);
-        app()->make('service');
-        abort(404);
-        dispatch(new Job());
-        resolve(Service::class);
-        validator([], []);
-        // 15 dependency-hiding helpers = 10 over threshold (Medium severity)
     }
 }
 PHP;
@@ -605,7 +599,7 @@ PHP;
         $this->assertPassed($result);
     }
 
-    public function test_helper_used_multiple_times(): void
+    public function test_helper_used_multiple_times_does_not_flag(): void
     {
         $code = <<<'PHP'
 <?php
@@ -622,7 +616,43 @@ class OrderService
         auth()->guest();
         auth()->guard('api');
         auth()->viaRemember();
-        // auth() called 6 times
+        // auth() called 6 times, but only 1 unique helper — should NOT be flagged
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/OrderService.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // 1 unique helper (auth) is well below threshold of 5 — no false positive
+        $this->assertPassed($result);
+    }
+
+    public function test_six_different_helpers_are_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class OrderService
+{
+    public function store()
+    {
+        auth()->user();
+        request()->all();
+        cache()->put('key', 'value', 3600);
+        logger()->info('Order created');
+        event(new OrderCreated());
+        session()->flash('success', 'Order created');
+        // 6 unique helpers — should be flagged
     }
 }
 PHP;
@@ -640,6 +670,9 @@ PHP;
         $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertEquals(6, $issues[0]->metadata['count']);
+        // Per-helper call counts are preserved in metadata
+        $this->assertEquals(1, $issues[0]->metadata['helpers']['auth']);
+        $this->assertEquals(1, $issues[0]->metadata['helpers']['session']);
     }
 
     public function test_empty_php_file(): void
@@ -768,7 +801,8 @@ class OrderService
         logger()->info('test');
         logger()->error('error');
         event(new OrderCreated());
-        // auth: 2, request: 1, cache: 1, logger: 2, event: 1 = 7 total
+        session()->put('a', 'b');
+        // auth: 2, request: 1, cache: 1, logger: 2, event: 1, session: 1 = 6 unique helpers
     }
 }
 PHP;
@@ -785,7 +819,9 @@ PHP;
 
         $this->assertWarning($result);
         $issues = $result->getIssues();
-        $this->assertEquals(7, $issues[0]->metadata['count']);
+        // Count reflects 6 unique helpers, not total calls
+        $this->assertEquals(6, $issues[0]->metadata['count']);
+        // Per-helper call counts are still tracked in the helpers array
         $this->assertEquals(2, $issues[0]->metadata['helpers']['auth']);
         $this->assertEquals(2, $issues[0]->metadata['helpers']['logger']);
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `array_sum($context['helpers'])` summed *total calls* across all helpers, so `config()` called 7 times counted as 7 — triggering a false positive despite being only one hidden dependency (the config system).
- **Fix**: Changed to `count($context['helpers'])` which counts distinct keys (unique helper functions used), aligning the metric with the analyzer's intent: detecting classes that depend on many *different* global helpers.
- Recalibrated severity thresholds for the unique-count scale (max ~23 distinct helpers): High at excess ≥ 10, Medium at excess ≥ 5.
- Updated all messages to say "unique helper functions" and adjusted tests accordingly.