### PR TITLE
fix: exclude skipped analyzers from score denominator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.16
+
+### Changed
+- Score now excludes skipped analyzers from the denominator — `score()` in `AnalysisReport`, per-category percentages in `Reporter::generateReportCard()`, and per-category percentages in `AnalyzeCommand::outputReportCard()` all use `total - skipped` as the denominator; a project where all applicable checks pass now scores 100% in CI regardless of how many analyzers were skipped due to `runInCI = false`
+- Report card: "Not Applicable" row moved to the last position and percentage columns removed — the row is purely informational context, not a scored metric
+
 ## v1.5.15
 
 ### Fixed

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -667,6 +667,12 @@ class AnalyzeCommand extends Command
             $totalAll += count($results);
         }
 
+        // Pre-compute totalSkipped so other rows can exclude it from their denominators
+        $totalSkipped = 0;
+        foreach (array_keys($filteredCategories) as $category) {
+            $totalSkipped += $stats[$category]['skipped'];
+        }
+
         $categories = array_keys($filteredCategories);
         $table = [];
 
@@ -681,17 +687,19 @@ class AnalyzeCommand extends Command
         $table[] = '|'.$statusCell.'|'.implode('|', $categoryCells).'|'.$totalCell.'|';
         $table[] = '+----------------+'.str_repeat('----------------+', count($categories)).'------------+';
 
+        $totalDenominator = $totalAll - $totalSkipped;
+
         // Passed row with green color
         $passedRow = '| '.$this->color('Passed        ', 'green').' |';
         $totalPassed = 0;
         foreach ($categories as $category) {
             $passed = $stats[$category]['passed'];
-            $total = $stats[$category]['total'];
-            $pct = $total > 0 ? round(($passed / $total) * 100) : 0;
+            $denominator = $stats[$category]['total'] - $stats[$category]['skipped'];
+            $pct = $denominator > 0 ? round(($passed / $denominator) * 100) : 0;
             $passedRow .= str_pad("   {$passed}  ({$pct}%)", 16).'|';
             $totalPassed += $passed;
         }
-        $totalPct = $totalAll > 0 ? round(($totalPassed / $totalAll) * 100) : 0;
+        $totalPct = $totalDenominator > 0 ? round(($totalPassed / $totalDenominator) * 100) : 0;
         $passedRow .= str_pad(" {$totalPassed}  ({$totalPct}%)", 12).'|';
         $table[] = $passedRow;
 
@@ -700,12 +708,12 @@ class AnalyzeCommand extends Command
         $totalFailed = 0;
         foreach ($categories as $category) {
             $failed = $stats[$category]['failed'];
-            $total = $stats[$category]['total'];
-            $pct = $total > 0 ? round(($failed / $total) * 100) : 0;
+            $denominator = $stats[$category]['total'] - $stats[$category]['skipped'];
+            $pct = $denominator > 0 ? round(($failed / $denominator) * 100) : 0;
             $failedRow .= str_pad("    {$failed}   ({$pct}%)", 16).'|';
             $totalFailed += $failed;
         }
-        $totalPct = $totalAll > 0 ? round(($totalFailed / $totalAll) * 100) : 0;
+        $totalPct = $totalDenominator > 0 ? round(($totalFailed / $totalDenominator) * 100) : 0;
         $failedRow .= str_pad("  {$totalFailed}  ({$totalPct}%)", 12).'|';
         $table[] = $failedRow;
 
@@ -714,42 +722,37 @@ class AnalyzeCommand extends Command
         $totalWarnings = 0;
         foreach ($categories as $category) {
             $warnings = $stats[$category]['warning'];
-            $total = $stats[$category]['total'];
-            $pct = $total > 0 ? round(($warnings / $total) * 100) : 0;
+            $denominator = $stats[$category]['total'] - $stats[$category]['skipped'];
+            $pct = $denominator > 0 ? round(($warnings / $denominator) * 100) : 0;
             $warningRow .= str_pad("    {$warnings}   ({$pct}%)", 16).'|';
             $totalWarnings += $warnings;
         }
