### PR TITLE
fix: remove table string value check from NamingConventionAnalyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.17
+
+### Fixed
+- `NamingConventionAnalyzer` no longer checks the string value of `protected $table` for plural snake_case — a developer who explicitly sets `$table` is intentionally overriding Laravel's default (DB prefix, legacy schema, multi-tenancy, etc.) and the analyzer must not second-guess that choice; PSR naming conventions govern PHP identifiers, not string literals; the property name `table` is valid camelCase and is the only check that applies
+
 ## v1.5.16
 
 ### Changed

--- a/src/Analyzers/CodeQuality/NamingConventionAnalyzer.php
+++ b/src/Analyzers/CodeQuality/NamingConventionAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\CodeQuality;
 
-use Illuminate\Support\Str;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
@@ -24,7 +23,6 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
  * - Methods/Properties: camelCase
  * - Public Constants: SCREAMING_SNAKE_CASE
  * - Private/Protected Constants: camelCase allowed
- * - Laravel table names: plural snake_case
  *
  * Note: Local variables and parameters are NOT checked to avoid excessive noise.
  */
@@ -39,7 +37,7 @@ class NamingConventionAnalyzer extends AbstractFileAnalyzer
         return new AnalyzerMetadata(
             id: 'naming-convention',
             name: 'Naming Convention Analyzer',
-            description: 'Validates PSR and Laravel naming standards for better code consistency',
+            description: 'Validates PSR naming standards for better code consistency',
             category: Category::CodeQuality,
             severity: Severity::Low,
             tags: ['conventions', 'psr', 'code-quality', 'readability'],
@@ -105,7 +103,6 @@ class NamingConventionAnalyzer extends AbstractFileAnalyzer
             'method' => 'Methods should use camelCase (e.g., getUserById, processPayment)',
             'property' => 'Properties should use camelCase (e.g., firstName, isActive)',
             'constant' => 'Public constants should use SCREAMING_SNAKE_CASE (e.g., MAX_RETRIES, API_KEY). Private/protected constants may use camelCase',
-            'table' => 'Laravel table names should be plural snake_case (e.g., users, order_items, user_profiles)',
             default => 'Follow PSR-12 naming conventions',
         };
 
