### PR TITLE
fix: suppress ServiceContainerResolution false positives for Eloquent, ShouldQueue, and service providers

### DIFF
--- a/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
+++ b/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
@@ -31,13 +31,20 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  * - app()->bind() / singleton() outside service providers
  * - Recommends constructor injection
  *
- * Whitelisted contexts (where manual resolution is legitimate):
+ * Suppressed contexts (where app() is the only viable pattern):
+ * - Service Providers: Bootstrap infrastructure where app() is always intentional.
+ *   ALL resolution across all methods (boot, register, private helpers) is suppressed.
+ *   Binding detection (bind/singleton/instance/scoped) outside service providers is
+ *   still flagged at High severity.
+ * - ShouldQueue classes: PHP's serialize/unserialize flow bypasses __construct, so
+ *   constructor-injected services would be null after deserialization. app() in methods
+ *   like via() is the canonical Laravel pattern.
+ * - Eloquent models: Created via newInstance() / new static(), bypassing any constructor
+ *   signature. Constructor DI is impractical.
  * - Migrations: Don't support constructor DI, must use app() helper
  * - Seeders: Often need dynamic service resolution
  * - Factories: May need service resolution for test data
  * - Commands: Sometimes need conditional service resolution
- * - Service Providers: Bindings (bind/singleton/instance/scoped) are skipped as legitimate;
- *   resolution (make/resolve/app()) is still flagged as a code smell
  * - Jobs: Queued jobs may need conditional resolution
  * - Listeners: Event listeners with conditional dependencies
  * - Middleware: Conditional resolution based on request context
@@ -70,6 +77,17 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
         'Illuminate\\Foundation\\Support\\Providers\\RouteServiceProvider',
         'Illuminate\\Foundation\\Support\\Providers\\EventServiceProvider',
         'Illuminate\\Foundation\\Support\\Providers\\AuthServiceProvider',
+    ];
+
+    /**
+     * Known Eloquent base model FQNs.
+     *
+     * @var array<string>
+     */
+    private const ELOQUENT_MODEL_CLASSES = [
+        'Illuminate\\Database\\Eloquent\\Model',
+        'Illuminate\\Foundation\\Auth\\User',
+        'Illuminate\\Database\\Eloquent\\Relations\\Pivot',
     ];
 
     /** @var array<string> */
@@ -280,8 +298,9 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
                 continue;
             }
 
-            // Service providers: skip binding detection (legitimate) but still flag resolution
             $isServiceProvider = $this->isServiceProviderFromAst($ast, $file);
+            $isEloquentModel = $this->isEloquentModelFromAst($ast);
+            $isShouldQueue = $this->isShouldQueueFromAst($ast);
 
             $visitor = new ServiceContainerVisitor(
                 $this->whitelistClasses,
@@ -291,23 +310,27 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
                 $this->detectManualInstantiation,
                 $this->manualInstantiationPatterns,
                 $this->manualInstantiationExcludePatterns,
-                $isServiceProvider
+                $isServiceProvider,
+                $isEloquentModel,
+                $isShouldQueue
             );
             $traverser = new NodeTraverser;
             $traverser->addVisitor($visitor);
             $traverser->traverse($ast);
 
