### PR TITLE
feat: track and report suppressed/ignored issues

### DIFF
--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -37,12 +37,16 @@ class AnalyzeCommand extends Command
 
     private InlineSuppressionParser $suppressionParser;
 
+    /** @var array<string, list<\ShieldCI\ValueObjects\SuppressionRecord>> */
+    private array $suppressedIssues = [];
+
     public function handle(
         AnalyzerManager $manager,
         ReporterInterface $reporter,
         \ShieldCI\Contracts\ClientInterface $client,
     ): int {
         $this->suppressionParser = new InlineSuppressionParser;
+        $this->suppressedIssues = [];
 
         // Activate CI mode for this run if --ci flag is passed
         if ($this->option('ci')) {
@@ -156,6 +160,19 @@ class AnalyzeCommand extends Command
             $report = $this->filterAgainstBaseline($report);
         }
 
+        // Inject all accumulated suppression records into the final report
+        $report = new AnalysisReport(
+            projectId: $report->projectId,
+            laravelVersion: $report->laravelVersion,
+            packageVersion: $report->packageVersion,
+            results: $report->results,
+            totalExecutionTime: $report->totalExecutionTime,
+            analyzedAt: $report->analyzedAt,
+            triggeredBy: $report->triggeredBy,
+            metadata: $report->metadata,
+            suppressedIssues: $this->suppressedIssues,
+        );
+
         // Output report (skip if already streamed)
         if (! $useStreaming) {
             $this->outputReport($report, $reporter);
@@ -258,14 +275,22 @@ class AnalyzeCommand extends Command
                 );
 
                 // Apply ignore_errors and inline suppression filtering before streaming
-                $filteredResult = $this->filterSingleResultAgainstIgnoreErrors($enrichedResult);
-                $filteredResult = $this->filterSingleResultAgainstInlineSuppressions($filteredResult);
+                $fr1 = $this->filterSingleResultAgainstIgnoreErrors($enrichedResult);
+                $fr2 = $this->filterSingleResultAgainstInlineSuppressions($fr1->result);
+                $analyzerId = $enrichedResult->getAnalyzerId();
+                $this->accumulateSuppressed($fr1->suppressedRecords, $analyzerId);
+                $this->accumulateSuppressed($fr2->suppressedRecords, $analyzerId);
 
-                $results->push($filteredResult);
+                $results->push($fr2->result);
 
                 // Stream output immediately
                 $categoryLabel = $metadata->category->label();
-                $this->line($reporter->streamResult($filteredResult, $current, $total, $categoryLabel));
+                $this->line($reporter->streamResult($fr2->result, $current, $total, $categoryLabel));
+                $allSuppressed = array_merge($fr1->suppressedRecords, $fr2->suppressedRecords);
+                if ($allSuppressed !== []) {
+                    $count = count($allSuppressed);
+                    $this->line('  ('.$count.' '.($count === 1 ? 'issue' : 'issues').' suppressed — use --format=json to see details)');
+                }
             }
 
             return $results;
@@ -384,13 +409,21 @@ class AnalyzeCommand extends Command
                 );
 
                 // Apply ignore_errors and inline suppression filtering before streaming
-                $filteredResult = $this->filterSingleResultAgainstIgnoreErrors($enrichedResult);
-                $filteredResult = $this->filterSingleResultAgainstInlineSuppressions($filteredResult);
+                $fr1 = $this->filterSingleResultAgainstIgnoreErrors($enrichedResult);
+                $fr2 = $this->filterSingleResultAgainstInlineSuppressions($fr1->result);
+                $analyzerId = $enrichedResult->getAnalyzerId();
+                $this->accumulateSuppressed($fr1->suppressedRecords, $analyzerId);
+                $this->accumulateSuppressed($fr2->suppressedRecords, $analyzerId);
 
-                $results->push($filteredResult);
+                $results->push($fr2->result);
 
                 // Stream output immediately
-                $this->line($reporter->streamResult($filteredResult, $current, $total, $categoryLabel));
+                $this->line($reporter->streamResult($fr2->result, $current, $total, $categoryLabel));
+                $allSuppressed = array_merge($fr1->suppressedRecords, $fr2->suppressedRecords);
+                if ($allSuppressed !== []) {
+                    $count = count($allSuppressed);
+                    $this->line('  ('.$count.' '.($count === 1 ? 'issue' : 'issues').' suppressed — use --format=json to see details)');
+                }
             }
         }
 
@@ -1157,27 +1190,35 @@ class AnalyzeCommand extends Command
      * Filter a single result against ignore_errors config.
      * Used in streaming mode to filter results before displaying them.
      */
