### PR TITLE
fix: disable 4 analyzers in CI that check environment-dependent state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.14
+
+### Changed
+- `EnvFileAnalyzer`, `FilePermissionsAnalyzer`, `CachePrefixAnalyzer`, and `DirectoryWritePermissionsAnalyzer` now set `runInCI = false` — these analyzers check conditions that depend on CI runner environment setup (`.env` presence/permissions, filesystem permission bits, shared cache server prefix, storage symlinks) rather than developer-controlled code, so they are not meaningful in CI and are skipped when `--ci` is passed
+
 ## v1.5.13
 
 ### Fixed

--- a/src/Analyzers/Reliability/CachePrefixAnalyzer.php
+++ b/src/Analyzers/Reliability/CachePrefixAnalyzer.php
@@ -24,6 +24,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class CachePrefixAnalyzer extends AbstractFileAnalyzer
 {
+    public static bool $runInCI = false;
+
     /**
      * Shared cache drivers that require prefix configuration.
      *

--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -24,6 +24,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
 {
+    public static bool $runInCI = false;
+
     public function __construct(
         private Filesystem $files
     ) {}

--- a/src/Analyzers/Reliability/EnvFileAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvFileAnalyzer.php
@@ -19,6 +19,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
  */
 class EnvFileAnalyzer extends AbstractFileAnalyzer
 {
+    public static bool $runInCI = false;
+
     protected function metadata(): AnalyzerMetadata
     {
         return new AnalyzerMetadata(

--- a/src/Analyzers/Security/FilePermissionsAnalyzer.php
+++ b/src/Analyzers/Security/FilePermissionsAnalyzer.php
@@ -23,6 +23,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class FilePermissionsAnalyzer extends AbstractFileAnalyzer
 {
+    public static bool $runInCI = false;
+
     /** Mask to isolate permission bits (strip file type and special bits) */
     private const PERMISSION_MASK = 0x01FF; // 0777
 


### PR DESCRIPTION
## Summary

- `EnvFileAnalyzer`: set `runInCI = false` — `.env` presence and permissions depend on CI setup, not developer code
- `FilePermissionsAnalyzer`: set `runInCI = false` — file permission bits are set by the OS/runner umask, not controllable by the developer
- `CachePrefixAnalyzer`: set `runInCI = false` — consistent with `CacheStatusAnalyzer`; no shared cache server runs in CI so prefix config is irrelevant
- `DirectoryWritePermissionsAnalyzer`: set `runInCI = false` — storage symlinks (`public/storage`) are never created in CI (`php artisan storage:link` is not run)

All 4 previously inherited `runInCI = true` from `AbstractFileAnalyzer`. The guiding principle: if the developer has no control over the environment condition being checked, the analyzer should not run in CI.