+            $relativePath = $this->getRelativePath($file);
+
             foreach ($visitor->getIssues() as $issue) {
                 $issues[] = $this->createIssue(
                     message: "Manual service resolution in '{$issue['location']}': {$issue['pattern']}",
-                    location: new Location($file, $issue['line']),
+                    location: new Location($relativePath, $issue['line']),
                     severity: $issue['severity'],
                     recommendation: $this->getRecommendation($issue['pattern'], $issue['location'], $issue['argument_type'] ?? 'unknown', $issue['in_closure']),
                     metadata: [
                         'pattern' => $issue['pattern'],
                         'location' => $issue['location'],
                         'class' => $issue['class'],
-                        'file' => $file,
+                        'file' => $relativePath,
                         'argument_type' => $issue['argument_type'] ?? 'unknown',
                     ]
                 );
@@ -424,6 +447,123 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
+     * Check if AST represents an Eloquent model by checking class extends.
+     *
+     * Uses the same CloningVisitor + NameResolver pattern as isServiceProviderFromAst
+     * to resolve class names to FQN before checking.
+     *
+     * @param  array<Node>  $ast
+     */
+    private function isEloquentModelFromAst(array $ast): bool
+    {
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor(new CloningVisitor);
+        $traverser->addVisitor(new NameResolver);
+        $resolvedAst = $traverser->traverse($ast);
+
+        foreach ($resolvedAst as $node) {
+            if ($node instanceof Stmt\Namespace_) {
+                foreach ($node->stmts as $stmt) {
+                    if ($stmt instanceof Stmt\Class_ && $this->extendsEloquentModel($stmt)) {
+                        return true;
+                    }
+                }
+            } elseif ($node instanceof Stmt\Class_ && $this->extendsEloquentModel($node)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if class extends an Eloquent Model.
+     *
+     * After NameResolver has been applied, parent class names should be FQN.
+     * We check against known Eloquent model FQNs and common base model patterns.
+     */
+    private function extendsEloquentModel(Stmt\Class_ $class): bool
+    {
+        if ($class->extends === null) {
+            return false;
+        }
+
+        $parent = ltrim($class->extends->toString(), '\\');
+
+        // Direct FQN match against known Eloquent model classes
+        if (in_array($parent, self::ELOQUENT_MODEL_CLASSES, true)) {
+            return true;
+        }
+
+        // FQN ends with \Model (namespace separator required)
+        // This catches custom base models like App\Models\BaseModel
+        if (str_ends_with($parent, '\\Model')) {
+            return true;
+        }
+
+        // Illuminate namespace models (any Illuminate-based model)
+        if (str_starts_with($parent, 'Illuminate\\') && str_ends_with($parent, 'Model')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if AST represents a ShouldQueue class by checking class implements.
+     *
+     * Uses the same CloningVisitor + NameResolver pattern as isServiceProviderFromAst
+     * to resolve interface names to FQN before checking.
+     *
+     * @param  array<Node>  $ast
+     */
+    private function isShouldQueueFromAst(array $ast): bool
+    {
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor(new CloningVisitor);
+        $traverser->addVisitor(new NameResolver);
+        $resolvedAst = $traverser->traverse($ast);
+
+        foreach ($resolvedAst as $node) {
+            if ($node instanceof Stmt\Namespace_) {
+                foreach ($node->stmts as $stmt) {
+                    if ($stmt instanceof Stmt\Class_ && $this->implementsShouldQueue($stmt)) {
+                        return true;
+                    }
+                }
+            } elseif ($node instanceof Stmt\Class_ && $this->implementsShouldQueue($node)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if class implements ShouldQueue.
+     *
+     * After NameResolver has been applied, interface names should be FQN.
+     * We match against the canonical FQN and any interface ending with \ShouldQueue.
+     */
+    private function implementsShouldQueue(Stmt\Class_ $class): bool
+    {
+        foreach ($class->implements as $interface) {
+            $name = ltrim($interface->toString(), '\\');
+
+            if ($name === 'Illuminate\\Contracts\\Queue\\ShouldQueue') {
+                return true;
+            }
+
+            // Catches custom ShouldQueue contracts (e.g. App\Contracts\ShouldQueue)
+            if (str_ends_with($name, '\\ShouldQueue')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Get recommendation for container resolution.
      */
     private function getRecommendation(string $pattern, string $location, string $argumentType, bool $inClosure = false): string
@@ -519,7 +659,9 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
         private bool $detectManualInstantiation = false,
         private array $manualInstantiationPatterns = [],
         private array $manualInstantiationExcludePatterns = [],
-        private bool $isServiceProvider = false
+        private bool $isServiceProvider = false,
+        private bool $isEloquentModel = false,
+        private bool $isShouldQueue = false
     ) {}
 
     public function enterNode(Node $node)
@@ -554,6 +696,24 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
 
         // Skip if class is whitelisted
         if ($this->isWhitelistedClass()) {
+            return null;
+        }
+
+        // Eloquent models: instantiated via newInstance() / new static(), constructor DI is impractical
+        if ($this->isEloquentModel) {
+            return null;
+        }
+
+        // ShouldQueue classes: serialize/unserialize bypasses __construct, DI isn't viable
+        if ($this->isShouldQueue) {
+            return null;
+        }
+
+        // Service providers: bootstrap infrastructure where app() is always intentional.
+        // Suppresses ALL resolution across all methods (boot, register, private helpers).
+        // Binding detection (bind/singleton/instance/scoped) outside service providers is
+        // still flagged via the ! $this->isServiceProvider guards further below.
+        if ($this->isServiceProvider) {
             return null;
         }
 

--- a/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
@@ -376,7 +376,7 @@ PHP;
         $this->assertSame(Severity::High, $issues[0]->severity);
     }
 
-    public function test_service_provider_skips_binding_but_flags_resolution(): void
+    public function test_service_provider_skips_binding_and_resolution(): void
     {
         $code = <<<'PHP'
 <?php
@@ -406,11 +406,8 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // Bindings (bind, singleton) should be skipped, but resolution (app()->make()) should be flagged
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertHasIssueContaining('app()->make()', $result);
+        // All app() usage in service providers is suppressed — bindings and resolution alike
+        $this->assertPassed($result);
     }
 
     public function test_skips_whitelisted_directory_tests(): void
@@ -1515,7 +1512,7 @@ PHP;
         $this->assertHasIssueContaining('app()', $result);
     }
 
-    public function test_route_service_provider_closure_resolution_reported_as_low(): void
+    public function test_route_service_provider_closure_resolution_suppressed(): void
     {
         $code = <<<'PHP'
 <?php
@@ -1546,14 +1543,11 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // Resolution in closure with string argument gets Medium severity
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertSame(Severity::Medium, $issues[0]->severity);
+        // All resolution in service providers (including closures) is suppressed
+        $this->assertPassed($result);
     }
 
-    public function test_event_service_provider_closure_resolution_reported_as_low(): void
+    public function test_event_service_provider_closure_resolution_suppressed(): void
     {
         $code = <<<'PHP'
 <?php
@@ -1586,11 +1580,8 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // Bindings are skipped (service provider), resolution in closure with string arg is Medium
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertSame(Severity::Medium, $issues[0]->severity);
+        // All resolution in service providers (including closures) is suppressed
+        $this->assertPassed($result);
     }
 
     public function test_closure_string_resolution_gets_medium_severity(): void
@@ -1816,7 +1807,7 @@ PHP;
 
     public function test_correctly_skips_real_service_provider_with_use(): void
     {
-        // Real service provider with use statement
+        // Real service provider with use statement — all app() usage is suppressed
         $code = <<<'PHP'
 <?php
 
@@ -1848,11 +1839,8 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // Binding in register() should be skipped, but app() resolution in boot() should be flagged
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertHasIssueContaining('app()', $result);
+        // All app() in service providers (bindings and resolution) is suppressed
+        $this->assertPassed($result);
     }
 
     public function test_service_provider_with_only_bindings_passes(): void
@@ -1890,7 +1878,7 @@ PHP;
         $this->assertPassed($result);
     }
 
-    public function test_service_provider_resolution_in_closure_reported_as_low(): void
+    public function test_service_provider_resolution_in_closure_suppressed(): void
     {
         $code = <<<'PHP'
 <?php
@@ -1904,7 +1892,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->resolving(SomeService::class, function ($service) {
-            // Resolution inside closure is reported at Low severity
+            // Resolution inside closure is suppressed for service providers
             $config = app(ConfigManager::class);
             $service->setConfig($config);
         });
@@ -1922,11 +1910,8 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // Resolution inside closure is now reported at Low severity
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertSame(Severity::Low, $issues[0]->severity);
+        // All resolution in service providers is suppressed
+        $this->assertPassed($result);
     }
 
     // ============================================================
@@ -2522,5 +2507,228 @@ PHP;
         // Should fail - PaymentService matches *Service and no exclusion
         $this->assertWarning($result);
         $this->assertHasIssueContaining('new PaymentService()', $result);
+    }
+
+    // ============================================================
+    // TESTS FOR ELOQUENT MODEL SUPPRESSION
+    // ============================================================
+
+    public function test_eloquent_model_resolution_is_suppressed(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    public function getSomeAttribute()
+    {
+        $service = app(SomeService::class);
+        return $service->compute($this->value);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/Post.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Eloquent models bypass __construct via newInstance(), so app() is suppressed
+        $this->assertPassed($result);
+    }
+
+    public function test_eloquent_model_custom_base_class_suppressed(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use App\Domain\Model;
+
+class User extends Model
+{
+    public function getProfileUrl()
+    {
+        $helper = app(UrlHelper::class);
+        return $helper->generate($this->id);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/User.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Custom base class whose FQN ends with \Model is also suppressed
+        $this->assertPassed($result);
+    }
+
+    // ============================================================
+    // TESTS FOR SHOULD_QUEUE SUPPRESSION
+    // ============================================================
+
+    public function test_should_queue_resolution_suppressed(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class ProcessPayment implements ShouldQueue
+{
+    public function via()
+    {
+        $config = app(\Illuminate\Config\Repository::class);
+        return $config->get('queue.default');
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Jobs/ProcessPayment.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // ShouldQueue classes: serialize/unserialize bypasses __construct, app() is suppressed
+        $this->assertPassed($result);
+    }
+
+    public function test_should_queue_with_use_statement_suppressed(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendWelcomeEmail implements ShouldQueue
+{
+    public function handle()
+    {
+        $mailer = app('mailer');
+        $mailer->send('welcome', [], fn ($m) => $m->to('test@example.com'));
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Jobs/SendWelcomeEmail.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // ShouldQueue via use statement is still detected and suppressed
+        $this->assertPassed($result);
+    }
+
+    // ============================================================
+    // TESTS FOR SERVICE PROVIDER FULL SUPPRESSION
+    // ============================================================
+
+    public function test_service_provider_resolution_fully_suppressed(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $multiplier = $this->getRestApiMultiplier();
+        $this->app->singleton('api.limiter', fn () => new RateLimiter($multiplier));
+    }
+
+    public function register()
+    {
+        $repo = app(ConfigRepository::class);
+        $this->app->bind(ConfigInterface::class, fn () => $repo);
+    }
+
+    private function getRestApiMultiplier(): int
+    {
+        $config = app('config');
+        return (int) $config->get('api.rate_multiplier', 1);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Providers/AppServiceProvider.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // All app() in service providers (boot, register, private helpers) is suppressed
+        $this->assertPassed($result);
+    }
+
+    public function test_service_provider_binding_outside_sp_still_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class SetupService
+{
+    public function configure()
+    {
+        app()->bind(SomeInterface::class, SomeImplementation::class);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/SetupService.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Bindings outside service providers are still flagged at High severity
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        $this->assertSame(Severity::High, $issues[0]->severity);
+        $this->assertHasIssueContaining('app()->bind()', $result);
     }
 }


### PR DESCRIPTION
## Summary

- **Eloquent models**: suppress all `app()` detection — models are instantiated via `newInstance()`/`new static()`, making constructor DI impractical
- **ShouldQueue classes**: suppress detection — PHP's serialize/unserialize flow bypasses `__construct`, so `app()` in methods like `via()` is the canonical Laravel pattern
- **Service providers**: suppress ALL resolution (not just bindings) — `boot()` and private helper methods called from it are bootstrap infrastructure where `app()` is always intentional
- **Fix absolute paths**: issue `location` and `file` metadata now use `getRelativePath()` consistently with all other analyzers
- Update 3 tests that expected SP resolution to be flagged; add 6 new suppression tests covering all new contexts