### PR TITLE
feat: include configuration snapshot in JSON output and API payload

### DIFF
--- a/src/Support/Reporter.php
+++ b/src/Support/Reporter.php
@@ -35,6 +35,7 @@ class Reporter implements ReporterInterface
             analyzedAt: new DateTimeImmutable('now', new \DateTimeZone('UTC')),
             triggeredBy: $triggeredBy,
             metadata: $this->buildMetadata($gitContext),
+            configuration: $this->buildConfiguration(),
         );
     }
 
@@ -568,6 +569,84 @@ class Reporter implements ReporterInterface
         }
 
         return 'dev';
+    }
+
+    /**
+     * Build the effective configuration snapshot for the report payload.
+     *
+     * Captured inside generate() so runtime mutations (e.g. --ci sets shieldci.ci_mode)
+     * are reflected accurately.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildConfiguration(): array
+    {
+        $rawPaths = config('shieldci.paths.analyze', []);
+        $paths = is_array($rawPaths) ? array_values(array_filter($rawPaths, 'is_string')) : [];
+
+        $rawExcluded = config('shieldci.excluded_paths', []);
+        $excludedPaths = is_array($rawExcluded) ? array_values(array_filter($rawExcluded, 'is_string')) : [];
+
+        $rawAnalyzers = config('shieldci.analyzers', []);
+        $categories = [];
+        if (is_array($rawAnalyzers)) {
+            foreach ($rawAnalyzers as $category => $settings) {
+                if (is_string($category) && is_array($settings)) {
+                    $enabled = $settings['enabled'] ?? true;
+                    $categories[$category] = (bool) $enabled;
+                }
+            }
+        }
+
+        $rawDisabled = config('shieldci.disabled_analyzers', []);
+        $disabledAnalyzers = is_array($rawDisabled) ? array_values(array_filter($rawDisabled, 'is_string')) : [];
+
+        $rawDontReport = config('shieldci.dont_report', []);
+        $dontReport = is_array($rawDontReport) ? array_values(array_filter($rawDontReport, 'is_string')) : [];
+
+        $rawIgnoreErrors = config('shieldci.ignore_errors', []);
+        $ignoreErrors = is_array($rawIgnoreErrors) ? $rawIgnoreErrors : [];
+
+        $rawEnvMapping = config('shieldci.environment_mapping', []);
+        $environmentMapping = is_array($rawEnvMapping) ? $rawEnvMapping : [];
+
+        $rawCiMode = config('shieldci.ci_mode', false);
+        $ciMode = (bool) $rawCiMode;
+
+        $rawCiAnalyzers = config('shieldci.ci_mode_analyzers', []);
+        $ciModeAnalyzers = is_array($rawCiAnalyzers) ? array_values(array_filter($rawCiAnalyzers, 'is_string')) : [];
+
+        $rawCiExclude = config('shieldci.ci_mode_exclude_analyzers', []);
+        $ciModeExcludeAnalyzers = is_array($rawCiExclude) ? array_values(array_filter($rawCiExclude, 'is_string')) : [];
+
+        $rawTimeout = config('shieldci.timeout', 300);
+        $timeout = is_int($rawTimeout) ? $rawTimeout : (is_numeric($rawTimeout) ? (int) $rawTimeout : 300);
+
+        $rawMemoryLimit = config('shieldci.memory_limit', '512M');
+        $memoryLimit = is_string($rawMemoryLimit) ? $rawMemoryLimit : '512M';
+
+        $rawFailOn = config('shieldci.fail_on', 'high');
+        $failOn = is_string($rawFailOn) ? $rawFailOn : 'high';
+
+        $rawThreshold = config('shieldci.fail_threshold', null);
+        $failThreshold = is_int($rawThreshold) ? $rawThreshold : (is_numeric($rawThreshold) ? (int) $rawThreshold : null);
+
+        return [
+            'paths' => $paths,
+            'excluded_paths' => $excludedPaths,
+            'categories' => $categories,
+            'disabled_analyzers' => $disabledAnalyzers,
+            'dont_report' => $dontReport,
+            'ignore_errors' => $ignoreErrors,
+            'environment_mapping' => $environmentMapping,
+            'ci_mode' => $ciMode,
+            'ci_mode_analyzers' => $ciModeAnalyzers,
+            'ci_mode_exclude_analyzers' => $ciModeExcludeAnalyzers,
+            'timeout' => $timeout,
+            'memory_limit' => $memoryLimit,
+            'fail_on' => $failOn,
+            'fail_threshold' => $failThreshold,
+        ];
     }
 
     /**

--- a/src/ValueObjects/AnalysisReport.php
+++ b/src/ValueObjects/AnalysisReport.php
@@ -18,7 +18,9 @@ final class AnalysisReport
 {
     /**
      * @param  Collection<int, ResultInterface>  $results
+     * @param  array<string, string>  $metadata
      * @param  array<string, list<SuppressionRecord>>  $suppressedIssues
+     * @param  array<string, mixed>  $configuration
      */
     public function __construct(
         public readonly string $projectId,
@@ -30,6 +32,7 @@ final class AnalysisReport
         public readonly TriggerSource $triggeredBy = TriggerSource::Manual,
         public readonly array $metadata = [],
         public readonly array $suppressedIssues = [],
+        public readonly array $configuration = [],
     ) {}
 
     public function score(): int
