### PR TITLE
fix: suppress @props and @aware false positives in LogicInBladeAnalyzer

### DIFF
--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -199,6 +199,13 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
                 $phpBlockLines++;
             }
 
+            // Suppress Blade component directives (@props, @aware) — they compile to
+            // framework-internal PHP (e.g. array_filter for ComponentSlot detection)
+            // that would otherwise trigger false-positive "business logic" warnings.
+            if (preg_match('/^\s*@(?:props|aware)\b/', $line)) {
+                $this->reportedLines[$lineNumber] = true;
+            }
+
             // Detect inline <?php tags
             if (preg_match('/<\?php/', $line)) {
                 $this->reportedLines[$lineNumber] = true;

--- a/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
@@ -2869,4 +2869,46 @@ BLADE;
 
         $this->assertPassed($result);
     }
+
+    public function test_passes_with_blade_props_directive(): void
+    {
+        $blade = <<<'BLADE'
+@props(['url'])
+<tr>
+<td class="header">
+<a href="{{ $url }}" style="display: inline-block;">
+<img src="{{ asset('images/logo.png') }}" alt="{{ config('app.name') }}">
+</a>
+</td>
+</tr>
+BLADE;
+
+        $tempDir = $this->createTempDirectory(['views/mail/header.blade.php' => $blade]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['views']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_with_blade_aware_directive(): void
+    {
+        $blade = <<<'BLADE'
+@aware(['color' => 'gray'])
+<div>{{ $color }}</div>
+BLADE;
+
+        $tempDir = $this->createTempDirectory(['views/component.blade.php' => $blade]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['views']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
 }


### PR DESCRIPTION
## Summary
- `@props` and `@aware` Blade component directives compile to framework-internal PHP containing `array_filter` (used for `ComponentSlot` detection), which `LogicInBladeAnalyzer` was incorrectly flagging as "business logic found in Blade directive"
- Fix marks these directive lines in `reportedLines` during Pass 1 so Pass 2 (AST compilation) silently skips them
- Adds two regression tests covering `@props` (mail header pattern) and `@aware`