### PR TITLE
feat: progress bar on STDERR, clean JSON on STDOUT, suppress output when --output is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage.xml
 .claude
 /tests/shieldci-console-report.json
 /tests/shieldci-test-report.json
+/tests/shieldci-suppress-stdout-test.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.6.2
+
+### Added
+- `shield:analyze --format=json` now shows a progress bar on STDERR while analyzers run — the bar displays the current analyzer name and advances per-analyzer; it only renders when STDERR is a TTY so piped or redirected STDERR stays clean
+
+### Changed
+- All status messages (e.g. "Running all 73 analyzers...") are now written to STDERR instead of STDOUT — `--format=json` output piped to `jq` or redirected to a file is no longer corrupted by interleaved text
+- `--output` now suppresses STDOUT — when a file path is provided (via `--output` or `shieldci.report.output_file` config), the report is written to the file only and a `"Report saved to: ..."` confirmation is shown; the full report is no longer also dumped to the console
+
 ## v1.6.1
 
 ### Fixed

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -470,17 +470,24 @@ class AnalyzeCommand extends Command
         return $allResults;
     }
 
+    /**
+     * @param  resource  $stderrStream
+     */
+    protected function isProgressEnabled(mixed $stderrStream): bool
+    {
+        return stream_isatty($stderrStream);
+    }
+
     protected function runAnalysis(AnalyzerManager $manager): Collection
     {
         /** @var resource $stderrStream */
         $stderrStream = fopen('php://stderr', 'w');
-        $stderrIsDecorated = stream_isatty($stderrStream);
+        $showProgress = $this->isProgressEnabled($stderrStream);
         $stderrOutput = new \Symfony\Component\Console\Output\StreamOutput(
             $stderrStream,
             $this->getOutput()->getVerbosity(),
-            $stderrIsDecorated,
+            $showProgress,
         );
-        $showProgress = $stderrIsDecorated;
 
         if ($analyzerOption = $this->option('analyzer')) {
             // Support comma-separated analyzer IDs

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -173,19 +173,6 @@ class AnalyzeCommand extends Command
             suppressedIssues: $this->suppressedIssues,
         );
 
-        // Output report (skip if already streamed)
-        if (! $useStreaming) {
-            $this->outputReport($report, $reporter);
-        } else {
-            // For streaming mode, just output the report card
-            $this->newLine();
-            $this->line($this->color('Report Card', 'bright_yellow'));
-            $this->line($this->color('===========', 'bright_yellow'));
-            $this->newLine();
-            $this->outputReportCard($report);
-            $this->newLine();
-        }
-
         // Save to file if requested (CLI option or config default)
         $output = $this->option('output');
         if (! $output) {
@@ -195,6 +182,19 @@ class AnalyzeCommand extends Command
 
         if ($output && is_string($output)) {
             $this->saveReport($report, $reporter, $output);
+        }
+
+        // Output report to STDOUT (skip if saved to file or already streamed)
+        if (! $output && ! $useStreaming) {
+            $this->outputReport($report, $reporter);
+        } elseif (! $output && $useStreaming) {
+            // For streaming mode, just output the report card
+            $this->newLine();
+            $this->line($this->color('Report Card', 'bright_yellow'));
+            $this->line($this->color('===========', 'bright_yellow'));
+            $this->newLine();
+            $this->outputReportCard($report);
+            $this->newLine();
         }
 
         // Send to API if configured
@@ -472,6 +472,15 @@ class AnalyzeCommand extends Command
 
     protected function runAnalysis(AnalyzerManager $manager): Collection
     {
+        /** @var resource $stderrStream */
+        $stderrStream = fopen('php://stderr', 'w');
+        $stderrOutput = new \Symfony\Component\Console\Output\StreamOutput(
+            $stderrStream,
+            $this->getOutput()->getVerbosity(),
+            $this->getOutput()->isDecorated(),
+        );
+        $showProgress = $this->getOutput()->isDecorated();
+
         if ($analyzerOption = $this->option('analyzer')) {
             // Support comma-separated analyzer IDs
             $analyzerIds = array_map('trim', explode(',', $analyzerOption));
@@ -479,11 +488,25 @@ class AnalyzeCommand extends Command
 
             $displayName = $this->resolveAnalyzerDisplayName($manager, $analyzerIds);
             $label = count($analyzerIds) === 1 ? 'Running analyzer' : 'Running analyzers';
-            $this->line("{$label}: {$displayName}");
+            $stderrOutput->writeln("{$label}: {$displayName}");
+
+            $progressBar = null;
+            if ($showProgress && count($analyzerIds) > 1) {
+                $progressBar = new \Symfony\Component\Console\Helper\ProgressBar($stderrOutput, count($analyzerIds));
+                $progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% — %message%');
+                $progressBar->setMessage('Starting...');
+                $progressBar->start();
+            }
 
             $results = [];
             foreach ($analyzerIds as $analyzerId) {
+                if ($progressBar !== null) {
+                    $progressBar->setMessage($analyzerId);
+                }
                 $result = $manager->run($analyzerId);
+                if ($progressBar !== null) {
+                    $progressBar->advance();
+                }
                 if ($result !== null) {
                     $results[] = $result;
                 } else {
@@ -493,6 +516,11 @@ class AnalyzeCommand extends Command
                         $results[] = $skippedResult;
                     }
                 }
+            }
+
+            if ($progressBar !== null) {
+                $progressBar->finish();
+                $stderrOutput->writeln('');
             }
 
             return collect($results);
@@ -528,9 +556,9 @@ class AnalyzeCommand extends Command
             $totalCount = $enabledCount + $skippedCount;
 
             if ($skippedCount > 0) {
-                $this->line("Running {$categoryLabel} analyzers... ({$enabledCount} running, {$skippedCount} skipped, {$totalCount} total)");
+                $stderrOutput->writeln("Running {$categoryLabel} analyzers... ({$enabledCount} running, {$skippedCount} skipped, {$totalCount} total)");
             } else {
-                $this->line("Running {$categoryLabel} analyzers... ({$enabledCount}/{$totalCount})");
+                $stderrOutput->writeln("Running {$categoryLabel} analyzers... ({$enabledCount}/{$totalCount})");
             }
         } else {
             $analyzers = $manager->getAnalyzers();
@@ -570,19 +598,33 @@ class AnalyzeCommand extends Command
             $totalCount = $enabledCount + $skippedCount;
 
             if ($skippedCount > 0) {
-                $this->line("Running {$enabledCount} of {$totalCount} analyzers ({$skippedCount} skipped)...");
+                $stderrOutput->writeln("Running {$enabledCount} of {$totalCount} analyzers ({$skippedCount} skipped)...");
             } else {
-                $this->line("Running all {$enabledCount} analyzers...");
+                $stderrOutput->writeln("Running all {$enabledCount} analyzers...");
             }
         }
 
         // Run analyzers and collect results
-        $results = $analyzers->map(function ($analyzer) {
-            $result = $analyzer->analyze();
-            $metadata = $analyzer->getMetadata();
+        $progressBar = null;
+        if ($showProgress) {
+            $progressBar = new \Symfony\Component\Console\Helper\ProgressBar($stderrOutput, $enabledCount);
+            $progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% — %message%');
+            $progressBar->setMessage('Starting...');
+            $progressBar->start();
+        }
 
+        $resultsList = [];
+        foreach ($analyzers as $analyzer) {
+            $metadata = $analyzer->getMetadata();
+            if ($progressBar !== null) {
+                $progressBar->setMessage($metadata->name);
+            }
+            $result = $analyzer->analyze();
+            if ($progressBar !== null) {
+                $progressBar->advance();
+            }
             // Enrich result with analyzer metadata (same as runAll)
-            return new \ShieldCI\AnalyzersCore\Results\AnalysisResult(
+            $resultsList[] = new \ShieldCI\AnalyzersCore\Results\AnalysisResult(
                 analyzerId: $result->getAnalyzerId(),
                 status: $result->getStatus(),
                 message: $result->getMessage(),
@@ -597,7 +639,14 @@ class AnalyzeCommand extends Command
                     'docsUrl' => $metadata->getDocsUrl(),
                 ],
             );
-        });
+        }
+
+        if ($progressBar !== null) {
+            $progressBar->finish();
+            $stderrOutput->writeln('');
+        }
+
+        $results = collect($resultsList);
 
         // Add skipped analyzers
         if ($normalizedCategories) {
@@ -620,11 +669,8 @@ class AnalyzeCommand extends Command
         // Convert both to arrays and merge, then convert back to collection (same approach as runAll)
         /** @var Collection<int, ResultInterface> $allResults */
         $allResults = collect(array_merge($results->all(), $skippedResults->all()));
-        $results = $allResults;
 
-        $this->newLine(2);
-
-        return $results;
+        return $allResults;
     }
 
     protected function outputReport(AnalysisReport $report, ReporterInterface $reporter): void

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -474,12 +474,13 @@ class AnalyzeCommand extends Command
     {
         /** @var resource $stderrStream */
         $stderrStream = fopen('php://stderr', 'w');
+        $stderrIsDecorated = stream_isatty($stderrStream);
         $stderrOutput = new \Symfony\Component\Console\Output\StreamOutput(
             $stderrStream,
             $this->getOutput()->getVerbosity(),
-            $this->getOutput()->isDecorated(),
+            $stderrIsDecorated,
         );
-        $showProgress = $this->getOutput()->isDecorated();
+        $showProgress = $stderrIsDecorated;
 
         if ($analyzerOption = $this->option('analyzer')) {
             // Support comma-separated analyzer IDs

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -220,6 +220,31 @@ class AnalyzeCommandTest extends TestCase
     }
 
     #[Test]
+    public function it_suppresses_stdout_when_output_file_is_specified(): void
+    {
+        $this->registerTestAnalyzers();
+
+        $outputPath = base_path('tests/shieldci-suppress-stdout-test.json');
+        if (file_exists($outputPath)) {
+            unlink($outputPath);
+        }
+
+        $result = $this->artisan('shield:analyze', [
+            '--format' => 'json',
+            '--output' => 'tests/shieldci-suppress-stdout-test.json',
+        ])->assertSuccessful();
+
+        // JSON must not appear on STDOUT when saved to a file
+        $result->doesntExpectOutput('"summary"');
+        // Confirmation message should still appear
+        $result->expectsOutputToContain('Report saved to');
+
+        if (file_exists($outputPath)) {
+            unlink($outputPath);
+        }
+    }
+
+    #[Test]
     public function it_respects_enabled_config(): void
     {
         config(['shieldci.enabled' => false]);
@@ -3888,5 +3913,71 @@ PHP);
         $this->assertSame(0, $data['summary']['suppressed_issues']['total']);
 
         unlink($outputPath);
+    }
+
+    #[Test]
+    public function json_output_does_not_contain_status_messages(): void
+    {
+        $this->registerTestAnalyzers();
+
+        $result = $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful();
+
+        // Status messages (e.g. "Running all N analyzers...") must not appear in STDOUT
+        // as they would corrupt JSON piped to jq or other tools
+        $result->expectsOutputToContain('"summary"');
+        $result->doesntExpectOutput('Running all');
+        $result->doesntExpectOutput('Running analyzers');
+        $result->doesntExpectOutput('Running analyzer');
+    }
+
+    #[Test]
+    public function json_output_with_specific_analyzer_does_not_contain_status_messages(): void
+    {
+        $this->registerTestAnalyzers();
+
+        $result = $this->artisan('shield:analyze', [
+            '--analyzer' => 'test-security-analyzer',
+            '--format' => 'json',
+        ])->assertSuccessful();
+
+        $result->doesntExpectOutput('Running analyzer');
+        $result->doesntExpectOutput('Running analyzers');
+    }
+
+    #[Test]
+    public function json_output_with_multiple_analyzers_does_not_contain_status_messages(): void
+    {
+        $this->registerTestAnalyzers();
+
+        $result = $this->artisan('shield:analyze', [
+            '--analyzer' => 'test-security-analyzer,test-performance-analyzer',
+            '--format' => 'json',
+        ])->assertSuccessful();
+
+        $result->doesntExpectOutput('Running analyzers');
+    }
+
+    #[Test]
+    public function json_output_with_category_does_not_contain_status_messages(): void
+    {
+        $this->registerTestAnalyzers();
+
+        $result = $this->artisan('shield:analyze', [
+            '--category' => 'security',
+            '--format' => 'json',
+        ])->assertSuccessful();
+
+        $result->doesntExpectOutput('Running');
+    }
+
+    #[Test]
+    public function console_format_still_shows_output_without_regression(): void
+    {
+        $this->registerTestAnalyzers();
+
+        $this->artisan('shield:analyze', ['--format' => 'console'])
+            ->assertSuccessful()
+            ->expectsOutputToContain('ShieldCI');
     }
 }

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -3980,4 +3980,107 @@ PHP);
             ->assertSuccessful()
             ->expectsOutputToContain('ShieldCI');
     }