@@ -176,6 +179,7 @@ final class AnalysisReport
                 return $arr;
             })->all(),
             'metadata' => $this->metadata,
+            'configuration' => $this->configuration,
         ];
     }
 }

--- a/tests/Unit/Support/ReporterTest.php
+++ b/tests/Unit/Support/ReporterTest.php
@@ -1351,4 +1351,88 @@ class ReporterTest extends TestCase
             $prevWt === false ? putenv('WT_SESSION') : putenv("WT_SESSION={$prevWt}");
         }
     }
+
+    // ─── Configuration snapshot tests ────────────────────────────────────────
+
+    #[Test]
+    public function it_includes_configuration_in_generated_report(): void
+    {
+        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+
+        $report = $this->reporter->generate($results);
+
+        $this->assertIsArray($report->configuration);
+        foreach ([
+            'paths', 'excluded_paths', 'categories', 'disabled_analyzers',
+            'dont_report', 'ignore_errors', 'environment_mapping',
+            'ci_mode', 'ci_mode_analyzers', 'ci_mode_exclude_analyzers',
+            'timeout', 'memory_limit', 'fail_on', 'fail_threshold',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $report->configuration);
+        }
+    }
+
+    #[Test]
+    public function api_payload_includes_configuration(): void
+    {
+        config([
+            'shieldci.paths.analyze' => ['app', 'routes'],
+            'shieldci.excluded_paths' => ['vendor/*'],
+            'shieldci.analyzers' => [
+                'security' => ['enabled' => true],
+                'performance' => ['enabled' => false],
+            ],
+            'shieldci.disabled_analyzers' => ['sql-injection'],
+            'shieldci.dont_report' => ['missing-error-tracking'],
+            'shieldci.ignore_errors' => [],
+            'shieldci.environment_mapping' => ['prod' => 'production'],
+            'shieldci.ci_mode' => false,
+            'shieldci.ci_mode_analyzers' => [],
+            'shieldci.ci_mode_exclude_analyzers' => ['collection-call-analyzer'],
+            'shieldci.timeout' => 300,
+            'shieldci.memory_limit' => '512M',
+            'shieldci.fail_on' => 'high',
+            'shieldci.fail_threshold' => null,
+        ]);
+
+        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $report = $this->reporter->generate($results);
+        $payload = $this->reporter->toApi($report);
+
+        $this->assertArrayHasKey('configuration', $payload);
+        $c = $payload['configuration'];
+        $this->assertEquals(['app', 'routes'], $c['paths']);
+        $this->assertEquals(['vendor/*'], $c['excluded_paths']);
+        $this->assertEquals(['security' => true, 'performance' => false], $c['categories']);
+        $this->assertEquals(['sql-injection'], $c['disabled_analyzers']);
+        $this->assertEquals(['missing-error-tracking'], $c['dont_report']);
+        $this->assertEquals([], $c['ignore_errors']);
+        $this->assertEquals(['prod' => 'production'], $c['environment_mapping']);
+        $this->assertFalse($c['ci_mode']);
+        $this->assertEquals([], $c['ci_mode_analyzers']);
+        $this->assertEquals(['collection-call-analyzer'], $c['ci_mode_exclude_analyzers']);
+        $this->assertEquals(300, $c['timeout']);
+        $this->assertEquals('512M', $c['memory_limit']);
+        $this->assertEquals('high', $c['fail_on']);
+        $this->assertNull($c['fail_threshold']);
+    }
+
+    #[Test]
+    public function json_output_includes_configuration(): void
+    {
+        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $report = $this->reporter->generate($results);
+
+        $decoded = json_decode($this->reporter->toJson($report), true);
+
+        $this->assertArrayHasKey('configuration', $decoded);
+        foreach ([
+            'paths', 'excluded_paths', 'categories', 'disabled_analyzers',
+            'dont_report', 'ignore_errors', 'environment_mapping',
+            'ci_mode', 'ci_mode_analyzers', 'ci_mode_exclude_analyzers',
+            'timeout', 'memory_limit', 'fail_on', 'fail_threshold',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $decoded['configuration']);
+        }
+    }
 }

