### PR TITLE
fix: skipped analyzers no longer cause "not found" error when targeted with --analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.19
+
+### Fixed
+- `shield:analyze --analyzer=<id>` no longer errors with "Analyzer(s) not found" when the requested analyzer exists but is skipped (e.g. `runInCI = false` with `--ci`, or environment-conditional analyzers like `HSTSHeaderAnalyzer`) — `validateOptions()` now distinguishes between truly unknown IDs (error) and skipped IDs (yellow warning); skipped results are included in the output and streamed correctly in both streaming and non-streaming paths; the "Running analyzer: X" header now resolves the analyzer's display name from skipped metadata instead of falling back to the raw ID
+
 ## v1.5.18
 
 ### Fixed

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -217,6 +217,19 @@ class AnalyzeCommand extends Command
             foreach ($analyzerIds as $analyzerId) {
                 $analyzer = $manager->getAnalyzers()->first(fn ($a) => $a->getId() === $analyzerId);
                 if ($analyzer === null) {
+                    // Check if it's a skipped analyzer and stream its pre-built result
+                    $skippedResult = $manager->getSkippedAnalyzers()->first(fn ($r) => $r->getAnalyzerId() === $analyzerId);
+                    if ($skippedResult !== null) {
+                        $current++;
+                        $skippedMeta = $skippedResult->getMetadata();
+                        $skippedCategory = $skippedMeta['category'] ?? 'Unknown';
+                        $skippedCategoryLabel = is_object($skippedCategory) && isset($skippedCategory->value)
+                            ? Category::from($skippedCategory->value)->label()
+                            : 'Unknown';
+                        $results->push($skippedResult);
+                        $this->line($reporter->streamResult($skippedResult, $current, $total, $skippedCategoryLabel));
+                    }
+
                     continue;
                 }
 
@@ -436,6 +449,12 @@ class AnalyzeCommand extends Command
                 $result = $manager->run($analyzerId);
                 if ($result !== null) {
                     $results[] = $result;
+                } else {
+                    // Check if it's a skipped analyzer and include its pre-built result
+                    $skippedResult = $manager->getSkippedAnalyzers()->first(fn ($r) => $r->getAnalyzerId() === $analyzerId);
+                    if ($skippedResult !== null) {
+                        $results[] = $skippedResult;
+                    }
                 }
             }
 
@@ -1737,8 +1756,14 @@ class AnalyzeCommand extends Command
     {
         $names = array_map(function (string $id) use ($manager) {
             $analyzer = $manager->getAnalyzers()->first(fn ($a) => $a->getId() === $id);
+            if ($analyzer !== null) {
+                return $analyzer->getMetadata()->name;
+            }
 
-            return $analyzer ? $analyzer->getMetadata()->name : $id;
+            $skipped = $manager->getSkippedAnalyzers()->first(fn ($r) => $r->getAnalyzerId() === $id);
+            $skippedName = $skipped !== null ? ($skipped->getMetadata()['name'] ?? null) : null;
+
+            return is_string($skippedName) ? $skippedName : $id;
         }, $analyzerIds);
 
         if (count($names) === 1) {
@@ -1780,13 +1805,21 @@ class AnalyzeCommand extends Command
                 return false;
             }
 
-            // Check if all analyzers exist
+            // Check if all analyzers exist (active or skipped)
             $allAnalyzers = $manager->getAnalyzers();
             $allAnalyzerIds = $allAnalyzers->map(fn ($analyzer) => $analyzer->getId())->toArray();
+            $skippedAnalyzerIds = $manager->getSkippedAnalyzers()
+                ->map(fn ($result) => $result->getAnalyzerId())
+                ->toArray();
 
             $invalidIds = [];
+            $warnSkippedIds = [];
             foreach ($analyzerIds as $analyzerId) {
-                if (! in_array($analyzerId, $allAnalyzerIds, true)) {
+                if (in_array($analyzerId, $allAnalyzerIds, true)) {
+                    // Active — fine
+                } elseif (in_array($analyzerId, $skippedAnalyzerIds, true)) {
+                    $warnSkippedIds[] = $analyzerId;
+                } else {
                     $invalidIds[] = $analyzerId;
                 }
             }
@@ -1802,6 +1835,11 @@ class AnalyzeCommand extends Command
                 });
 
                 return false;
+            }
+
+            if (! empty($warnSkippedIds)) {
+                $skippedList = implode(', ', $warnSkippedIds);
+                $this->line("<fg=yellow>⚠ Analyzer(s) are skipped: {$skippedList}</>");
             }
         }
 

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -1128,6 +1128,49 @@ class AnalyzeCommandTest extends TestCase
     }
 
     #[Test]
+    public function it_does_not_error_when_analyzer_option_targets_a_skipped_analyzer(): void
+    {
+        config(['shieldci.fail_on' => 'never']);
+        $this->registerAnalyzersWithSkipped();
+
+        $this->artisan('shield:analyze', ['--analyzer' => 'test-skipped-analyzer'])
+            ->assertSuccessful()
+            ->expectsOutputToContain('skipped');
+    }
+
+    #[Test]
+    public function it_shows_warning_for_skipped_analyzer_in_validate_options(): void
+    {
+        config(['shieldci.fail_on' => 'never']);
+        $this->registerAnalyzersWithSkipped();
+
+        $this->artisan('shield:analyze', ['--analyzer' => 'test-skipped-analyzer'])
+            ->assertSuccessful()
+            ->expectsOutputToContain('⚠');
+    }
+
+    #[Test]
+    public function it_includes_skipped_result_when_analyzer_option_targets_skipped_in_json_mode(): void
+    {
+        config(['shieldci.fail_on' => 'never']);
+        $this->registerAnalyzersWithSkipped();
+
+        $this->artisan('shield:analyze', ['--analyzer' => 'test-skipped-analyzer', '--format' => 'json'])
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_shows_analyzer_display_name_not_id_when_targeted_analyzer_is_skipped(): void
+    {
+        config(['shieldci.fail_on' => 'never']);
+        $this->registerAnalyzersWithSkipped();
+
+        $this->artisan('shield:analyze', ['--analyzer' => 'test-skipped-analyzer'])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Test Skipped Analyzer');
+    }
+
+    #[Test]
     public function it_saves_report_in_console_format(): void
     {
         $this->registerTestAnalyzers();


### PR DESCRIPTION
## Summary

- `validateOptions()` now recognizes skipped analyzer IDs as valid (shows a yellow warning instead of an error)
- `runAnalysisWithStreaming()` and `runAnalysis()` include the pre-built skipped result when an explicitly requested analyzer is skipped
- `resolveAnalyzerDisplayName()` falls back to skipped analyzer metadata so the display name shows correctly instead of the raw ID