### PR TITLE
fix: report QB call line for mixed Eloquent/QB issues instead of Eloquent call line

### DIFF
--- a/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
+++ b/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
@@ -616,8 +616,10 @@ class MixedQueryVisitor extends NodeVisitorAbstract
 
                             // Check if table already tracked as eloquent
                             if (isset($this->tableUsage[$tableName]) && $this->tableUsage[$tableName]['type'] === 'eloquent') {
-                                // Mark as mixed
-                                $this->tableUsage[$tableName]['type'] = 'mixed';
+                                $this->tableUsage[$tableName] = [
+                                    'type' => 'mixed',
+                                    'line' => $node->getLine(),
+                                ];
                             } else {
                                 $this->tableUsage[$tableName] = [
                                     'type' => 'query_builder',
@@ -665,8 +667,10 @@ class MixedQueryVisitor extends NodeVisitorAbstract
             $tableName = explode(' ', $tableName)[0];
             // Check if table already tracked as eloquent
             if (isset($this->tableUsage[$tableName]) && $this->tableUsage[$tableName]['type'] === 'eloquent') {
-                // Mark as mixed by changing type
-                $this->tableUsage[$tableName]['type'] = 'mixed';
+                $this->tableUsage[$tableName] = [
+                    'type' => 'mixed',
+                    'line' => $node->getLine(),
+                ];
             } else {
                 $this->tableUsage[$tableName] = [
                     'type' => 'query_builder',

--- a/tests/Unit/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzerTest.php
@@ -2204,4 +2204,77 @@ PHP;
         $this->assertFailed($result);
         $this->assertHasIssueContaining('both Eloquent and Query Builder', $result);
     }
+
+    public function test_mixed_usage_reports_line_of_query_builder_call(): void
+    {
+        $dir = $this->createTempDirectory([
+            'app/Models/Post.php' => '<?php namespace App\Models; use Illuminate\Database\Eloquent\Model; class Post extends Model {}',
+            'app/Repositories/PostRepository.php' => '<?php
+namespace App\Repositories;
+use App\Models\Post;
+use Illuminate\Support\Facades\DB;
+
+class PostRepository
+{
+    public function summary(): array
+    {
+        $count = Post::count();
+        $raw = DB::table(\'posts\')->value(\'legacy_col\');
+        return [$count, $raw];
+    }
+}',
+        ]);
+
+        $analyzer = $this->createAnalyzer([
+            'model_paths' => ['app/Models'],
+        ]);
+        $analyzer->setBasePath($dir);
+        $analyzer->setPaths(['app/Repositories']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertNotEmpty($issues);
+
+        // The issue should point to the DB::table() call (line 11), not Post::count() (line 10)
+        $this->assertNotNull($issues[0]->location);
+        $this->assertSame(11, $issues[0]->location->line);
+    }
+
+    public function test_tobase_mixed_usage_reports_line_of_tobase_call(): void
+    {
+        $dir = $this->createTempDirectory([
+            'app/Models/Order.php' => '<?php namespace App\Models; use Illuminate\Database\Eloquent\Model; class Order extends Model {}',
+            'app/Services/OrderService.php' => '<?php
+namespace App\Services;
+use App\Models\Order;
+
+class OrderService
+{
+    public function process(): void
+    {
+        $count = Order::count();
+        $qb = Order::query()->toBase();
+    }
+}',
+        ]);
+
+        $analyzer = $this->createAnalyzer([
+            'model_paths' => ['app/Models'],
+            'treat_tobase_as_query_builder' => true,
+        ]);
+        $analyzer->setBasePath($dir);
+        $analyzer->setPaths(['app/Services']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertNotEmpty($issues);
+
+        // The issue should point to the toBase() call (line 10), not Order::count() (line 9)
+        $this->assertNotNull($issues[0]->location);
+        $this->assertSame(10, $issues[0]->location->line);
+    }
 }


### PR DESCRIPTION
## Summary

- Fix `trackDbTableCall()` to overwrite `line` when upgrading a table entry from `'eloquent'` → `'mixed'`, so the issue points to the `DB::table()` call rather than the earlier Eloquent call
- Fix `leaveNode()` toBase/getQuery path with the same correction for `Model::query()->toBase()` chains
- Add two new regression tests covering each fix path