### PR TITLE
fix: suppress guard clause false positives in MissingDatabaseTransactionsAnalyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.12 - 2026-03-10
+
+### Fixed
+- `MissingDatabaseTransactionsAnalyzer` no longer false-positives on guard clause patterns — an `if`-block with no `else`/`elseif` whose last statement is `return` or `throw` is now recognised as a guard clause; writes inside it are isolated (they exist on execution paths that always terminate before reaching the main flow) and are excluded from the atomicity threshold check; fixes false positives like a guard clause deleting a record before a properly-wrapped `DB::transaction()`
+
 ## v1.5.11 - 2026-03-10
 
 ### Added

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -141,12 +141,23 @@ class TransactionVisitor extends NodeVisitorAbstract
 
     private int $manualTransactionDepth = 0;
 
+    private int $isolatedWrites = 0;
+
+    private int $earlyExitIfDepth = 0;
+
     /**
      * Track file positions of closures passed directly to DB::transaction().
      *
      * @var array<int, true>
      */
     private array $transactionClosurePositions = [];
+
+    /**
+     * Track file start positions of guard-clause if-blocks.
+     *
+     * @var array<int, true>
+     */
+    private array $earlyExitIfPositions = [];
 
     public function __construct(
         private int $threshold
@@ -168,7 +179,10 @@ class TransactionVisitor extends NodeVisitorAbstract
             $this->unprotectedWriteLines = [];
             $this->transactionDepth = 0;
             $this->manualTransactionDepth = 0;
+            $this->isolatedWrites = 0;
+            $this->earlyExitIfDepth = 0;
             $this->transactionClosurePositions = [];
+            $this->earlyExitIfPositions = [];
         }
 
         // Check for DB::transaction or DB::beginTransaction
@@ -206,6 +220,12 @@ class TransactionVisitor extends NodeVisitorAbstract
             }
         }
 
+        // Track guard clause if-blocks (early-exit ifs with no else)
+        if ($node instanceof Node\Stmt\If_ && $this->isGuardClauseIf($node)) {
+            $this->earlyExitIfPositions[$node->getStartFilePos()] = true;
+            $this->earlyExitIfDepth++;
+        }
+
         // Detect write operations
         if ($this->isWriteOperation($node)) {
             $this->writeOperations++;
@@ -216,6 +236,8 @@ class TransactionVisitor extends NodeVisitorAbstract
             // 2. After DB::beginTransaction() was called (with or without try-catch)
             if ($this->transactionDepth > 0 || $this->manualTransactionDepth > 0) {
                 $this->writeOperationsInTransaction++;
+            } elseif ($this->earlyExitIfDepth > 0) {
+                $this->isolatedWrites++;
             } else {
                 $this->unprotectedWriteLines[] = $node->getLine();
             }
@@ -234,24 +256,35 @@ class TransactionVisitor extends NodeVisitorAbstract
             }
         }
 
