### PR TITLE
fix: remove false-positive Low severity broad catch issues from SilentFailureAnalyzer

### DIFF
--- a/src/Analyzers/BestPractices/SilentFailureAnalyzer.php
+++ b/src/Analyzers/BestPractices/SilentFailureAnalyzer.php
@@ -297,7 +297,7 @@ class SilentFailureVisitor extends NodeVisitorAbstract
                     // Severity depends on how well the developer handles the exception:
                     //   High   — no logging at all (genuinely silent failure)
                     //   Medium — logging present but exception variable unused (details lost)
-                    //   Low    — logging + uses exception variable (architectural note)
+                    //   (hasLogging && usesVar) → acceptable handling, no issue added
                     $addedBroadIssue = false;
                     $broadInfo = $this->getBroadExceptionInfo($catch->types);
                     if ($broadInfo['isBroad'] && ! $hasRethrow) {
@@ -305,24 +305,25 @@ class SilentFailureVisitor extends NodeVisitorAbstract
                         $usesVar = $this->usesExceptionVariable($catch->stmts, $exceptionVarName);
 
                         if (! $hasLogging) {
-                            $broadSeverity = Severity::High;
-                            $broadRecommendation = "Catch specific exception types instead of {$broadTypeStr}. Broad catches hide programming errors like TypeError, ArgumentCountError";
+                            $this->issues[] = [
+                                'message' => "Catching {$broadTypeStr} is overly broad and can mask fatal errors",
+                                'line' => $catch->getLine(),
+                                'severity' => Severity::High,
+                                'recommendation' => "Catch specific exception types instead of {$broadTypeStr}. Broad catches hide programming errors like TypeError, ArgumentCountError",
+                                'code' => null,
+                            ];
+                            $addedBroadIssue = true;
                         } elseif (! $usesVar) {
-                            $broadSeverity = Severity::Medium;
-                            $broadRecommendation = "Catch specific exception types instead of {$broadTypeStr}. Also include the exception variable in your log call to preserve debugging context";
-                        } else {
-                            $broadSeverity = Severity::Low;
-                            $broadRecommendation = "Consider catching specific exception types instead of {$broadTypeStr}. Broad catches can hide programming errors even when logged";
+                            $this->issues[] = [
+                                'message' => "Catching {$broadTypeStr} is overly broad and can mask fatal errors",
+                                'line' => $catch->getLine(),
+                                'severity' => Severity::Medium,
+                                'recommendation' => "Catch specific exception types instead of {$broadTypeStr}. Also include the exception variable in your log call to preserve debugging context",
+                                'code' => null,
+                            ];
+                            $addedBroadIssue = true;
                         }
-
-                        $this->issues[] = [
-                            'message' => "Catching {$broadTypeStr} is overly broad and can mask fatal errors",
-                            'line' => $catch->getLine(),
-                            'severity' => $broadSeverity,
-                            'recommendation' => $broadRecommendation,
-                            'code' => null,
-                        ];
-                        $addedBroadIssue = true;
+                        // else: hasLogging && usesVar → well-handled broad catch, no issue added
                     }
 
                     // Exception variable usage only counts as "handling" when combined with logging/rethrow/fallback

--- a/tests/Unit/Analyzers/BestPractices/SilentFailureAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/SilentFailureAnalyzerTest.php
@@ -3043,7 +3043,7 @@ PHP;
     // BUG 3: BROAD EXCEPTION TYPE DETECTION TESTS
     // ========================================================================
 
-    public function test_broad_catch_throwable_with_logging_and_exception_var_is_low_severity(): void
+    public function test_broad_catch_with_logging_and_exception_var_is_not_flagged(): void
     {
         $code = <<<'PHP'
 <?php
@@ -3074,16 +3074,12 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // Broad catch with logging + uses $e → Low severity (architectural note), Warning status
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $broadIssue = collect($issues)->first(fn ($i) => str_contains($i->message, 'Throwable'));
-        $this->assertNotNull($broadIssue);
-        $this->assertSame(\ShieldCI\AnalyzersCore\Enums\Severity::Low, $broadIssue->severity);
-        $this->assertStringContainsString('Consider catching', $broadIssue->recommendation);
+        // Broad catch with logging + uses $e → well-handled, no issue added
+        $this->assertPassed($result);
+        $this->assertEmpty($result->getIssues());
     }
 
-    public function test_broad_catch_exception_with_logging_and_exception_var_is_low_severity(): void
+    public function test_broad_catch_exception_with_logging_and_exception_var_is_not_flagged(): void
     {
         $code = <<<'PHP'
 <?php
@@ -3114,12 +3110,45 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // Broad catch with logging + uses $e → Low severity (architectural note), Warning status
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertSame(\ShieldCI\AnalyzersCore\Enums\Severity::Low, $issues[0]->severity);
-        $this->assertStringContainsString('Consider catching', $issues[0]->recommendation);
+        // Broad catch with logging + uses $e → well-handled, no issue added
+        $this->assertPassed($result);
+        $this->assertEmpty($result->getIssues());
+    }
+
+    public function test_broad_catch_with_logging_and_mark_as_failed_is_not_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Support\Facades\Log;
+
+class PostGitHubCheckJob
+{
+    public function handle()
+    {
+        try {
+            $this->doWork();
+        } catch (\Throwable $e) {
+            Log::error('Job failed', ['error' => $e->getMessage()]);
+            $check->markAsFailed($e->getMessage());
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Jobs/PostGitHubCheckJob.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // Log::error + markAsFailed + $e → hasLogging && usesVar → no issue added
+        $this->assertPassed($result);
+        $this->assertEmpty($result->getIssues());
     }
 
     public function test_passes_catch_throwable_with_rethrow(): void


### PR DESCRIPTION
## Summary

- Removes the Low severity tier from broad exception catch detection in `SilentFailureAnalyzer`
- When a broad catch (`\Throwable`/`\Exception`/`\Error`) has both logging **and** uses the exception variable, it is now treated as acceptable handling — no issue is added
- High severity (no logging) and Medium severity (logging but `$e` unused) are retained unchanged
- Updates two existing tests that asserted Low severity to assert `assertPassed` + `assertEmpty` instead
- Adds one new test covering the `Log::error` + `$check->markAsFailed($e->getMessage())` pattern

## False positives fixed

| Pattern | Previous severity | New behaviour |
|---------|------------------|---------------|
| `catch (\Throwable $e) { Log::error(...); }` | Low | Not flagged |
| `catch (\Exception $e) { Log::warning(..., ['error' => $e->getMessage()]); }` | Low | Not flagged |
| `catch (\Throwable $e) { Log::error(...); $check->markAsFailed($e->getMessage()); }` | Low | Not flagged |