@@ -171,10 +168,7 @@ class NamingConventionVisitor extends NodeVisitorAbstract
             foreach ($node->props as $prop) {
                 $propertyName = $prop->name->toString();
 
-                // Laravel convention: protected $table should be plural snake_case
-                if ($propertyName === 'table' && $node->isProtected()) {
-                    $this->checkLaravelTableNaming($node, $prop);
-                } elseif (! $this->isCamelCase($propertyName)) {
+                if (! $this->isCamelCase($propertyName)) {
                     $suggestion = $this->toCamelCase($propertyName);
                     $this->issues[] = [
                         'message' => "Property '{$propertyName}' does not follow camelCase convention",
@@ -302,123 +296,6 @@ class NamingConventionVisitor extends NodeVisitorAbstract
         $name = str_replace(['-', ' '], '_', $name);
 
         return strtoupper($name);
-    }
-
-    /**
-     * Check Laravel table naming convention: plural snake_case.
-     */
-    private function checkLaravelTableNaming(Stmt\Property $node, Node\PropertyItem $prop): void
-    {
-        // Extract the table name value
-        if ($prop->default === null) {
-            return; // No default value, skip check
-        }
-
-        // Only check string literals
-        if (! $prop->default instanceof Node\Scalar\String_) {
-            return;
-        }
-
-        $tableName = $prop->default->value;
-
-        // Check if it's snake_case
-        if (! $this->isSnakeCase($tableName)) {
-            $suggestion = $this->toSnakeCase($tableName);
-            $this->issues[] = [
-                'message' => "Laravel table name '{$tableName}' should use snake_case convention",
-                'line' => $node->getStartLine(),
-                'type' => 'table',
-                'name' => $tableName,
-                'suggestion' => $suggestion,
-            ];
-
-            return;
-        }
-
-        // Check if it's plural
-        if (! $this->isPlural($tableName)) {
-            $suggestion = $this->toPlural($tableName);
-            $this->issues[] = [
-                'message' => "Laravel table name '{$tableName}' should be plural",
-                'line' => $node->getStartLine(),
-                'type' => 'table',
-                'name' => $tableName,
-                'suggestion' => $suggestion,
-            ];
-        }
-    }
-
-    /**
-     * Check if string is snake_case.
-     */
-    private function isSnakeCase(string $name): bool
-    {
-        // snake_case: all lowercase with underscores, no consecutive underscores
-        return preg_match('/^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/', $name) === 1;
-    }
-
-    /**
-     * Convert to snake_case.
-     */
-    private function toSnakeCase(string $name): string
-    {
-        // Insert underscore before uppercase letters (except first)
-        $name = preg_replace('/(?<!^)[A-Z]/', '_$0', $name) ?? $name;
-
-        // Replace existing separators with underscores
-        $name = str_replace(['-', ' '], '_', $name);
-
-        return strtolower($name);
-    }
-
-    /**
-     * Check if a table name is plural using Laravel's Str::singular().
-     *
-     * Uses Laravel's robust singularization engine to determine if a word is already plural.
-     * A word is plural if its singular form is different from the original.
-     * Handles irregular plurals (children->child), regular plurals (users->user),
-     * and uncountable words (sheep->sheep) automatically.
-     */
-    private function isPlural(string $name): bool
-    {
-        // Extract the last word (after last underscore)
-        $parts = explode('_', $name);
-        $lastWord = end($parts);
-
-        // Check if singular form differs from the word
-        // e.g., singular('users') = 'user' (different, so 'users' is plural)
-        //       singular('user') = 'user' (same, so 'user' is singular)
-        //       singular('children') = 'child' (different, so 'children' is plural)
-        //       singular('sheep') = 'sheep' (same, but acceptable for uncountables)
-        $singular = Str::singular($lastWord);
-
-        // If singular differs, it's plural
-        if ($singular !== $lastWord) {
-            return true;
-        }
-
-        // For uncountables (sheep, fish), accept them as valid plural forms
-        // They're technically both singular and plural in English
-        return Str::plural($lastWord) === $lastWord;
-    }
-
-    /**
-     * Convert to plural form using Laravel's Str::plural().
-     *
-     * Uses Laravel's robust pluralization engine to convert words to plural.
-     * Handles irregular plurals (person->people), -y endings (category->categories),
-     * uncountable words (sheep, fish), and all edge cases automatically.
-     */
-    private function toPlural(string $name): string
-    {
-        // Extract the last word (after last underscore)
-        $parts = explode('_', $name);
-        $lastWord = end($parts);
-
-        // Use Laravel's pluralization
-        $parts[count($parts) - 1] = Str::plural($lastWord);
-
-        return implode('_', $parts);
     }
 
     /**

--- a/tests/Unit/Analyzers/CodeQuality/NamingConventionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/NamingConventionAnalyzerTest.php
@@ -638,8 +638,11 @@ PHP;
     }
 
     #[Test]
-    public function test_validates_laravel_table_names_are_plural_snake_case(): void
+    public function test_does_not_flag_explicitly_set_table_string_values(): void
     {
+        // A developer who sets protected $table = 'dh_deals_tracking' is intentionally
+        // overriding Laravel's default. The property name 'table' is valid camelCase —
+        // the string value is their deliberate choice and must not be second-guessed.
         $code = <<<'PHP'
 <?php
 
@@ -647,21 +650,14 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class User extends Model
+class DhDealsTracking extends Model
 {
-    // Correct: plural snake_case
-    protected $table = 'users';
-}
-
-class OrderItem extends Model
-{
-    // Correct: plural snake_case with underscores
-    protected $table = 'order_items';
+    protected $table = 'dh_deals_tracking';
 }
 PHP;
 
         $tempDir = $this->createTempDirectory([
-            'app/Models/User.php' => $code,
+            'app/Models/DhDealsTracking.php' => $code,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -671,208 +667,5 @@ PHP;
         $result = $analyzer->analyze();
 
         $this->assertPassed($result);
-    }
-
-    #[Test]
-    public function test_flags_singular_table_names(): void
-    {
-        $code = <<<'PHP'
-<?php
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-
-class User extends Model
-{
-    protected $table = 'user';  // Should be plural
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory([
-            'app/Models/User.php' => $code,
-        ]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['app']);
-
-        $result = $analyzer->analyze();
-
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertStringContainsString("Laravel table name 'user' should be plural", $issues[0]->message);
-        $this->assertSame('users', $issues[0]->metadata['suggestion']);
-    }
-
-    #[Test]
-    public function test_flags_non_snake_case_table_names(): void
-    {
-        $code = <<<'PHP'
-<?php
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-
-class User extends Model
-{
-    protected $table = 'UserAccounts';  // Should be snake_case
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory([
-            'app/Models/User.php' => $code,
-        ]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['app']);
-
-        $result = $analyzer->analyze();
-
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertStringContainsString("Laravel table name 'UserAccounts' should use snake_case convention", $issues[0]->message);
-        $this->assertSame('user_accounts', $issues[0]->metadata['suggestion']);
-    }
-
-    #[Test]
-    public function test_handles_irregular_plural_table_names(): void
-    {
-        $code = <<<'PHP'
-<?php
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-
-class Person extends Model
-{
-    protected $table = 'people';  // Correct irregular plural
-}
-
-class Child extends Model
-{
-    protected $table = 'children';  // Correct irregular plural
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory([
-            'app/Models/Person.php' => $code,
-        ]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['app']);
-
-        $result = $analyzer->analyze();
-
-        $this->assertPassed($result);
-    }
-
-    #[Test]
-    public function test_suggests_irregular_plural_for_table_names(): void
-    {
-        $code = <<<'PHP'
-<?php
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-
-class Person extends Model
-{
-    protected $table = 'person';  // Should be 'people'
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory([
-            'app/Models/Person.php' => $code,
-        ]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['app']);
-
-        $result = $analyzer->analyze();
-
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertStringContainsString("Laravel table name 'person' should be plural", $issues[0]->message);
-        $this->assertSame('people', $issues[0]->metadata['suggestion']);
-    }
-
-    #[Test]
-    public function test_handles_table_names_ending_in_y(): void
-    {
-        $code = <<<'PHP'
-<?php
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-
-class Category extends Model
-{
-    protected $table = 'category';  // Should be 'categories'
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory([
-            'app/Models/Category.php' => $code,
-        ]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['app']);
-
-        $result = $analyzer->analyze();
-
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertSame('categories', $issues[0]->metadata['suggestion']);
-    }
-
-    #[Test]
-    public function test_only_checks_protected_table_property(): void
-    {
-        $code = <<<'PHP'
-<?php
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-
-class User extends Model
-{
-    // Public or private $table should not be checked for Laravel conventions
-    public $table = 'user';
-    private $custom_data = 'data';
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory([
-            'app/Models/User.php' => $code,
-        ]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['app']);
-
-        $result = $analyzer->analyze();
-
-        // Should only flag 'custom_data' for camelCase, not check table naming
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-
-        // Should have issues for camelCase properties, not table naming
-        foreach ($issues as $issue) {
-            $this->assertNotSame('table', $issue->metadata['type']);
-        }
     }
 }


### PR DESCRIPTION
## Summary

- Removes the special-case branch that checked `protected $table` string values for plural snake_case — PSR conventions govern PHP identifiers, not string literals
- Deletes five now-unused methods (`checkLaravelTableNaming`, `isSnakeCase`, `toSnakeCase`, `isPlural`, `toPlural`) and the `Illuminate\Support\Str` import
- Replaces 7 table-naming tests with one regression test confirming `protected $table = 'dh_deals_tracking'` produces no issue

## Why

A developer who explicitly sets `protected $table = 'some_value'` is intentionally overriding Laravel's default convention — they have a deliberate reason (DB prefix, legacy schema, multi-tenancy, etc.). The analyzer was flagging `'dh_deals_tracking'` and recommending `'dh_deals_trackings'` — a nonsense word. String literal values are outside the scope of PSR naming conventions.