### PR TITLE
fix: remove code snippets and line numbers from lock file issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.18
+
+### Fixed
+- Dependency analyzers no longer attach code snippets or line numbers to issues pointing at lock files (`composer.lock`, `package-lock.json`, `yarn.lock`) — lock files are machine-generated and not user-editable; line 1 of `composer.lock` is the `_readme` metadata header, and any line is a fragment of deeply-nested JSON with no actionable context; `code` is now `null` and `Location` carries no line number for lock file issues across `StableDependencyAnalyzer`, `UpToDateDependencyAnalyzer`, `VulnerableDependencyAnalyzer`, `LicenseAnalyzer`, and `FrontendVulnerableDependencyAnalyzer`; `composer.json` snippets are unchanged (flat structure, one key per line, readable)
+
 ## v1.5.17
 
 ### Fixed

--- a/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
@@ -9,7 +9,6 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
-use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
@@ -351,7 +350,7 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($packageLock)),
                     severity: $severity,
                     recommendation: 'Run "npm audit" to see details and "npm audit fix" to automatically fix vulnerabilities',
-                    code: FileParser::getCodeSnippet($packageLock, 1),
+                    code: null,
                     metadata: [
                         'total_vulnerabilities' => $total,
                         'issue_type' => 'summary',
@@ -418,7 +417,7 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
                         location: new Location($this->getRelativePath($yarnLock)),
                         severity: $severity,
                         recommendation: 'Run "yarn audit" to see details and upgrade vulnerable packages',
-                        code: FileParser::getCodeSnippet($yarnLock, 1),
+                        code: null,
                         metadata: [
                             'total_vulnerabilities' => $total,
                             'issue_type' => 'summary',
@@ -440,7 +439,7 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
                         location: new Location($this->getRelativePath($yarnLock)),
                         severity: Severity::High,
                         recommendation: 'Run "yarn audit" to see details and upgrade vulnerable packages',
-                        code: FileParser::getCodeSnippet($yarnLock, 1),
+                        code: null,
                         metadata: [
                             'total_vulnerabilities' => $total,
                             'issue_type' => 'summary',
@@ -576,65 +575,13 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
             $metadata['advisory_id'] = $advisoryId;
         }
 
-        // Find the exact line number of the package in the lock file
-        $lineNumber = $this->findPackageLineNumber($lockFile, $package);
-
         $issues[] = $this->createIssue(
             message: sprintf('Frontend package "%s" has a known vulnerability: %s', $package, $message),
-            location: new Location($this->getRelativePath($lockFile), $lineNumber),
+            location: new Location($this->getRelativePath($lockFile)),
             severity: $severity,
             recommendation: $recommendation,
-            code: FileParser::getCodeSnippet($lockFile, $lineNumber),
+            code: null,
             metadata: $metadata
         );
-    }
-
-    /**
-     * Find the line number where a package is defined in the lock file.
-     */
-    private function findPackageLineNumber(string $lockFile, string $package): int
-    {
-        $lines = FileParser::getLines($lockFile);
-
-        if (empty($lines)) {
-            return 1;
-        }
-
-        // For package-lock.json, look for "node_modules/package-name" or "packages/node_modules/package-name"
-        // For yarn.lock, look for package-name@version
-        $isYarnLock = str_ends_with($lockFile, 'yarn.lock');
-
-        foreach ($lines as $lineNumber => $line) {
-            if (! is_string($line)) {
-                continue;
-            }
-
-            if ($isYarnLock) {
-                // Yarn lock format: "package-name@version":
-                // Also handle scoped packages: "@scope/package-name@version":
-                if (preg_match('/^"?'.preg_quote($package, '/').'@/i', trim($line))) {
-                    return $lineNumber + 1;
-                }
-            } else {
-                // NPM lock format: "node_modules/package-name": {
-                // Also handle scoped packages: "node_modules/@scope/package-name": {
-                if (preg_match('/"node_modules\/'.preg_quote($package, '/').'":\s*\{/i', $line)) {
-                    return $lineNumber + 1;
-                }
-
-                // Alternative npm format (newer versions): "packages": { "node_modules/package-name": {
-                if (preg_match('/"packages\/node_modules\/'.preg_quote($package, '/').'":\s*\{/i', $line)) {
-                    return $lineNumber + 1;
-                }
-
-                // Direct package name in dependencies object (npm v7+)
-                if (preg_match('/"'.preg_quote($package, '/').'":\s*\{/i', $line)) {
-                    return $lineNumber + 1;
-                }
-            }
-        }
-
-        // If not found, return 1
-        return 1;
     }
 }