+
+    #[Test]
+    public function progress_bar_renders_when_progress_enabled_for_all_analyzers(): void
+    {
+        $manager = $this->buildProgressTestManager();
+        $results = $this->invokeRunAnalysisWithProgress([], $manager);
+
+        $this->assertCount(2, $results);
+    }
+
+    #[Test]
+    public function progress_bar_renders_when_progress_enabled_for_specific_analyzer(): void
+    {
+        $manager = $this->buildProgressTestManager();
+        $results = $this->invokeRunAnalysisWithProgress(['--analyzer' => 'test-security-analyzer'], $manager);
+
+        $this->assertCount(1, $results);
+    }
+
+    #[Test]
+    public function progress_bar_renders_when_progress_enabled_for_multiple_analyzers(): void
+    {
+        $manager = $this->buildProgressTestManager();
+        $results = $this->invokeRunAnalysisWithProgress(['--analyzer' => 'test-security-analyzer,test-performance-analyzer'], $manager);
+
+        $this->assertCount(2, $results);
+    }
+
+    #[Test]
+    public function progress_bar_renders_when_progress_enabled_for_category(): void
+    {
+        $manager = $this->buildProgressTestManager();
+        $results = $this->invokeRunAnalysisWithProgress(['--category' => 'security'], $manager);
+
+        $this->assertCount(1, $results);
+    }
+
+    /**
+     * Directly invoke runAnalysis() on a progress-enabled command via reflection,
+     * bypassing the full Artisan stack so we get clean coverage of the progress bar branches.
+     *
+     * @param  array<string, mixed>  $options
+     * @return \Illuminate\Support\Collection<int, mixed>
+     */
+    private function invokeRunAnalysisWithProgress(array $options, AnalyzerManager $manager): \Illuminate\Support\Collection
+    {
+        $command = new class extends \ShieldCI\Commands\AnalyzeCommand {
+            protected function isProgressEnabled(mixed $stderrStream): bool
+            {
+                return true;
+            }
+        };
+
+        $input = new \Symfony\Component\Console\Input\ArrayInput($options);
+        $input->bind($command->getDefinition());
+        $output = new \Symfony\Component\Console\Output\NullOutput();
+        $command->setInput($input);
+        $command->setOutput(new \Illuminate\Console\OutputStyle($input, $output));
+
+        $reflection = new \ReflectionMethod($command, 'runAnalysis');
+        /** @var \Illuminate\Support\Collection<int, mixed> */
+        return $reflection->invoke($command, $manager);
+    }
+
+    /**
+     * @return MockInterface&AnalyzerManager
+     */
+    private function buildProgressTestManager(): AnalyzerManager
+    {
+        $securityAnalyzer = $this->createMockAnalyzer(
+            'test-security-analyzer',
+            'Test Security Analyzer',
+            Category::Security,
+            Severity::High,
+            Status::Passed,
+            'No issues',
+        );
+        $performanceAnalyzer = $this->createMockAnalyzer(
+            'test-performance-analyzer',
+            'Test Performance Analyzer',
+            Category::Performance,
+            Severity::Medium,
+            Status::Passed,
+            'No issues',
+        );
+
+        /** @var MockInterface&AnalyzerManager $manager */
+        $manager = Mockery::mock(AnalyzerManager::class);
+        /** @phpstan-ignore-next-line */
+        $manager->shouldReceive('getAnalyzers')->andReturn(collect([$securityAnalyzer, $performanceAnalyzer]));
+        /** @phpstan-ignore-next-line */
+        $manager->shouldReceive('getByCategories')->with(['security'])->andReturn(collect([$securityAnalyzer]));
+        /** @phpstan-ignore-next-line */
+        $manager->shouldReceive('getSkippedAnalyzers')->andReturn(collect());
+        /** @phpstan-ignore-next-line */
+        $manager->shouldReceive('run')->with('test-security-analyzer')->andReturn($securityAnalyzer->analyze());
+        /** @phpstan-ignore-next-line */
+        $manager->shouldReceive('run')->with('test-performance-analyzer')->andReturn($performanceAnalyzer->analyze());
+        /** @phpstan-ignore-next-line */
+        $manager->shouldReceive('resolveAnalyzerDisplayName')->andReturn('Test Security Analyzer');
+
+        return $manager;
+    }
 }