-    protected function filterSingleResultAgainstIgnoreErrors(\ShieldCI\AnalyzersCore\Results\AnalysisResult $result): \ShieldCI\AnalyzersCore\Results\AnalysisResult
+    protected function filterSingleResultAgainstIgnoreErrors(\ShieldCI\AnalyzersCore\Results\AnalysisResult $result): \ShieldCI\ValueObjects\FilterResult
     {
         $configIgnoreErrors = config('shieldci.ignore_errors', []);
         $configIgnoreErrors = is_array($configIgnoreErrors) ? $configIgnoreErrors : [];
 
         if (empty($configIgnoreErrors)) {
-            return $result;
+            return new \ShieldCI\ValueObjects\FilterResult($result, []);
         }
 
         $analyzerId = $result->getAnalyzerId();
 
         // If no ignore_errors for this analyzer, return as-is
         if (! isset($configIgnoreErrors[$analyzerId])) {
-            return $result;
+            return new \ShieldCI\ValueObjects\FilterResult($result, []);
         }
 
         $currentIssues = $result->getIssues();
+        $suppressedRecords = [];
 
         // Filter out issues that match ignore_errors config
-        $newIssues = collect($currentIssues)->filter(function ($issue) use ($configIgnoreErrors, $analyzerId) {
-            if ($this->matchesIgnoreError($issue, $configIgnoreErrors[$analyzerId])) {
+        $newIssues = collect($currentIssues)->filter(function ($issue) use ($configIgnoreErrors, $analyzerId, &$suppressedRecords) {
+            $matchingRule = $this->findMatchingIgnoreRule($issue, $configIgnoreErrors[$analyzerId]);
+            if ($matchingRule !== null) {
+                $suppressedRecords[] = new \ShieldCI\ValueObjects\SuppressionRecord(
+                    $issue,
+                    \ShieldCI\Enums\SuppressionType::Config,
+                    $this->describeIgnoreRule($matchingRule)
+                );
+
                 return false; // Issue matches ignore_errors, filter it out
             }
 
@@ -1218,13 +1259,16 @@ class AnalyzeCommand extends Command
             }
         }
 
-        return new \ShieldCI\AnalyzersCore\Results\AnalysisResult(
-            analyzerId: $result->getAnalyzerId(),
-            status: $status,
-            message: $message,
-            issues: $newIssues->all(),
-            executionTime: $result->getExecutionTime(),
-            metadata: $result->getMetadata(),
+        return new \ShieldCI\ValueObjects\FilterResult(
+            new \ShieldCI\AnalyzersCore\Results\AnalysisResult(
+                analyzerId: $result->getAnalyzerId(),
+                status: $status,
+                message: $message,
+                issues: $newIssues->all(),
+                executionTime: $result->getExecutionTime(),
+                metadata: $result->getMetadata(),
+            ),
+            $suppressedRecords
         );
     }
 
@@ -1240,68 +1284,16 @@ class AnalyzeCommand extends Command
             return $report;
         }
 
-        // Filter results
-        $filteredResults = $report->results->map(function ($result) use ($configIgnoreErrors) {
-            $analyzerId = $result->getAnalyzerId();
-
-            // If no ignore_errors for this analyzer, return as-is
-            if (! isset($configIgnoreErrors[$analyzerId])) {
+        // Filter results, accumulating suppression records via the single-result method
+        $filteredResults = $report->results->map(function ($result) {
+            if (! $result instanceof \ShieldCI\AnalyzersCore\Results\AnalysisResult) {
                 return $result;
             }
 
-            $currentIssues = $result->getIssues();
+            $fr = $this->filterSingleResultAgainstIgnoreErrors($result);
+            $this->accumulateSuppressed($fr->suppressedRecords, $result->getAnalyzerId());
 
-            // Filter out issues that match ignore_errors config
-            $newIssues = collect($currentIssues)->filter(function ($issue) use ($configIgnoreErrors, $analyzerId) {
-                if ($this->matchesIgnoreError($issue, $configIgnoreErrors[$analyzerId])) {
-                    return false; // Issue matches ignore_errors, filter it out
-                }
-
-                return true; // Keep issue
-            });
-
-            // Create new result with filtered issues
-            $status = $newIssues->isEmpty()
-                ? \ShieldCI\AnalyzersCore\Enums\Status::Passed
-                : $result->getStatus();
-
-            // Update message to reflect filtered count
-            $message = $result->getMessage();
-            if ($newIssues->isEmpty()) {
-                $message = 'All issues are ignored via config';
-            } elseif ($newIssues->count() !== count($currentIssues)) {
-                // Some (but not all) issues were filtered - update the count in the message
-                $originalCount = count($currentIssues);
-                $filteredCount = $newIssues->count();
-
-                // Update numeric counts in the message
-                $updatedMessage = preg_replace('/\b'.$originalCount.'\b/', (string) $filteredCount, $message, 1);
-                $message = is_string($updatedMessage) ? $updatedMessage : $message;
-
-                // Fix singular/plural grammar (e.g., "1 dependency stability issues" -> "1 dependency stability issue")
-                if ($filteredCount === 1) {
-                    $message = preg_replace_callback('/\b(issues|errors|warnings|problems|vulnerabilities)\b/', function ($matches) {
-                        $singular = [
-                            'issues' => 'issue',
-                            'errors' => 'error',
-                            'warnings' => 'warning',
-                            'problems' => 'problem',
-                            'vulnerabilities' => 'vulnerability',
-                        ];
-
-                        return $singular[strtolower($matches[1])] ?? $matches[1];
-                    }, $message, 1) ?? $message;
-                }
-            }
-
-            return new \ShieldCI\AnalyzersCore\Results\AnalysisResult(
-                analyzerId: $result->getAnalyzerId(),
-                status: $status,
-                message: $message,
-                issues: $newIssues->all(),
-                executionTime: $result->getExecutionTime(),
-                metadata: $result->getMetadata(),
-            );
+            return $fr->result;
         });
 
         // Return new report with filtered results
@@ -1321,28 +1313,39 @@ class AnalyzeCommand extends Command
      * Filter a single result against inline @shieldci-ignore comments.
      * Used in streaming mode to filter results before displaying them.
      */
-    protected function filterSingleResultAgainstInlineSuppressions(\ShieldCI\AnalyzersCore\Results\AnalysisResult $result): \ShieldCI\AnalyzersCore\Results\AnalysisResult
+    protected function filterSingleResultAgainstInlineSuppressions(\ShieldCI\AnalyzersCore\Results\AnalysisResult $result): \ShieldCI\ValueObjects\FilterResult
     {
         $currentIssues = $result->getIssues();
 
         if ($currentIssues === []) {
-            return $result;
+            return new \ShieldCI\ValueObjects\FilterResult($result, []);
         }
 
         $analyzerId = $result->getAnalyzerId();
+        $suppressedRecords = [];
 
-        $newIssues = array_filter($currentIssues, function ($issue) use ($analyzerId) {
+        $newIssues = array_filter($currentIssues, function ($issue) use ($analyzerId, &$suppressedRecords) {
             $location = $issue->location;
 
             if ($location === null || $location->line === null || $location->line < 1) {
                 return true; // Keep issues without a location — can't suppress inline
             }
 
-            return ! $this->suppressionParser->isLineSuppressed($location->file, $location->line, $analyzerId);
+            if ($this->suppressionParser->isLineSuppressed($location->file, $location->line, $analyzerId)) {
+                $suppressedRecords[] = new \ShieldCI\ValueObjects\SuppressionRecord(
+                    $issue,
+                    \ShieldCI\Enums\SuppressionType::Inline,
+                    '@shieldci-ignore at '.$location->file.':'.$location->line
+                );
+
+                return false;
+            }
+
+            return true;
         });
 
         if (count($newIssues) === count($currentIssues)) {
-            return $result; // Nothing was suppressed
+            return new \ShieldCI\ValueObjects\FilterResult($result, []); // Nothing was suppressed
         }
 
         $status = $newIssues === []
@@ -1351,13 +1354,16 @@ class AnalyzeCommand extends Command
 
         $message = $this->adjustFilteredMessage($result->getMessage(), count($currentIssues), count($newIssues));
 
-        return new \ShieldCI\AnalyzersCore\Results\AnalysisResult(
-            analyzerId: $result->getAnalyzerId(),
-            status: $status,
-            message: $message,
-            issues: array_values($newIssues),
-            executionTime: $result->getExecutionTime(),
-            metadata: $result->getMetadata(),
+        return new \ShieldCI\ValueObjects\FilterResult(
+            new \ShieldCI\AnalyzersCore\Results\AnalysisResult(
+                analyzerId: $result->getAnalyzerId(),
+                status: $status,
+                message: $message,
+                issues: array_values($newIssues),
+                executionTime: $result->getExecutionTime(),
+                metadata: $result->getMetadata(),
+            ),
+            $suppressedRecords
         );
     }
 
@@ -1371,7 +1377,10 @@ class AnalyzeCommand extends Command
                 return $result;
             }
 
-            return $this->filterSingleResultAgainstInlineSuppressions($result);
+            $fr = $this->filterSingleResultAgainstInlineSuppressions($result);
+            $this->accumulateSuppressed($fr->suppressedRecords, $result->getAnalyzerId());
+
+            return $fr->result;
         });
 
         return new AnalysisReport(
@@ -1441,18 +1450,27 @@ class AnalyzeCommand extends Command
 
             $baselineIssues = $baselineErrors[$analyzerId];
             $currentIssues = $result->getIssues();
+            $suppressedRecords = [];
 
             // Filter out issues that exist in baseline
-            $newIssues = collect($currentIssues)->filter(function ($issue) use ($baselineIssues) {
+            $newIssues = collect($currentIssues)->filter(function ($issue) use ($baselineIssues, &$suppressedRecords) {
                 /** @var array<int, array<string, mixed>> $baselineIssues */
                 foreach ($baselineIssues as $baselineIssue) {
                     if (is_array($baselineIssue) && $this->matchesBaselineIssue($issue, $baselineIssue)) {
+                        $suppressedRecords[] = new \ShieldCI\ValueObjects\SuppressionRecord(
+                            $issue,
+                            \ShieldCI\Enums\SuppressionType::Baseline,
+                            $this->describeBaselineMatch($baselineIssue)
+                        );
+
                         return false; // Issue matches baseline, filter it out
                     }
                 }
 
                 return true; // New issue
             });
+
+            $this->accumulateSuppressed($suppressedRecords, $analyzerId);
 
             // Create new result with filtered issues
             $status = $newIssues->isEmpty()
@@ -1512,24 +1530,83 @@ class AnalyzeCommand extends Command
     }
 
     /**
-     * Check if an issue matches an ignore_errors config entry.
+     * Push suppression records into the instance accumulator for a given analyzer.
      *
-     * Matching logic:
-     * - If rule specifies 'path': exact path match required
-     * - If rule specifies 'path_pattern': glob pattern match required
-     * - If rule specifies 'message': exact message match required
-     * - If rule specifies 'message_pattern': wildcard pattern match required
-     *   (also matches against recommendation field for analyzers like PHPStan)
-     * - If rule specifies only path criteria: matches ANY message
-     * - If rule specifies only message criteria: matches ANY path
-     * - If rule specifies both: BOTH must match
+     * @param  list<\ShieldCI\ValueObjects\SuppressionRecord>  $records
+     */
+    private function accumulateSuppressed(array $records, string $analyzerId): void
+    {
+        if ($records === []) {
+            return;
+        }
+
+        if (! isset($this->suppressedIssues[$analyzerId])) {
+            $this->suppressedIssues[$analyzerId] = [];
+        }
+
+        foreach ($records as $record) {
+            $this->suppressedIssues[$analyzerId][] = $record;
+        }
+    }
+
+    /**
+     * Build a human-readable description of an ignore_errors rule.
+     *
+     * @param  array<string, mixed>  $rule
+     */
+    private function describeIgnoreRule(array $rule): string
+    {
+        if (isset($rule['path_pattern']) && is_string($rule['path_pattern'])) {
+            return 'path_pattern: '.$rule['path_pattern'];
+        }
+
+        if (isset($rule['path']) && is_string($rule['path'])) {
+            return 'path: '.$rule['path'];
+        }
+
+        if (isset($rule['message_pattern']) && is_string($rule['message_pattern'])) {
+            return 'message_pattern: '.$rule['message_pattern'];
+        }
+
+        if (isset($rule['message']) && is_string($rule['message'])) {
+            return 'message: '.$rule['message'];
+        }
+
+        return 'config rule';
+    }
+
+    /**
+     * Build a human-readable description of a baseline match.
+     *
+     * @param  array<string, mixed>  $baselineIssue
+     */
+    private function describeBaselineMatch(array $baselineIssue): string
+    {
+        if (isset($baselineIssue['hash']) && is_string($baselineIssue['hash'])) {
+            return 'baseline hash: '.substr($baselineIssue['hash'], 0, 8).'...';
+        }
+
+        if (isset($baselineIssue['path']) && is_string($baselineIssue['path'])) {
+            return 'baseline match: '.$baselineIssue['path'];
+        }
+
+        if (isset($baselineIssue['path_pattern']) && is_string($baselineIssue['path_pattern'])) {
+            return 'baseline pattern: '.$baselineIssue['path_pattern'];
+        }
+
+        return 'baseline match';
+    }
+
+    /**
+     * Find the first ignore_errors rule that matches an issue and return it, or null if none match.
      *
      * @param  array<int, array<string, mixed>>  $ignoreErrors
+     * @return array<string, mixed>|null
      */
-    private function matchesIgnoreError(\ShieldCI\AnalyzersCore\ValueObjects\Issue $issue, array $ignoreErrors): bool
+    private function findMatchingIgnoreRule(\ShieldCI\AnalyzersCore\ValueObjects\Issue $issue, array $ignoreErrors): ?array
     {
         if (! is_array($ignoreErrors)) {
-            return false;
+            return null;
         }
 
         $issuePath = $issue->location->file ?? 'unknown';
@@ -1540,69 +1617,50 @@ class AnalyzeCommand extends Command
                 continue;
             }
 
-            // Skip empty rules - they should not match anything
             $hasAtLeastOneCriterion = isset($ignoreError['path']) ||
                                      isset($ignoreError['path_pattern']) ||
                                      isset($ignoreError['message']) ||
                                      isset($ignoreError['message_pattern']);
 
             if (! $hasAtLeastOneCriterion) {
-                continue; // Empty rule, skip it
+                continue;
             }
 
-            // Default to true - if a criterion is not specified, it matches everything
-            // This allows rules like { "path": "foo.php" } to match any message in that file
             $pathMatches = true;
             $messageMatches = true;
 
-            // Check path (exact match only)
             if (isset($ignoreError['path']) && is_string($ignoreError['path'])) {
                 $ignorePath = $ignoreError['path'];
                 $normalizedIssuePath = str_replace('\\', '/', $issuePath);
                 $normalizedIgnorePath = str_replace('\\', '/', $ignorePath);
-
-                // Exact match only (normalized for cross-platform compatibility)
                 $pathMatches = $ignorePath === $issuePath || $normalizedIgnorePath === $normalizedIssuePath;
             }
 
-            // Check path_pattern (glob pattern match)
             if (isset($ignoreError['path_pattern']) && is_string($ignoreError['path_pattern'])) {
                 $pattern = $ignoreError['path_pattern'];
                 $normalizedIssuePath = str_replace('\\', '/', $issuePath);
-
-                // Use fnmatch for glob patterns (cross-platform)
                 $pathMatches = fnmatch($pattern, $issuePath) ||
                               fnmatch($pattern, $normalizedIssuePath) ||
                               \Illuminate\Support\Str::is($pattern, $issuePath);
             }
 
-            // Check message (exact match only)
             if (isset($ignoreError['message']) && is_string($ignoreError['message'])) {
-                $ignoreMessage = $ignoreError['message'];
-
-                // Exact match only
-                $messageMatches = $ignoreMessage === $issueMessage;
+                $messageMatches = $ignoreError['message'] === $issueMessage;
             }
 
-            // Check message_pattern (wildcard pattern match)
             if (isset($ignoreError['message_pattern']) && is_string($ignoreError['message_pattern'])) {
                 $pattern = $ignoreError['message_pattern'];
-
-                // Use Laravel Str::is for wildcard matching
-                // Match against both message AND recommendation (PHPStan errors include details in recommendation)
                 $issueRecommendation = $issue->recommendation ?? '';
                 $messageMatches = \Illuminate\Support\Str::is($pattern, $issueMessage) ||
                                  \Illuminate\Support\Str::is($pattern, $issueRecommendation);
             }
 
-            // Both path and message criteria must match
-            // (if a criterion is not specified, it defaults to true)
             if ($pathMatches && $messageMatches) {
-                return true;
+                return $ignoreError;
             }
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/src/Enums/SuppressionType.php
+++ b/src/Enums/SuppressionType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Enums;
+
+enum SuppressionType: string
+{
+    case Inline = 'inline';
+    case Config = 'config';
+    case Baseline = 'baseline';
+}

--- a/src/Support/Reporter.php
+++ b/src/Support/Reporter.php
@@ -108,6 +108,12 @@ class Reporter implements ReporterInterface
                     $statusLine .= ' '.$this->color("({$timeLabel} to fix)", 'gray');
                 }
 
+                $suppressedForThis = $report->suppressedIssues[$result->getAnalyzerId()] ?? [];
+                if ($suppressedForThis !== []) {
+                    $count = count($suppressedForThis);
+                    $statusLine .= $this->color(' ('.$count.' '.($count === 1 ? 'issue' : 'issues').' suppressed)', 'gray');
+                }
+
                 $output[] = $this->color("Analyzer {$current}/{$total}: ", 'yellow').$statusLine;
 
                 // Show skip reason for skipped analyzers

--- a/src/ValueObjects/AnalysisReport.php
+++ b/src/ValueObjects/AnalysisReport.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Illuminate\Support\Collection;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Status;
+use ShieldCI\Enums\SuppressionType;
 use ShieldCI\Enums\TriggerSource;
 
 /**
@@ -17,6 +18,7 @@ final class AnalysisReport
 {
     /**
      * @param  Collection<int, ResultInterface>  $results
+     * @param  array<string, list<SuppressionRecord>>  $suppressedIssues
      */
     public function __construct(
         public readonly string $projectId,
@@ -27,6 +29,7 @@ final class AnalysisReport
         public readonly DateTimeImmutable $analyzedAt,
         public readonly TriggerSource $triggeredBy = TriggerSource::Manual,
         public readonly array $metadata = [],
+        public readonly array $suppressedIssues = [],
     ) {}
 
     public function score(): int
@@ -110,6 +113,33 @@ final class AnalysisReport
         return $counts;
     }
 
+    /**
+     * @return array{inline: int, config: int, baseline: int, total: int}
+     */
+    public function suppressedSummary(): array
+    {
+        $counts = [
+            'inline' => 0,
+            'config' => 0,
+            'baseline' => 0,
+            'total' => 0,
+        ];
+
+        foreach ($this->suppressedIssues as $records) {
+            foreach ($records as $record) {
+                $key = match ($record->type) {
+                    SuppressionType::Inline => 'inline',
+                    SuppressionType::Config => 'config',
+                    SuppressionType::Baseline => 'baseline',
+                };
+                $counts[$key]++;
+                $counts['total']++;
+            }
+        }
+
+        return $counts;
+    }
+
     public function summary(): array
     {
         return [
@@ -122,6 +152,7 @@ final class AnalysisReport
             'total_issues' => $this->totalIssues(),
             'issues_by_severity' => $this->issuesBySeverity(),
             'score' => $this->score(),
+            'suppressed_issues' => $this->suppressedSummary(),
         ];
     }
 
@@ -135,7 +166,15 @@ final class AnalysisReport
             'analyzed_at' => $this->analyzedAt->format('c'),
             'total_execution_time' => $this->totalExecutionTime,
             'summary' => $this->summary(),
-            'results' => $this->results->map(fn (ResultInterface $result) => $result->toArray())->all(),
+            'results' => $this->results->map(function (ResultInterface $result) {
+                $arr = $result->toArray();
+                $arr['suppressed_issues'] = array_map(
+                    fn (SuppressionRecord $r) => $r->toArray(),
+                    $this->suppressedIssues[$result->getAnalyzerId()] ?? []
+                );
+
+                return $arr;
+            })->all(),
             'metadata' => $this->metadata,
         ];
     }

--- a/src/ValueObjects/FilterResult.php
+++ b/src/ValueObjects/FilterResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\ValueObjects;
+
+use ShieldCI\AnalyzersCore\Results\AnalysisResult;
+
+/**
+ * Internal envelope returned by single-result filter methods.
+ * Carries the filtered result together with any records that were suppressed.
+ */
+final class FilterResult
+{
+    /**
+     * @param  list<SuppressionRecord>  $suppressedRecords
+     */
+    public function __construct(
+        public readonly AnalysisResult $result,
+        public readonly array $suppressedRecords,
+    ) {}
+}

--- a/src/ValueObjects/SuppressionRecord.php
+++ b/src/ValueObjects/SuppressionRecord.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\ValueObjects;
+
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
+use ShieldCI\Enums\SuppressionType;
+
+/**
+ * Records a single issue that was suppressed during analysis.
+ */
+final class SuppressionRecord
+{
+    public function __construct(
+        public readonly Issue $issue,
+        public readonly SuppressionType $type,
+        public readonly string $description,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $arr = $this->issue->toArray();
+        $arr['suppression'] = [
+            'type' => $this->type->value,
+            'description' => $this->description,
+        ];
+
+        return $arr;
+    }
+}

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -3605,4 +3605,229 @@ PHP);
                 && ($metadata['base_branch'] ?? '') === 'main';
         });
     }