--- a/src/Analyzers/Security/LicenseAnalyzer.php
+++ b/src/Analyzers/Security/LicenseAnalyzer.php
@@ -11,7 +11,6 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
-use ShieldCI\Support\Composer;
 
 /**
  * Validates that dependencies use legally acceptable licenses.
@@ -166,9 +165,6 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
                 ? $package['name']
                 : 'Unknown';
 
-            // Find the line number where this package is defined
-            $lineNumber = Composer::findPackageLineNumber($composerLock, $packageName);
-
             // Normalize license to array and detect if it's conjunctive (AND) or disjunctive (OR)
             $licenseData = $this->parseLicenseField($package);
             $licenses = $licenseData['licenses'];
@@ -180,10 +176,10 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
                 if (! $isDevDependency) {
                     $issues[] = $this->createIssue(
                         message: sprintf('Package "%s" has no license information', $packageName),
-                        location: new Location($composerLock, $lineNumber),
+                        location: new Location($composerLock),
                         severity: Severity::Medium,
                         recommendation: sprintf('Investigate license for "%s" or contact the package maintainer', $packageName),
-                        code: FileParser::getCodeSnippet($composerLock, $lineNumber),
+                        code: null,
                         metadata: [
                             'package' => $packageName,
                             'issue_type' => 'missing_license',
@@ -247,14 +243,14 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
                         implode(', ', $licenses),
                         $licenseType
                     ),
-                    location: new Location($composerLock, $lineNumber),
+                    location: new Location($composerLock),
                     severity: $severity,
                     recommendation: $isDevDependency
                         ? sprintf('Dev dependency "%s" has GPL/AGPL license. This is generally safe for development tools, but verify it\'s not distributed with your application', $packageName)
                         : ($isConjunctive
                             ? sprintf('Package "%s" has conjunctive license (AND) including GPL/AGPL - ALL licenses apply simultaneously. You must comply with GPL/AGPL terms. Consider finding an alternative package', $packageName)
                             : sprintf('GPL/AGPL licenses may require your application to be open-source. Review "%s" license implications or find an alternative package', $packageName)),
-                    code: FileParser::getCodeSnippet($composerLock, $lineNumber),
+                    code: null,
                     metadata: [
                         'package' => $packageName,
                         'licenses' => $licenses,
@@ -275,14 +271,14 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
                             implode(', ', $licenses),
                             $licenseType
                         ),
-                        location: new Location($composerLock, $lineNumber),
+                        location: new Location($composerLock),
                         severity: Severity::Low,
                         recommendation: sprintf(
                             'Review the "%s" license terms to ensure compatibility with your application. %s Common safe licenses: MIT, Apache-2.0, BSD',
                             $packageName,
                             $isConjunctive ? 'Note: This is a conjunctive license (AND) - ALL licenses apply simultaneously.' : ''
                         ),
-                        code: FileParser::getCodeSnippet($composerLock, $lineNumber),
+                        code: null,
                         metadata: [
                             'package' => $packageName,
                             'licenses' => $licenses,

--- a/src/Analyzers/Security/StableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/StableDependencyAnalyzer.php
@@ -74,12 +74,13 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
             $preferStableOutput = $this->composer->updateDryRun(['--prefer-stable']);
             if ($this->preferStableRunChangesDependencies($preferStableOutput)) {
                 $filePath = file_exists($composerLock) ? $composerLock : $composerJson;
+                $isLockFile = file_exists($composerLock);
                 $issues[] = $this->createIssue(
                     message: 'Composer update --prefer-stable would modify installed packages',
                     location: new Location($this->getRelativePath($filePath)),
                     severity: Severity::Low,
                     recommendation: 'Run "composer update --prefer-stable" and ensure all dependencies resolve to stable releases.',
-                    code: FileParser::getCodeSnippet($filePath, 1),
+                    code: $isLockFile ? null : FileParser::getCodeSnippet($filePath, 1),
                     metadata: [
                         'composer_version_check' => 'update --dry-run --prefer-stable',
                     ]
@@ -332,7 +333,6 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
         }
 
         $unstablePackages = [];
-        $firstUnstablePackageName = null;
 
         foreach ($packages as $package) {
             if (! is_array($package)) {
@@ -350,10 +350,6 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
             // Check for unstable versions using the same logic as checkVersionConstraints
             if ($this->isUnstableVersion($version)) {
                 $unstablePackages[] = sprintf('%s (%s)', $packageName, $version);
-                // Track the first unstable package for accurate line reporting
-                if ($firstUnstablePackageName === null && $packageName !== 'Unknown') {
-                    $firstUnstablePackageName = $packageName;
-                }
             }
         }
 
@@ -361,21 +357,16 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
             $count = count($unstablePackages);
             $examples = implode(', ', array_slice($unstablePackages, 0, 3));
 
-            // Use the first unstable package's line number for better location reporting
-            $line = $firstUnstablePackageName !== null
-                ? Composer::findPackageLineNumber($composerLock, $firstUnstablePackageName)
-                : 1;
-
             $issues[] = $this->createIssue(
                 message: sprintf('Found %d unstable package versions installed', $count),
-                location: new Location($this->getRelativePath($composerLock), $line),
+                location: new Location($this->getRelativePath($composerLock)),
                 severity: Severity::Low,
                 recommendation: sprintf(
                     'Update to stable versions: %s%s. Run "composer update --prefer-stable"',
                     $examples,
                     $count > 3 ? sprintf(' and %d more', $count - 3) : ''
                 ),
-                code: FileParser::getCodeSnippet($composerLock, $line),
+                code: null,
                 metadata: [
                     'count' => $count,
                     'examples' => array_slice($unstablePackages, 0, 3),

--- a/src/Analyzers/Security/UpToDateDependencyAnalyzer.php
+++ b/src/Analyzers/Security/UpToDateDependencyAnalyzer.php
@@ -8,7 +8,6 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
-use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Support\Composer;
@@ -130,7 +129,7 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
                     location: new Location($this->getRelativePath($composerLockPath)),
                     severity: Severity::Medium,
                     recommendation: $this->getBothDepsRecommendation(),
-                    code: FileParser::getCodeSnippet($composerLockPath, 1),
+                    code: null,
                     metadata: [
                         'scope' => 'unknown',
                         'composer_version_check' => 'install --dry-run',
@@ -153,7 +152,7 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
                         location: new Location($this->getRelativePath($composerLockPath)),
                         severity: Severity::Medium,
                         recommendation: $this->getBothDepsRecommendation(),
-                        code: FileParser::getCodeSnippet($composerLockPath, 1),
+                        code: null,
                         metadata: [
                             'scope' => 'production and dev',
                             'composer_version_check' => 'install --dry-run',
@@ -168,7 +167,7 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
                         location: new Location($this->getRelativePath($composerLockPath)),
                         severity: Severity::Medium,
                         recommendation: $this->getProductionDepsRecommendation(),
-                        code: FileParser::getCodeSnippet($composerLockPath, 1),
+                        code: null,
                         metadata: [
                             'scope' => 'production',
                             'composer_version_check' => 'install --dry-run',
@@ -182,7 +181,7 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
                         location: new Location($this->getRelativePath($composerLockPath)),
                         severity: Severity::Low,
                         recommendation: $this->getDevDepsRecommendation(),
-                        code: FileParser::getCodeSnippet($composerLockPath, 1),
+                        code: null,
                         metadata: [
                             'scope' => 'dev',
                             'composer_version_check' => 'install --dry-run',

--- a/src/Analyzers/Security/VulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/VulnerableDependencyAnalyzer.php
@@ -11,7 +11,6 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
-use ShieldCI\Support\Composer;
 use ShieldCI\Support\SecurityAdvisories\AdvisoryAnalyzerInterface;
 use ShieldCI\Support\SecurityAdvisories\AdvisoryFetcherInterface;
 use ShieldCI\Support\SecurityAdvisories\ComposerDependencyReader;
@@ -85,10 +84,6 @@ class VulnerableDependencyAnalyzer extends AbstractFileAnalyzer
             return $this->error('Invalid advisory analysis result');
         }
 
-        // Cache for package line numbers to avoid repeated lookups
-        // Key: package name, Value: line number
-        $lineNumberCache = [];
-
         // Aggregate advisories per package to avoid flooding output with multiple issues
         // for the same package (e.g., a package with 5 CVEs creates 5 issues → now 1 issue)
         foreach ($vulnerabilities as $package => $details) {
@@ -116,7 +111,6 @@ class VulnerableDependencyAnalyzer extends AbstractFileAnalyzer
                 continue;
             }
 
-            $lineNumber = $this->getPackageLineNumber($composerLock, $package, $lineNumberCache);
             $advisoryCount = count($validAdvisories);
 
             // Build aggregated message
@@ -151,10 +145,10 @@ class VulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
             $issues[] = $this->createIssue(
                 message: $message,
-                location: new Location($this->getRelativePath($composerLock), $lineNumber),
+                location: new Location($this->getRelativePath($composerLock)),
                 severity: Severity::Critical,
                 recommendation: $recommendation,
-                code: FileParser::getCodeSnippet($composerLock, $lineNumber),
+                code: null,
                 metadata: [
                     'package' => $package,
                     'version' => $version,
@@ -166,7 +160,7 @@ class VulnerableDependencyAnalyzer extends AbstractFileAnalyzer
             );
         }
 
-        $this->checkAbandonedPackages($issues, $composerLock, $lineNumberCache);
+        $this->checkAbandonedPackages($issues, $composerLock);
 
         if (empty($issues)) {
             return $this->passed('No vulnerable dependencies detected');
@@ -180,10 +174,8 @@ class VulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check for abandoned packages in composer.lock.
-     *
-     * @param  array<string, int>  $lineNumberCache  Cache of package line numbers
      */