-        $totalPct = $totalAll > 0 ? round(($totalWarnings / $totalAll) * 100) : 0;
+        $totalPct = $totalDenominator > 0 ? round(($totalWarnings / $totalDenominator) * 100) : 0;
         $warningRow .= str_pad("  {$totalWarnings}  ({$totalPct}%)", 12).'|';
         $table[] = $warningRow;
-
-        // Not Applicable row with gray color
-        $skippedRow = '| '.$this->color('Not Applicable', 'gray').' |';
-        $totalSkipped = 0;
-        foreach ($categories as $category) {
-            $skipped = $stats[$category]['skipped'];
-            $total = $stats[$category]['total'];
-            $pct = $total > 0 ? round(($skipped / $total) * 100) : 0;
-            $skippedRow .= str_pad("    {$skipped}   ({$pct}%)", 16).'|';
-            $totalSkipped += $skipped;
-        }
-        $totalPct = $totalAll > 0 ? round(($totalSkipped / $totalAll) * 100) : 0;
-        $skippedRow .= str_pad("  {$totalSkipped}   ({$totalPct}%)", 12).'|';
-        $table[] = $skippedRow;
 
         // Error row with bright red color
         $errorRow = '| '.$this->color('Error         ', 'bright_red').' |';
         $totalErrors = 0;
         foreach ($categories as $category) {
             $errors = $stats[$category]['error'];
-            $total = $stats[$category]['total'];
-            $pct = $total > 0 ? round(($errors / $total) * 100) : 0;
+            $denominator = $stats[$category]['total'] - $stats[$category]['skipped'];
+            $pct = $denominator > 0 ? round(($errors / $denominator) * 100) : 0;
             $errorRow .= str_pad("    {$errors}   ({$pct}%)", 16).'|';
             $totalErrors += $errors;
         }
-        $totalPct = $totalAll > 0 ? round(($totalErrors / $totalAll) * 100) : 0;
+        $totalPct = $totalDenominator > 0 ? round(($totalErrors / $totalDenominator) * 100) : 0;
         $errorRow .= str_pad("  {$totalErrors}   ({$totalPct}%)", 12).'|';
         $table[] = $errorRow;
+
+        // Not Applicable row last, with gray color, no percentages
+        $skippedRow = '| '.$this->color('Not Applicable', 'gray').' |';
+        foreach ($categories as $category) {
+            $skipped = $stats[$category]['skipped'];
+            $skippedRow .= str_pad("    {$skipped}      ", 16).'|';
+        }
+        $skippedRow .= str_pad("  {$totalSkipped}      ", 12).'|';
+        $table[] = $skippedRow;
 
         // Footer
         $table[] = '+----------------+'.str_repeat('----------------+', count($categories)).'------------+';

--- a/src/Support/Reporter.php
+++ b/src/Support/Reporter.php
@@ -464,17 +464,24 @@ class Reporter implements ReporterInterface
             $totalAll += count($results);
         }
 
+        // Pre-compute totalSkipped so other rows can exclude it from their denominators
+        $totalSkipped = 0;
+        foreach ($categories as $category) {
+            $totalSkipped += $stats[$category]['skipped'];
+        }
+
         // Passed row
         $passedRow = '| Passed         |';
         $totalPassed = 0;
         foreach ($categories as $category) {
             $passed = $stats[$category]['passed'];
-            $total = $stats[$category]['total'];
-            $pct = $total > 0 ? round(($passed / $total) * 100) : 0;
+            $denominator = $stats[$category]['total'] - $stats[$category]['skipped'];
+            $pct = $denominator > 0 ? round(($passed / $denominator) * 100) : 0;
             $passedRow .= str_pad("   {$passed}  ({$pct}%)", 16).'|';
             $totalPassed += $passed;
         }
-        $totalPct = $totalAll > 0 ? round(($totalPassed / $totalAll) * 100) : 0;
+        $totalDenominator = $totalAll - $totalSkipped;
+        $totalPct = $totalDenominator > 0 ? round(($totalPassed / $totalDenominator) * 100) : 0;
         $passedRow .= str_pad(" {$totalPassed}  ({$totalPct}%)", 12).'|';
         $table[] = $passedRow;
 
