### PR TITLE
fix: place suppressed issues note directly under analyzer status line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.6.1
+
+### Fixed
+- Suppressed issues note no longer has a blank line between it and the analyzer status line — the note is now embedded directly into the streamed output so it appears immediately below the status with no gap
+
 ## v1.6.0
 
 ### Added

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -285,12 +285,14 @@ class AnalyzeCommand extends Command
 
                 // Stream output immediately
                 $categoryLabel = $metadata->category->label();
-                $this->line($reporter->streamResult($fr2->result, $current, $total, $categoryLabel));
                 $allSuppressed = array_merge($fr1->suppressedRecords, $fr2->suppressedRecords);
+                $streamOutput = $reporter->streamResult($fr2->result, $current, $total, $categoryLabel);
                 if ($allSuppressed !== []) {
                     $count = count($allSuppressed);
-                    $this->line('  ('.$count.' '.($count === 1 ? 'issue' : 'issues').' suppressed — use --format=json to see details)');
+                    $suppressedNote = '('.$count.' '.($count === 1 ? 'issue' : 'issues').' suppressed — use --format=json to see details)';
+                    $streamOutput = rtrim($streamOutput, PHP_EOL).PHP_EOL.$suppressedNote.PHP_EOL;
                 }
+                $this->line($streamOutput);
             }
 
             return $results;
@@ -418,12 +420,14 @@ class AnalyzeCommand extends Command
                 $results->push($fr2->result);
 
                 // Stream output immediately
-                $this->line($reporter->streamResult($fr2->result, $current, $total, $categoryLabel));
                 $allSuppressed = array_merge($fr1->suppressedRecords, $fr2->suppressedRecords);
+                $streamOutput = $reporter->streamResult($fr2->result, $current, $total, $categoryLabel);
                 if ($allSuppressed !== []) {
                     $count = count($allSuppressed);
-                    $this->line('  ('.$count.' '.($count === 1 ? 'issue' : 'issues').' suppressed — use --format=json to see details)');
+                    $suppressedNote = '('.$count.' '.($count === 1 ? 'issue' : 'issues').' suppressed — use --format=json to see details)';
+                    $streamOutput = rtrim($streamOutput, PHP_EOL).PHP_EOL.$suppressedNote.PHP_EOL;
                 }
+                $this->line($streamOutput);
             }
         }
 

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -1609,6 +1609,65 @@ PHP);
     }
 
     #[Test]
+    public function suppressed_issues_note_appears_directly_below_analyzer_status_with_no_blank_line(): void
+    {
+        $file = $this->createTempPhpFile(<<<'PHP'
+<?php
+// @shieldci-ignore
+$result = DB::select("SELECT * FROM users WHERE id = $id");
+PHP);
+
+        $result = new AnalysisResult(
+            analyzerId: 'sql-injection',
+            status: Status::Failed,
+            message: 'Found 1 issues',
+            issues: [
+                new Issue(
+                    message: 'SQL Injection detected',
+                    location: new \ShieldCI\AnalyzersCore\ValueObjects\Location($file, 3),
+                    severity: Severity::Critical,
+                    recommendation: 'Use prepared statements',
+                ),
+            ],
+            executionTime: 0.1,
+            metadata: [
+                'id' => 'sql-injection',
+                'name' => 'SQL Injection',
+                'description' => 'Detects SQL injection',
+                'category' => Category::Security,
+                'severity' => Severity::Critical,
+            ],
+        );
+
+        $this->registerManagerWithResults([$result]);
+        config(['shieldci.fail_on' => 'never']);
+
+        \Illuminate\Support\Facades\Artisan::call('shield:analyze', ['--format' => 'console']);
+        $output = \Illuminate\Support\Facades\Artisan::output();
+
+        // Note must be present
+        $this->assertStringContainsString('(1 issue suppressed — use --format=json to see details)', $output);
+
+        // Note must appear on the line immediately following the analyzer status (no blank line between)
+        $lines = explode("\n", $output);
+        $statusIdx = null;
+        foreach ($lines as $i => $line) {
+            if (str_contains($line, 'Analyzer 1/1:')) {
+                $statusIdx = $i;
+                break;
+            }
+        }
+        $this->assertNotNull($statusIdx, 'Analyzer status line not found in output');
+        $this->assertStringContainsString(
+            'issue suppressed',
+            $lines[$statusIdx + 1] ?? '',
+            'Suppressed note must appear on the line immediately after the analyzer status (no blank line between)'
+        );
+
+        $this->cleanupTempPaths();
+    }
+
+    #[Test]
     public function inline_suppression_partial_filtering_keeps_unsuppressed_issues(): void
     {
         $file = $this->createTempPhpFile(<<<'PHP'


### PR DESCRIPTION
## Summary
- Suppressed issues note was emitting as a separate `$this->line()` call after the stream output, causing a blank line to appear between the analyzer status and the note
- Refactored both streaming code paths to embed the suppressed note into `$streamOutput` before the trailing newline, so it appears flush against the status line with no gap