+
+    // ─── Suppressed Issues Tracking ───────────────────────────────────────────
+
+    #[Test]
+    public function json_output_includes_suppressed_issues_for_config_suppression(): void
+    {
+        $outputPath = sys_get_temp_dir().'/shieldci-suppression-config-test-'.uniqid().'.json';
+
+        config([
+            'shieldci.fail_on' => 'never',
+            'shieldci.report.output_file' => $outputPath,
+            'shieldci.ignore_errors' => [
+                'test-security-failed' => [
+                    ['path' => '/app/Vulnerable.php'],
+                ],
+            ],
+        ]);
+        $this->registerFailedAnalyzers();
+
+        $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful();
+
+        $this->assertFileExists($outputPath);
+        $json = (string) file_get_contents($outputPath);
+        /** @var array<string, mixed> $data */
+        $data = json_decode($json, true);
+
+        // Verify suppressed_issues present in result
+        $result = collect((array) $data['results'])->firstWhere('analyzer_id', 'test-security-failed');
+        $this->assertNotNull($result, 'Result for test-security-failed not found');
+        $this->assertArrayHasKey('suppressed_issues', $result);
+        $this->assertCount(1, $result['suppressed_issues']);
+        $this->assertSame('config', $result['suppressed_issues'][0]['suppression']['type']);
+        $this->assertSame('SQL Injection vulnerability', $result['suppressed_issues'][0]['message']);
+
+        // Verify summary counts
+        $this->assertSame(1, $data['summary']['suppressed_issues']['config']);
+        $this->assertSame(1, $data['summary']['suppressed_issues']['total']);
+
+        @unlink($outputPath);
+    }
+
+    #[Test]
+    public function json_output_includes_suppressed_issues_for_inline_suppression(): void
+    {
+        $file = $this->createTempPhpFile(<<<'PHP'
+<?php
+// @shieldci-ignore
+$result = DB::select("SELECT * FROM users WHERE id = $id");
+PHP);
+
+        $result = new AnalysisResult(
+            analyzerId: 'sql-injection',
+            status: Status::Failed,
+            message: 'Found 1 issues',
+            issues: [
+                new Issue(
+                    message: 'SQL Injection detected',
+                    location: new \ShieldCI\AnalyzersCore\ValueObjects\Location($file, 3),
+                    severity: Severity::Critical,
+                    recommendation: 'Use prepared statements',
+                ),
+            ],
+            executionTime: 0.1,
+            metadata: [
+                'id' => 'sql-injection',
+                'name' => 'SQL Injection',
+                'description' => 'Detects SQL injection',
+                'category' => Category::Security,
+                'severity' => Severity::Critical,
+            ],
+        );
+
+        $outputPath = sys_get_temp_dir().'/shieldci-suppression-inline-test-'.uniqid().'.json';
+
+        $this->registerManagerWithResults([$result]);
+        config([
+            'shieldci.fail_on' => 'never',
+            'shieldci.report.output_file' => $outputPath,
+        ]);
+
+        $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful();
+
+        $this->assertFileExists($outputPath);
+        $json = (string) file_get_contents($outputPath);
+        /** @var array<string, mixed> $data */
+        $data = json_decode($json, true);
+
+        $result = collect((array) $data['results'])->firstWhere('analyzer_id', 'sql-injection');
+        $this->assertNotNull($result, 'Result for sql-injection not found');
+        $this->assertArrayHasKey('suppressed_issues', $result);
+        $this->assertCount(1, $result['suppressed_issues']);
+        $this->assertSame('inline', $result['suppressed_issues'][0]['suppression']['type']);
+        $this->assertSame('SQL Injection detected', $result['suppressed_issues'][0]['message']);
+
+        unlink($outputPath);
+        $this->cleanupTempPaths();
+    }
+
+    #[Test]
+    public function json_output_includes_suppressed_issues_for_baseline_suppression(): void
+    {
+        $this->registerFailedAnalyzers();
+
+        $baselinePath = sys_get_temp_dir().'/test-baseline-suppression-'.uniqid().'.json';
+        $outputPath = sys_get_temp_dir().'/shieldci-suppression-baseline-test-'.uniqid().'.json';
+
+        $issueHash = hash('sha256', json_encode([
+            'file' => '/app/Vulnerable.php',
+            'line' => 42,
+            'message' => 'SQL Injection vulnerability',
+        ]) ?: '');
+
+        $baseline = [
+            'generated_at' => '2024-01-01T00:00:00Z',
+            'version' => '1.0.0',
+            'errors' => [
+                'test-security-failed' => [
+                    ['hash' => $issueHash],
+                ],
+            ],
+        ];
+
+        file_put_contents($baselinePath, json_encode($baseline));
+        config([
+            'shieldci.baseline_file' => $baselinePath,
+            'shieldci.fail_on' => 'never',
+            'shieldci.report.output_file' => $outputPath,
+        ]);
+
+        $this->artisan('shield:analyze', ['--baseline' => true, '--format' => 'json'])
+            ->assertSuccessful();
+
+        $this->assertFileExists($outputPath);
+        $json = (string) file_get_contents($outputPath);
+        /** @var array<string, mixed> $data */
+        $data = json_decode($json, true);
+
+        $result = collect((array) $data['results'])->firstWhere('analyzer_id', 'test-security-failed');
+        $this->assertNotNull($result, 'Result for test-security-failed not found');
+        $this->assertArrayHasKey('suppressed_issues', $result);
+        $this->assertCount(1, $result['suppressed_issues']);
+        $this->assertSame('baseline', $result['suppressed_issues'][0]['suppression']['type']);
+        $this->assertSame('SQL Injection vulnerability', $result['suppressed_issues'][0]['message']);
+
+        @unlink($baselinePath);
+        @unlink($outputPath);
+    }
+
+    #[Test]
+    public function json_summary_includes_suppressed_issues_counts(): void
+    {
+        $outputPath = sys_get_temp_dir().'/shieldci-suppression-summary-test-'.uniqid().'.json';
+
+        config([
+            'shieldci.fail_on' => 'never',
+            'shieldci.report.output_file' => $outputPath,
+            'shieldci.ignore_errors' => [
+                'test-security-failed' => [
+                    ['path' => '/app/Vulnerable.php'],
+                ],
+            ],
+        ]);
+        $this->registerFailedAnalyzers();
+
+        $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful();
+
+        $this->assertFileExists($outputPath);
+        $json = (string) file_get_contents($outputPath);
+        /** @var array<string, mixed> $data */
+        $data = json_decode($json, true);
+
+        $this->assertSame(1, $data['summary']['suppressed_issues']['config']);
+        $this->assertSame(0, $data['summary']['suppressed_issues']['inline']);
+        $this->assertSame(0, $data['summary']['suppressed_issues']['baseline']);
+        $this->assertSame(1, $data['summary']['suppressed_issues']['total']);
+
+        unlink($outputPath);
+    }
+
+    #[Test]
+    public function console_output_shows_suppression_count_hint(): void
+    {
+        config([
+            'shieldci.fail_on' => 'never',
+            'shieldci.ignore_errors' => [
+                'test-security-failed' => [
+                    ['path' => '/app/Vulnerable.php'],
+                ],
+            ],
+        ]);
+        $this->registerFailedAnalyzers();
+
+        $this->artisan('shield:analyze', ['--format' => 'console'])
+            ->assertSuccessful()
+            ->expectsOutputToContain('suppressed');
+    }
+
+    #[Test]
+    public function suppressed_issues_is_empty_array_when_no_suppression_occurs(): void
+    {
+        $outputPath = sys_get_temp_dir().'/shieldci-suppression-empty-test-'.uniqid().'.json';
+
+        $this->registerTestAnalyzers();
+        config(['shieldci.report.output_file' => $outputPath]);
+
+        $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful();
+
+        $this->assertFileExists($outputPath);
+        $json = (string) file_get_contents($outputPath);
+        /** @var array<string, mixed> $data */
+        $data = json_decode($json, true);
+
+        /** @var array<int, array<string, mixed>> $results */
+        $results = $data['results'];
+        foreach ($results as $result) {
+            $this->assertSame([], $result['suppressed_issues'] ?? null, "Expected empty suppressed_issues for {$result['analyzer_id']}");
+        }
+        $this->assertSame(0, $data['summary']['suppressed_issues']['total']);
+
+        unlink($outputPath);
+    }
 }