@@ -483,12 +490,12 @@ class Reporter implements ReporterInterface
         $totalFailed = 0;
         foreach ($categories as $category) {
             $failed = $stats[$category]['failed'];
-            $total = $stats[$category]['total'];
-            $pct = $total > 0 ? round(($failed / $total) * 100) : 0;
+            $denominator = $stats[$category]['total'] - $stats[$category]['skipped'];
+            $pct = $denominator > 0 ? round(($failed / $denominator) * 100) : 0;
             $failedRow .= str_pad("    {$failed}   ({$pct}%)", 16).'|';
             $totalFailed += $failed;
         }
-        $totalPct = $totalAll > 0 ? round(($totalFailed / $totalAll) * 100) : 0;
+        $totalPct = $totalDenominator > 0 ? round(($totalFailed / $totalDenominator) * 100) : 0;
         $failedRow .= str_pad("  {$totalFailed}  ({$totalPct}%)", 12).'|';
         $table[] = $failedRow;
 
@@ -497,42 +504,37 @@ class Reporter implements ReporterInterface
         $totalWarnings = 0;
         foreach ($categories as $category) {
             $warnings = $stats[$category]['warning'];
-            $total = $stats[$category]['total'];
-            $pct = $total > 0 ? round(($warnings / $total) * 100) : 0;
+            $denominator = $stats[$category]['total'] - $stats[$category]['skipped'];
+            $pct = $denominator > 0 ? round(($warnings / $denominator) * 100) : 0;
             $warningRow .= str_pad("    {$warnings}   ({$pct}%)", 16).'|';
             $totalWarnings += $warnings;
         }
-        $totalPct = $totalAll > 0 ? round(($totalWarnings / $totalAll) * 100) : 0;
+        $totalPct = $totalDenominator > 0 ? round(($totalWarnings / $totalDenominator) * 100) : 0;
         $warningRow .= str_pad("  {$totalWarnings}  ({$totalPct}%)", 12).'|';
         $table[] = $warningRow;
-
-        // Not Applicable row
-        $skippedRow = '| Not Applicable |';
-        $totalSkipped = 0;
-        foreach ($categories as $category) {
-            $skipped = $stats[$category]['skipped'];
-            $total = $stats[$category]['total'];
-            $pct = $total > 0 ? round(($skipped / $total) * 100) : 0;
-            $skippedRow .= str_pad("    {$skipped}   ({$pct}%)", 16).'|';
-            $totalSkipped += $skipped;
-        }
-        $totalPct = $totalAll > 0 ? round(($totalSkipped / $totalAll) * 100) : 0;
-        $skippedRow .= str_pad("  {$totalSkipped}   ({$totalPct}%)", 12).'|';
-        $table[] = $skippedRow;
 
         // Error row
         $errorRow = '| Error          |';
         $totalErrors = 0;
         foreach ($categories as $category) {
             $errors = $stats[$category]['error'];
-            $total = $stats[$category]['total'];
-            $pct = $total > 0 ? round(($errors / $total) * 100) : 0;
+            $denominator = $stats[$category]['total'] - $stats[$category]['skipped'];
+            $pct = $denominator > 0 ? round(($errors / $denominator) * 100) : 0;
             $errorRow .= str_pad("    {$errors}   ({$pct}%)", 16).'|';
             $totalErrors += $errors;
         }
-        $totalPct = $totalAll > 0 ? round(($totalErrors / $totalAll) * 100) : 0;
+        $totalPct = $totalDenominator > 0 ? round(($totalErrors / $totalDenominator) * 100) : 0;
         $errorRow .= str_pad("  {$totalErrors}   ({$totalPct}%)", 12).'|';
         $table[] = $errorRow;
+
+        // Not Applicable row last, no percentages
+        $skippedRow = '| Not Applicable |';
+        foreach ($categories as $category) {
+            $skipped = $stats[$category]['skipped'];
+            $skippedRow .= str_pad("    {$skipped}      ", 16).'|';
+        }
+        $skippedRow .= str_pad("  {$totalSkipped}      ", 12).'|';
+        $table[] = $skippedRow;
 
         // Footer
         $table[] = '+----------------+'.str_repeat('----------------+', count($categories)).'------------+';