### PR DESCRIPTION
## Summary

- Progress bar written to STDERR so \`--format=json | jq\` piping works without corruption
- All \"Running N analyzers...\" status messages redirected from STDOUT to STDERR
- STDOUT output suppressed when \`--output\` is provided — report goes to file only, confirmation message shown instead
- Progress bar visibility based on \`stream_isatty(STDERR)\`, not STDOUT — bar shows even when STDOUT is piped or redirected
- \`isProgressEnabled()\` extracted as a protected method for testability
- Converted \`map()\` to \`foreach\` in \`runAnalysis()\` to enable per-analyzer progress updates with analyzer name in \`%message%\`
- Leftover test artifact \`tests/shieldci-suppress-stdout-test.json\` gitignored

## Behaviour

```bash
# Pipe JSON — progress on terminal (STDERR), clean JSON on STDOUT
php artisan shield:analyze --format=json | jq '.summary'

# Redirect JSON to file — progress still visible on terminal
php artisan shield:analyze --format=json > report.json

# Save via --output — no STDOUT dump, confirmation shown, progress visible
php artisan shield:analyze --format=json --output=report.json

# Suppress STDERR — no progress bar, no corruption
php artisan shield:analyze --format=json 2>/dev/null | jq '.summary'

# Console format — unchanged
php artisan shield:analyze
```

## STDOUT/STDERR matrix

| Scenario | STDOUT content | Progress bar |
|---|---|:---:|
| `shield:analyze` | console report | ✅ |
| `shield:analyze --format=json` | JSON | ✅ |
| `shield:analyze --format=json \| jq` | JSON | ✅ |
| `shield:analyze --format=json > report.json` | JSON | ✅ |
| `shield:analyze --format=json --output=report.json` | confirmation | ✅ |
| `shield:analyze --format=json 2>/dev/null \| jq` | JSON | ❌ |