--- a/tests/Unit/ValueObjects/AnalysisReportTest.php
+++ b/tests/Unit/ValueObjects/AnalysisReportTest.php
@@ -482,6 +482,142 @@ class AnalysisReportTest extends TestCase
         $this->assertSame($datetime, $report->analyzedAt);
     }
 
+    #[Test]
+    public function it_defaults_suppressed_issues_to_empty_array(): void
+    {
+        $report = $this->createReport(collect());
+
+        $this->assertSame([], $report->suppressedIssues);
+    }
+
+    #[Test]
+    public function suppressed_summary_counts_by_type_correctly(): void
+    {
+        $issue = new Issue(
+            message: 'Test',
+            location: new Location('/test.php', 1),
+            severity: Severity::High,
+            recommendation: 'Fix it',
+        );
+
+        $report = new AnalysisReport(
+            projectId: 'test-project-id',
+            laravelVersion: app()->version(),
+            packageVersion: '1.0.0',
+            results: collect([AnalysisResult::passed('analyzer-1', 'Passed')]),
+            totalExecutionTime: 1.0,
+            analyzedAt: new DateTimeImmutable,
+            suppressedIssues: [
+                'analyzer-1' => [
+                    new \ShieldCI\ValueObjects\SuppressionRecord($issue, \ShieldCI\Enums\SuppressionType::Inline, '@shieldci-ignore'),
+                    new \ShieldCI\ValueObjects\SuppressionRecord($issue, \ShieldCI\Enums\SuppressionType::Config, 'path: test.php'),
+                    new \ShieldCI\ValueObjects\SuppressionRecord($issue, \ShieldCI\Enums\SuppressionType::Config, 'path: other.php'),
+                    new \ShieldCI\ValueObjects\SuppressionRecord($issue, \ShieldCI\Enums\SuppressionType::Baseline, 'baseline hash: abc123...'),
+                ],
+            ],
+        );
+
+        $summary = $report->suppressedSummary();
+
+        $this->assertSame(1, $summary['inline']);
+        $this->assertSame(2, $summary['config']);
+        $this->assertSame(1, $summary['baseline']);
+        $this->assertSame(4, $summary['total']);
+    }
+
+    #[Test]
+    public function suppressed_summary_returns_zeros_when_no_suppressions(): void
+    {
+        $report = $this->createReport(collect());
+
+        $summary = $report->suppressedSummary();
+
+        $this->assertSame(0, $summary['inline']);
+        $this->assertSame(0, $summary['config']);
+        $this->assertSame(0, $summary['baseline']);
+        $this->assertSame(0, $summary['total']);
+    }
+
+    #[Test]
+    public function summary_includes_suppressed_issues_counts(): void
+    {
+        $issue = new Issue(
+            message: 'Test',
+            location: new Location('/test.php', 1),
+            severity: Severity::High,
+            recommendation: 'Fix it',
+        );
+
+        $report = new AnalysisReport(
+            projectId: 'test-project-id',
+            laravelVersion: app()->version(),
+            packageVersion: '1.0.0',
+            results: collect([AnalysisResult::passed('analyzer-1', 'Passed')]),
+            totalExecutionTime: 1.0,
+            analyzedAt: new DateTimeImmutable,
+            suppressedIssues: [
+                'analyzer-1' => [
+                    new \ShieldCI\ValueObjects\SuppressionRecord($issue, \ShieldCI\Enums\SuppressionType::Config, 'path: test.php'),
+                ],
+            ],
+        );
+
+        $summary = $report->summary();
+
+        $this->assertArrayHasKey('suppressed_issues', $summary);
+        $this->assertSame(1, $summary['suppressed_issues']['config']);
+        $this->assertSame(1, $summary['suppressed_issues']['total']);
+    }
+
+    #[Test]
+    public function to_array_includes_suppressed_issues_per_result(): void
+    {
+        $issue = new Issue(
+            message: 'SQL Injection',
+            location: new Location('/app/Vulnerable.php', 42),
+            severity: Severity::Critical,
+            recommendation: 'Use prepared statements',
+        );
+
+        $results = collect([AnalysisResult::passed('xss-detection', 'Passed')]);
+        $report = new AnalysisReport(
+            projectId: 'test-project-id',
+            laravelVersion: app()->version(),
+            packageVersion: '1.0.0',
+            results: $results,
+            totalExecutionTime: 1.0,
+            analyzedAt: new DateTimeImmutable,
+            suppressedIssues: [
+                'xss-detection' => [
+                    new \ShieldCI\ValueObjects\SuppressionRecord($issue, \ShieldCI\Enums\SuppressionType::Config, 'path_pattern: app/Legacy/*.php'),
+                ],
+            ],
+        );
+
+        $arr = $report->toArray();
+        $resultArr = $arr['results'][0];
+
+        $this->assertArrayHasKey('suppressed_issues', $resultArr);
+        $this->assertCount(1, $resultArr['suppressed_issues']);
+        $suppressed = $resultArr['suppressed_issues'][0];
+        $this->assertSame('SQL Injection', $suppressed['message']);
+        $this->assertSame('config', $suppressed['suppression']['type']);
+        $this->assertSame('path_pattern: app/Legacy/*.php', $suppressed['suppression']['description']);
+    }
+
+    #[Test]
+    public function to_array_includes_empty_suppressed_issues_when_none_for_result(): void
+    {
+        $results = collect([AnalysisResult::passed('xss-detection', 'Passed')]);
+        $report = $this->createReport($results);
+
+        $arr = $report->toArray();
+        $resultArr = $arr['results'][0];
+
+        $this->assertArrayHasKey('suppressed_issues', $resultArr);
+        $this->assertSame([], $resultArr['suppressed_issues']);
+    }
+
     private function createReport(Collection $results): AnalysisReport
     {
         return new AnalysisReport(

--- a/tests/Unit/ValueObjects/SuppressionRecordTest.php
+++ b/tests/Unit/ValueObjects/SuppressionRecordTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\ValueObjects;
+
+use PHPUnit\Framework\Attributes\Test;
+use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
+use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Enums\SuppressionType;
+use ShieldCI\Tests\TestCase;
+use ShieldCI\ValueObjects\SuppressionRecord;
+
+class SuppressionRecordTest extends TestCase
+{
+    private Issue $issue;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->issue = new Issue(
+            message: 'SQL Injection detected',
+            location: new Location('/app/Vulnerable.php', 42),
+            severity: Severity::Critical,
+            recommendation: 'Use prepared statements',
+        );
+    }
+
+    #[Test]
+    public function it_stores_all_properties(): void
+    {
+        $record = new SuppressionRecord(
+            $this->issue,
+            SuppressionType::Config,
+            'path_pattern: app/Legacy/*.php',
+        );
+
+        $this->assertSame($this->issue, $record->issue);
+        $this->assertSame(SuppressionType::Config, $record->type);
+        $this->assertSame('path_pattern: app/Legacy/*.php', $record->description);
+    }
+
+    #[Test]
+    public function to_array_includes_all_issue_fields_and_suppression_block(): void
+    {
+        $record = new SuppressionRecord(
+            $this->issue,
+            SuppressionType::Config,
+            'path_pattern: app/Legacy/*.php',
+        );
+
+        $arr = $record->toArray();
+
+        $this->assertSame('SQL Injection detected', $arr['message']);
+        $this->assertSame('critical', $arr['severity']);
+        $this->assertSame('Use prepared statements', $arr['recommendation']);
+        $this->assertArrayHasKey('location', $arr);
+        $this->assertArrayHasKey('suppression', $arr);
+        $this->assertSame('config', $arr['suppression']['type']);
+        $this->assertSame('path_pattern: app/Legacy/*.php', $arr['suppression']['description']);
+    }
+
+    #[Test]
+    public function to_array_serializes_inline_type_as_string(): void
+    {
+        $record = new SuppressionRecord(
+            $this->issue,
+            SuppressionType::Inline,
+            '@shieldci-ignore at /app/Vulnerable.php:42',
+        );
+
+        $arr = $record->toArray();
+
+        $this->assertSame('inline', $arr['suppression']['type']);
+    }
+
+    #[Test]
+    public function to_array_serializes_baseline_type_as_string(): void
+    {
+        $record = new SuppressionRecord(
+            $this->issue,
+            SuppressionType::Baseline,
+            'baseline hash: abc12345...',
+        );
+
+        $arr = $record->toArray();
+
+        $this->assertSame('baseline', $arr['suppression']['type']);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds full suppression tracking for the three active suppression mechanisms: `@shieldci-ignore` (inline), `ignore_errors` config rules, and `--baseline`
- Suppressed issues appear in a `suppressed_issues` array per analyzer result in JSON output, with full issue detail plus a `suppression` block containing `type` and `description` (e.g. `path_pattern: app/Legacy/*.php`, `baseline hash: abc12345...`)
- Top-level `summary` gains a `suppressed_issues` breakdown: `{inline, config, baseline, total}`
- Console output shows a brief count hint per analyzer when suppression occurs (e.g. `Passed (2 issues suppressed)`)
- Streaming mode emits the hint inline after each streamed result

## New files

- `src/Enums/SuppressionType.php` — `inline | config | baseline` backed enum
- `src/ValueObjects/SuppressionRecord.php` — immutable record of a suppressed issue + why
- `src/ValueObjects/FilterResult.php` — internal envelope pairing a filtered `AnalysisResult` with its suppression records (typed return for PHPStan Level 9)

## JSON shape

```json
{
  "summary": {
    "suppressed_issues": { "inline": 3, "config": 5, "baseline": 12, "total": 20 }
  },
  "results": [
    {
      "analyzer_id": "xss-detection",
      "suppressed_issues": [
        {
          "message": "Unescaped output detected",
          "severity": "critical",
          "suppression": { "type": "config", "description": "path_pattern: app/Legacy/*.php" }
        }
      ]
    }
  ]
}
```