### PR TITLE
fix: disable EnvFileSecurityAnalyzer in CI environments

### DIFF
--- a/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
+++ b/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
@@ -24,6 +24,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 {
+    public static bool $runInCI = false;
+
     private const WORLD_READABLE = 0x0004;
 
     private const WORLD_WRITABLE = 0x0002;


### PR DESCRIPTION
## Summary

- `EnvFileSecurityAnalyzer`: set `runInCI = false` — this analyzer checks `.env` file permissions, whether `.env` is in `.gitignore`, and whether `.env` is committed to git; in CI environments `.env` is intentionally absent (secrets come from platform variables), making these checks irrelevant or false-positive-prone