### PR TITLE
fix: hide OSC 8 hyperlinks in CI and unsupported terminals

### DIFF
--- a/src/Support/Reporter.php
+++ b/src/Support/Reporter.php
@@ -350,12 +350,46 @@ class Reporter implements ReporterInterface
     /**
      * Create a clickable hyperlink (OSC 8).
      * Supported in: iTerm2, GNOME Terminal, Konsole, Windows Terminal, VS Code terminal
+     * Falls back to plain text in CI environments and unsupported terminals.
      */
     private function hyperlink(string $url, ?string $text = null): string
     {
         $displayText = $text ?? $url;
 
+        if (! $this->supportsHyperlinks()) {
+            return $displayText;
+        }
+
         return "\033]8;;{$url}\033\\{$displayText}\033]8;;\033\\";
+    }
+
+    /**
+     * Detect whether the current terminal supports OSC 8 hyperlinks.
+     */
+    private function supportsHyperlinks(): bool
+    {
+        // CI environments don't support OSC 8 hyperlinks
+        if (getenv('CI') !== false) {
+            return false;
+        }
+
+        // Known terminals that support OSC 8
+        $termProgram = (string) (getenv('TERM_PROGRAM') ?: '');
+        if (in_array($termProgram, ['iTerm.app', 'WezTerm', 'vscode'], true)) {
+            return true;
+        }
+
+        // VTE-based terminals (GNOME Terminal, Tilix, etc.)
+        if (getenv('VTE_VERSION') !== false) {
+            return true;
+        }
+
+        // Windows Terminal
+        if (getenv('WT_SESSION') !== false) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Support/ReporterTest.php
+++ b/tests/Unit/Support/ReporterTest.php
@@ -1229,4 +1229,126 @@ class ReporterTest extends TestCase
         $this->assertEquals('acme/app', $payload['metadata']['repository']);
         $this->assertEquals('main', $payload['metadata']['base_branch']);
     }
+
+    #[Test]
+    public function hyperlink_returns_plain_text_in_ci_environment(): void
+    {
+        $method = new \ReflectionMethod($this->reporter, 'hyperlink');
+        $method->setAccessible(true);
+
+        $prevCi = getenv('CI');
+        putenv('CI=true');
+
+        try {
+            $result = $method->invoke($this->reporter, 'https://example.com', 'Click here');
+            $this->assertEquals('Click here', $result);
+
+            $resultNoText = $method->invoke($this->reporter, 'https://example.com');
+            $this->assertEquals('https://example.com', $resultNoText);
+        } finally {
+            $prevCi === false ? putenv('CI') : putenv("CI={$prevCi}");
+        }
+    }
+
+    #[Test]
+    public function hyperlink_returns_plain_text_for_unsupported_terminal(): void
+    {
+        $method = new \ReflectionMethod($this->reporter, 'hyperlink');
+        $method->setAccessible(true);
+
+        $envVars = ['CI', 'TERM_PROGRAM', 'VTE_VERSION', 'WT_SESSION'];
+        $prev = [];
+        foreach ($envVars as $var) {
+            $prev[$var] = getenv($var);
+            putenv($var);
+        }
+
+        try {
+            $result = $method->invoke($this->reporter, 'https://example.com', 'Click here');
+            $this->assertEquals('Click here', $result);
+        } finally {
+            foreach ($envVars as $var) {
+                $prev[$var] === false ? putenv($var) : putenv("{$var}={$prev[$var]}");
+            }
+        }
+    }
+
+    #[Test]
+    public function hyperlink_returns_osc8_sequence_for_iterm(): void
+    {
+        $method = new \ReflectionMethod($this->reporter, 'hyperlink');
+        $method->setAccessible(true);
+
+        $prevCi = getenv('CI');
+        $prevTermProgram = getenv('TERM_PROGRAM');
+
+        putenv('CI');
+        putenv('TERM_PROGRAM=iTerm.app');
+
+        try {
+            $result = $method->invoke($this->reporter, 'https://example.com', 'Click here');
+            $this->assertIsString($result);
+            $this->assertStringContainsString("\033]8;;https://example.com\033\\", $result);
+            $this->assertStringContainsString('Click here', $result);
+        } finally {
+            $prevCi === false ? putenv('CI') : putenv("CI={$prevCi}");
+            $prevTermProgram === false ? putenv('TERM_PROGRAM') : putenv("TERM_PROGRAM={$prevTermProgram}");
+        }
+    }
+
+    #[Test]
+    public function hyperlink_returns_osc8_for_vte_terminal(): void
+    {
+        $method = new \ReflectionMethod($this->reporter, 'hyperlink');
+        $method->setAccessible(true);
+
+        $envVars = ['CI', 'TERM_PROGRAM', 'WT_SESSION'];
+        $prev = [];
+        foreach ($envVars as $var) {
+            $prev[$var] = getenv($var);
+            putenv($var);
+        }
+
+        $prevVte = getenv('VTE_VERSION');
+        putenv('VTE_VERSION=6800');
+
+        try {
+            $result = $method->invoke($this->reporter, 'https://example.com', 'Link');
+            $this->assertIsString($result);
+            $this->assertStringContainsString("\033]8;;", $result);
+        } finally {
+            foreach ($envVars as $var) {
+                $prev[$var] === false ? putenv($var) : putenv("{$var}={$prev[$var]}");
+            }
+            $prevVte === false ? putenv('VTE_VERSION') : putenv("VTE_VERSION={$prevVte}");
+        }
+    }
+
+    #[Test]
+    public function hyperlink_returns_osc8_for_windows_terminal(): void
+    {
+        $method = new \ReflectionMethod($this->reporter, 'hyperlink');
+        $method->setAccessible(true);
+
+        $envVars = ['CI', 'TERM_PROGRAM', 'VTE_VERSION'];
+        $prev = [];
+        foreach ($envVars as $var) {
+            $prev[$var] = getenv($var);
+            putenv($var);
+        }
+
+        $prevWt = getenv('WT_SESSION');
+        putenv('WT_SESSION=some-session-id');
+
+        try {
+            $result = $method->invoke($this->reporter, 'https://example.com', 'Link');
+            $this->assertIsString($result);
+            $this->assertStringContainsString("\033]8;;", $result);
+        } finally {
+            foreach ($envVars as $var) {
+                $prev[$var] === false ? putenv($var) : putenv("{$var}={$prev[$var]}");
+            }
+            $prevWt === false ? putenv('WT_SESSION') : putenv("WT_SESSION={$prevWt}");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- `Reporter::hyperlink()` previously unconditionally wrapped URLs in OSC 8 terminal escape sequences, causing CI log viewers to consume the display text and render empty/invisible URLs
- Added `supportsHyperlinks()` that checks `CI`, `TERM_PROGRAM` (iTerm.app, WezTerm, vscode), `VTE_VERSION`, and `WT_SESSION` before applying escape sequences
- Falls back to plain `$displayText` in CI and unsupported terminals, preserving clickable links in capable terminals