### PR TITLE
feat: add code snippets to 5 best-practices analyzers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.6.3
+
+### Changed
+- `MissingDatabaseTransactionsAnalyzer`, `MixedQueryBuilderEloquentAnalyzer`, `PhpSideFilteringAnalyzer`, `SilentFailureAnalyzer`, and `ServiceContainerResolutionAnalyzer` now include code snippets in their issues — each issue shows the offending line with surrounding context via `createIssueWithSnippet()`
+
 ## v1.6.2
 
 ### Added

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -14,7 +14,6 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
-use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Concerns\ClassifiesFiles;
 
 /**
@@ -84,12 +83,12 @@ class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
                 $traverser->traverse($ast);
 
                 foreach ($visitor->getIssues() as $issue) {
-                    $issues[] = $this->createIssue(
+                    $issues[] = $this->createIssueWithSnippet(
                         message: $issue['message'],
-                        location: new Location($this->getRelativePath($file), $issue['line']),
+                        filePath: $file,
+                        lineNumber: $issue['line'],
                         severity: $issue['severity'],
                         recommendation: $issue['recommendation'],
-                        code: $issue['code'] ?? null,
                     );
                 }
             } catch (\Throwable $e) {

--- a/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
+++ b/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
@@ -16,7 +16,6 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
-use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
 /**
  * Detects mixing Query Builder and Eloquent for the same model.
@@ -385,12 +384,12 @@ class MixedQueryBuilderEloquentAnalyzer extends AbstractFileAnalyzer
                 $traverser->traverse($ast);
 
                 foreach ($visitor->getIssues() as $issue) {
-                    $issues[] = $this->createIssue(
+                    $issues[] = $this->createIssueWithSnippet(
                         message: $issue['message'],
-                        location: new Location($this->getRelativePath($file), $issue['line']),
+                        filePath: $file,
+                        lineNumber: $issue['line'],
                         severity: $issue['severity'],
                         recommendation: $issue['recommendation'],
-                        code: $issue['code'] ?? null,
                     );
                 }
             } catch (\Throwable $e) {

--- a/src/Analyzers/BestPractices/PhpSideFilteringAnalyzer.php
+++ b/src/Analyzers/BestPractices/PhpSideFilteringAnalyzer.php
@@ -14,7 +14,6 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
-use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
 /**
  * Detects PHP-side filtering patterns not covered by Larastan.
@@ -123,12 +122,12 @@ class PhpSideFilteringAnalyzer extends AbstractFileAnalyzer
                 $traverser->traverse($ast);
 
                 foreach ($visitor->getIssues() as $issue) {
-                    $issues[] = $this->createIssue(
+                    $issues[] = $this->createIssueWithSnippet(
                         message: $issue['message'],
-                        location: new Location($relativePath, $issue['line']),
+                        filePath: $file,
+                        lineNumber: $issue['line'],
                         severity: $issue['severity'],
                         recommendation: $issue['recommendation'],
-                        code: $issue['code'] ?? null,
                     );
                 }
             } catch (\Throwable $e) {

--- a/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
+++ b/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
@@ -18,7 +18,6 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
-use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
 /**
  * Detects manual service container resolution in application code.
@@ -321,9 +320,10 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
             $relativePath = $this->getRelativePath($file);
 
             foreach ($visitor->getIssues() as $issue) {
-                $issues[] = $this->createIssue(
+                $issues[] = $this->createIssueWithSnippet(
                     message: "Manual service resolution in '{$issue['location']}': {$issue['pattern']}",
-                    location: new Location($relativePath, $issue['line']),
+                    filePath: $file,
+                    lineNumber: $issue['line'],
                     severity: $issue['severity'],
                     recommendation: $this->getRecommendation($issue['pattern'], $issue['location'], $issue['argument_type'] ?? 'unknown', $issue['in_closure']),
                     metadata: [

--- a/src/Analyzers/BestPractices/SilentFailureAnalyzer.php
+++ b/src/Analyzers/BestPractices/SilentFailureAnalyzer.php
@@ -14,7 +14,6 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
-use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
 /**
  * Detects empty catch blocks and error suppression.
@@ -161,12 +160,12 @@ class SilentFailureAnalyzer extends AbstractFileAnalyzer
                 $traverser->traverse($ast);
 
                 foreach ($visitor->getIssues() as $issue) {
-                    $issues[] = $this->createIssue(
+                    $issues[] = $this->createIssueWithSnippet(
                         message: $issue['message'],
-                        location: new Location($this->getRelativePath($file), $issue['line']),
+                        filePath: $file,
+                        lineNumber: $issue['line'],
                         severity: $issue['severity'],
                         recommendation: $issue['recommendation'],
-                        code: $issue['code'] ?? null,
                     );
                 }
             } catch (\Throwable $e) {

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -4026,7 +4026,8 @@ PHP);
      */
     private function invokeRunAnalysisWithProgress(array $options, AnalyzerManager $manager): \Illuminate\Support\Collection
     {
-        $command = new class extends \ShieldCI\Commands\AnalyzeCommand {
+        $command = new class extends \ShieldCI\Commands\AnalyzeCommand
+        {
             protected function isProgressEnabled(mixed $stderrStream): bool
             {
                 return true;
@@ -4035,11 +4036,12 @@ PHP);
 
         $input = new \Symfony\Component\Console\Input\ArrayInput($options);
         $input->bind($command->getDefinition());
-        $output = new \Symfony\Component\Console\Output\NullOutput();
+        $output = new \Symfony\Component\Console\Output\NullOutput;
         $command->setInput($input);
         $command->setOutput(new \Illuminate\Console\OutputStyle($input, $output));
 
         $reflection = new \ReflectionMethod($command, 'runAnalysis');
+
         /** @var \Illuminate\Support\Collection<int, mixed> */
         return $reflection->invoke($command, $manager);
     }


### PR DESCRIPTION
## Summary

- `MissingDatabaseTransactionsAnalyzer`, `MixedQueryBuilderEloquentAnalyzer`, `PhpSideFilteringAnalyzer`, `SilentFailureAnalyzer`, and `ServiceContainerResolutionAnalyzer` now call `createIssueWithSnippet()` instead of `createIssue(..., code: null)`
- Each issue now includes the offending line with surrounding context extracted from the source file
- Removes the now-unused `use ShieldCI\AnalyzersCore\ValueObjects\Location;` import from all 5 files