--- a/tests/Unit/ValueObjects/AnalysisReportTest.php
+++ b/tests/Unit/ValueObjects/AnalysisReportTest.php
@@ -618,6 +618,45 @@ class AnalysisReportTest extends TestCase
         $this->assertSame([], $resultArr['suppressed_issues']);
     }
 
+    #[Test]
+    public function it_includes_configuration_in_to_array(): void
+    {
+        $configuration = [
+            'paths' => ['app', 'routes'],
+            'excluded_paths' => ['vendor/*'],
+            'categories' => ['security' => true, 'performance' => false],
+            'disabled_analyzers' => ['sql-injection'],
+            'ci_mode' => true,
+            'fail_on' => 'high',
+            'fail_threshold' => 80,
+        ];
+
+        $report = new AnalysisReport(
+            projectId: 'test-project-id',
+            laravelVersion: '10.0.0',
+            packageVersion: '1.0.0',
+            results: collect(),
+            totalExecutionTime: 1.0,
+            analyzedAt: new DateTimeImmutable,
+            configuration: $configuration,
+        );
+
+        $array = $report->toArray();
+
+        $this->assertArrayHasKey('configuration', $array);
+        $this->assertEquals($configuration, $array['configuration']);
+    }
+
+    #[Test]
+    public function it_defaults_configuration_to_empty_array(): void
+    {
+        $report = $this->createReport(collect());
+
+        $this->assertEquals([], $report->configuration);
+        $this->assertArrayHasKey('configuration', $report->toArray());
+        $this->assertEquals([], $report->toArray()['configuration']);
+    }
+
     private function createReport(Collection $results): AnalysisReport
     {
         return new AnalysisReport(


### PR DESCRIPTION
## Summary

- Add a top-level `configuration` key to `AnalysisReport` and `toArray()` capturing the effective analysis configuration at the time of the run
- `Reporter::buildConfiguration()` reads all relevant config values after CLI flags have been applied, so runtime mutations (e.g. `--ci` toggling `ci_mode`) are reflected accurately
- Included fields: `paths`, `excluded_paths`, `categories`, `disabled_analyzers`, `dont_report`, `ignore_errors`, `environment_mapping`, `ci_mode`, `ci_mode_analyzers`, `ci_mode_exclude_analyzers`, `timeout`, `memory_limit`, `fail_on`, `fail_threshold`