-    private function checkAbandonedPackages(array &$issues, string $composerLock, array &$lineNumberCache): void
+    private function checkAbandonedPackages(array &$issues, string $composerLock): void
     {
         $lockData = $this->parseComposerLock($composerLock);
 
@@ -210,42 +202,18 @@ class VulnerableDependencyAnalyzer extends AbstractFileAnalyzer
                 ? sprintf('Replace with "%s": composer require %s', $replacement, $replacement)
                 : sprintf('Find an alternative package and remove "%s"', $packageName);
 
-            $lineNumber = $this->getPackageLineNumber($composerLock, $packageName, $lineNumberCache);
-
             $issues[] = $this->createIssue(
                 message: sprintf('Package "%s" is abandoned and no longer maintained', $packageName),
-                location: new Location($this->getRelativePath($composerLock), $lineNumber),
+                location: new Location($this->getRelativePath($composerLock)),
                 severity: Severity::Medium,
                 recommendation: $recommendation,
-                code: FileParser::getCodeSnippet($composerLock, $lineNumber),
+                code: null,
                 metadata: [
                     'package' => $packageName,
                     'replacement' => $replacement,
                 ]
             );
         }
-    }
-
-    /**
-     * Get package line number with caching to avoid repeated lookups.
-     *
-     * Line number lookups involve parsing composer.lock, which is expensive.
-     * Cache results to avoid repeated lookups for the same package.
-     *
-     * @param  array<string, int>  $cache  Cache reference (modified by this method)
-     */
-    private function getPackageLineNumber(string $composerLock, string $packageName, array &$cache): int
-    {
-        // Check cache first
-        if (isset($cache[$packageName])) {
-            return $cache[$packageName];
-        }
-
-        // Cache miss - perform lookup and store result
-        $lineNumber = Composer::findPackageLineNumber($composerLock, $packageName);
-        $cache[$packageName] = $lineNumber;
-
-        return $lineNumber;
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/StableDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/StableDependencyAnalyzerTest.php
@@ -944,7 +944,7 @@ class StableDependencyAnalyzerTest extends AnalyzerTestCase
         $this->assertTrue($found, 'Should find issue for vendor/unstable-package');
     }
 