+        // Decrement guard clause depth when leaving an early-exit if-block
+        if ($node instanceof Node\Stmt\If_) {
+            $pos = $node->getStartFilePos();
+            if (isset($this->earlyExitIfPositions[$pos])) {
+                $this->earlyExitIfDepth--;
+                unset($this->earlyExitIfPositions[$pos]);
+            }
+        }
+
         // When leaving a method, check if we need transactions
         if ($node instanceof Node\Stmt\ClassMethod) {
-            // Calculate unprotected writes (writes outside transaction scope)
-            $unprotectedWrites = $this->writeOperations - $this->writeOperationsInTransaction;
+            // Isolated writes are in guard clauses (early-exit branches) that can never
+            // co-execute with writes in the main flow, so exclude them from the threshold.
+            $mainFlowWrites = $this->writeOperations - $this->isolatedWrites;
+            $mainFlowUnprotected = $mainFlowWrites - $this->writeOperationsInTransaction;
 
-            // If all writes are protected, no issue
-            if ($unprotectedWrites === 0) {
+            // If all main-flow writes are protected, no issue
+            if ($mainFlowUnprotected <= 0) {
                 return null;
             }
 
-            // If total writes >= threshold, ALL should be protected
-            if ($this->writeOperations >= $this->threshold) {
+            // If main-flow writes >= threshold, they should be protected
+            if ($mainFlowWrites >= $this->threshold) {
                 $this->issues[] = [
                     'message' => sprintf(
                         'Method "%s::%s()" has %d database write operation(s) outside transaction protection',
                         $this->currentClassName ?? 'Unknown',
                         $this->currentMethodName ?? 'unknown',
-                        $unprotectedWrites
+                        $mainFlowUnprotected
                     ),
                     'line' => $this->methodStartLine,
                     'severity' => Severity::High,
@@ -429,5 +462,28 @@ class TransactionVisitor extends NodeVisitorAbstract
         }
 
         return false;
+    }
+
+    /**
+     * A "guard clause" if is one whose body always terminates (return/throw),
+     * with no else or elseif branches. Writes inside are isolated and can never
+     * co-execute with writes in the main flow.
+     */
+    private function isGuardClauseIf(Node\Stmt\If_ $node): bool
+    {
+        if (! empty($node->elseifs) || $node->else !== null) {
+            return false;
+        }
+        if (empty($node->stmts)) {
+            return false;
+        }
+        $last = end($node->stmts);
+
+        // PHP-Parser 5.x: throw is an expression (Node\Expr\Throw_) wrapped in Node\Stmt\Expression
+        if ($last instanceof Node\Stmt\Expression && $last->expr instanceof Node\Expr\Throw_) {
+            return true;
+        }
+
+        return $last instanceof Node\Stmt\Return_ || $last instanceof Node\Stmt\Throw_;
     }
 }

--- a/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
@@ -1547,4 +1547,127 @@ PHP;
         $this->assertFailed($result);
         $this->assertHasIssueContaining('1 database write operation', $result);
     }
+
+    public function test_passes_with_guard_clause_delete_before_transaction(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Http\Controllers;
+use App\Models\Team;
+use App\Models\Invitation;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+class InvitationController
+{
+    public function accept(Request $request, string $token): mixed
+    {
+        $invitation = Invitation::where('token', $token)->first();
+        $team = $invitation->team;
+
+        // Guard clause: isolated write, always returns immediately after
+        if ($team->hasUser($request->user())) {
+            $invitation->delete();
+            return redirect()->route('dashboard');
+        }
+
+        // Main flow: properly wrapped in transaction
+        DB::transaction(function () use ($request, $team, $invitation): void {
+            $team->addMember($request->user(), $invitation->role);
+            $invitation->delete();
+        });
+
+        return redirect()->route('teams.show', $team);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Http/Controllers/InvitationController.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_fails_when_guard_clause_has_else_branch(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Http\Controllers;
+use App\Models\Team;
+use App\Models\Invitation;
+use Illuminate\Http\Request;
+class InvitationController
+{
+    public function accept(Request $request, string $token): mixed
+    {
+        $invitation = Invitation::where('token', $token)->first();
+        $team = $invitation->team;
+
+        // NOT a guard clause: has an else branch, so both paths continue
+        if ($team->hasUser($request->user())) {
+            $invitation->delete();
+            return redirect()->route('dashboard');
+        } else {
+            $invitation->delete();
+        }
+
+        $team->save();
+
+        return redirect()->route('teams.show', $team);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Http/Controllers/InvitationController.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+    }
+
+    public function test_passes_with_guard_clause_throw_before_transaction(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Services;
+use App\Models\Order;
+use Illuminate\Support\Facades\DB;
+class OrderService
+{
+    public function process(int $id): void
+    {
+        $order = Order::find($id);
+
+        // Guard clause using throw — isolated write
+        if ($order->isPaid()) {
+            $order->delete();
+            throw new \RuntimeException('Order already paid');
+        }
+
+        DB::transaction(function () use ($order): void {
+            $order->markPaid();
+            $order->save();
+        });
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/OrderService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
 }


### PR DESCRIPTION
## Summary

- Detects pure guard clause `if`-blocks (no `else`/`elseif`, last statement is `return` or `throw`) and classifies their writes as *isolated* — they exist on execution paths that always terminate before reaching the main flow
- Excludes isolated writes from the atomicity threshold check, fixing false positives like `InvitationAcceptController::accept()` where a guard clause deletes an invitation before a properly-wrapped `DB::transaction()`
- Handles PHP-Parser 5.x `throw`-as-expression (`Node\Expr\Throw_` inside `Node\Stmt\Expression`) alongside legacy `Node\Stmt\Throw_`
- Adds 3 regression tests covering: guard clause + return, guard clause + throw, and `if/else` (correctly still flagged)