--- a/src/ValueObjects/AnalysisReport.php
+++ b/src/ValueObjects/AnalysisReport.php
@@ -31,16 +31,15 @@ final class AnalysisReport
 
     public function score(): int
     {
-        $total = $this->results->count();
-        $passed = $this->results->filter(
-            fn (ResultInterface $result) => $result->getStatus() === Status::Passed
-        )->count();
+        $skipped = $this->skipped()->count();
+        $denominator = $this->results->count() - $skipped;
+        $passed = $this->passed()->count();
 
-        if ($total === 0) {
+        if ($denominator === 0) {
             return 100;
         }
 
-        return (int) round(($passed / $total) * 100);
+        return (int) round(($passed / $denominator) * 100);
     }
 
     public function passed(): Collection

--- a/tests/Unit/ValueObjects/AnalysisReportTest.php
+++ b/tests/Unit/ValueObjects/AnalysisReportTest.php
@@ -77,6 +77,54 @@ class AnalysisReportTest extends TestCase
     }
 
     #[Test]
+    public function it_excludes_skipped_from_score_denominator_when_all_applicable_pass(): void
+    {
+        $results = collect([
+            AnalysisResult::passed('analyzer-1', 'Passed'),
+            AnalysisResult::passed('analyzer-2', 'Passed'),
+            AnalysisResult::passed('analyzer-3', 'Passed'),
+            AnalysisResult::passed('analyzer-4', 'Passed'),
+            AnalysisResult::passed('analyzer-5', 'Passed'),
+            AnalysisResult::passed('analyzer-6', 'Passed'),
+            AnalysisResult::passed('analyzer-7', 'Passed'),
+            AnalysisResult::passed('analyzer-8', 'Passed'),
+            AnalysisResult::passed('analyzer-9', 'Passed'),
+            AnalysisResult::passed('analyzer-10', 'Passed'),
+            AnalysisResult::skipped('analyzer-11', 'Skipped'),
+            AnalysisResult::skipped('analyzer-12', 'Skipped'),
+        ]);
+
+        $report = $this->createReport($results);
+
+        // 10 passed, 2 skipped → denominator = 10, score = 100 (not 83)
+        $this->assertEquals(100, $report->score());
+    }
+
+    #[Test]
+    public function it_excludes_skipped_from_score_denominator_with_failures(): void
+    {
+        $results = collect([
+            AnalysisResult::passed('analyzer-1', 'Passed'),
+            AnalysisResult::passed('analyzer-2', 'Passed'),
+            AnalysisResult::passed('analyzer-3', 'Passed'),
+            AnalysisResult::passed('analyzer-4', 'Passed'),
+            AnalysisResult::passed('analyzer-5', 'Passed'),
+            AnalysisResult::passed('analyzer-6', 'Passed'),
+            AnalysisResult::passed('analyzer-7', 'Passed'),
+            AnalysisResult::passed('analyzer-8', 'Passed'),
+            AnalysisResult::failed('analyzer-9', 'Failed', []),
+            AnalysisResult::failed('analyzer-10', 'Failed', []),
+            AnalysisResult::skipped('analyzer-11', 'Skipped'),
+            AnalysisResult::skipped('analyzer-12', 'Skipped'),
+        ]);
+
+        $report = $this->createReport($results);
+
+        // 8 passed, 2 failed, 2 skipped → denominator = 10, score = 80 (not 67)
+        $this->assertEquals(80, $report->score());
+    }
+
+    #[Test]
     public function it_returns_100_for_empty_results(): void
     {
         $report = $this->createReport(collect());
@@ -218,7 +266,7 @@ class AnalysisReportTest extends TestCase
             'low' => 0,
             'info' => 0,
         ], $summary['issues_by_severity']);
-        $this->assertEquals(33, $summary['score']); // 2 passed out of 6
+        $this->assertEquals(40, $summary['score']); // 2 passed out of 5 applicable (1 skipped excluded)
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- `AnalysisReport::score()` now uses `total - skipped` as the denominator, so CI scores reflect actual code quality rather than environment capabilities (25 analyzers have `$runInCI = false`)
- `Reporter::generateReportCard()` and `AnalyzeCommand::outputReportCard()` apply the same fix per-category and for the Total column
- Not Applicable row moved to last position in the report card; percentage columns removed since the row is now purely informational context
- Tests updated: existing `it_generates_summary` score assertion corrected (33→40), two new explicit skipped-exclusion tests added