-    public function test_reports_accurate_line_numbers_for_composer_lock(): void
+    public function test_reports_no_line_number_for_composer_lock_issues(): void
     {
         $composerJson = json_encode([
             'name' => 'test/app',
@@ -985,19 +985,18 @@ class StableDependencyAnalyzerTest extends AnalyzerTestCase
         $this->assertWarning($result);
         $issues = $result->getIssues();
 
-        // Should find the issue and report it on the line where the first unstable package is defined
+        // Should find the issue — no line number for lock files (not user-editable)
         $found = false;
         foreach ($issues as $issue) {
             if (str_contains($issue->message, 'unstable package versions')) {
-                // The first unstable package "vendor/unstable-package" is on line 8
                 $this->assertNotNull($issue->location);
-                $this->assertEquals(8, $issue->location->line);
+                $this->assertNull($issue->location->line);
                 $found = true;
                 break;
             }
         }
 
-        $this->assertTrue($found, 'Should find unstable package issue with accurate line number');
+        $this->assertTrue($found, 'Should find unstable package issue');
     }
 
     /**


### PR DESCRIPTION
## Summary

- Lock files (`composer.lock`, `package-lock.json`, `yarn.lock`) are machine-generated — users never edit them directly. Code snippets extracted from them were broken JSON fragments (e.g. the `_readme` header at line 1), and line numbers pointed into deeply-nested structure with no actionable meaning.
- Set `code: null` for all issues pointing at lock files across 5 dependency analyzers (`StableDependency`, `UpToDate`, `VulnerableDependency`, `License`, `FrontendVulnerableDependency`)
- Removed `$lineNumber` from `Location` for lock file issues in 3 analyzers, and deleted the now-dead `getPackageLineNumber()` / `findPackageLineNumber()` helper methods
- `composer.json` snippets are left unchanged — flat structure, one key per line, readable and actionable