### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,9 @@ jobs:
         laravel: ['12.*', '13.*']
         include:
           - laravel: '12.*'
-            testbench: '^9.0'
-          - laravel: '13.*'
             testbench: '^10.0'
+          - laravel: '13.*'
+            testbench: '^11.0'
         exclude:
           - php: '8.1'
             laravel: '13.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,18 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['8.1', '8.2', '8.3', '8.4']
+        laravel: ['12.*', '13.*']
+        include:
+          - laravel: '12.*'
+            testbench: '^9.0'
+          - laravel: '13.*'
+            testbench: '^10.0'
+        exclude:
+          - php: '8.1'
+            laravel: '13.*'
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
@@ -35,7 +44,9 @@ jobs:
           coverage: xdebug
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction --no-progress
 
       - name: Run tests with coverage
         run: vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,13 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Laravel 9 (PHP 8.1–8.2)
-          - php: '8.1'
-            laravel: '9.*'
-            testbench: '^7.0'
-          - php: '8.2'
-            laravel: '9.*'
-            testbench: '^7.0'
           # Laravel 10 (PHP 8.1–8.3)
           - php: '8.1'
             laravel: '10.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,22 +17,59 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4']
-        laravel: ['12.*', '13.*']
         include:
-          - laravel: '12.*'
-            testbench: '^10.0'
-          - laravel: '13.*'
-            testbench: '^11.0'
-        exclude:
+          # Laravel 9 (PHP 8.1–8.2)
           - php: '8.1'
-            laravel: '12.*'
-          - php: '8.1'
-            laravel: '13.*'
+            laravel: '9.*'
+            testbench: '^7.0'
           - php: '8.2'
+            laravel: '9.*'
+            testbench: '^7.0'
+          # Laravel 10 (PHP 8.1–8.3)
+          - php: '8.1'
+            laravel: '10.*'
+            testbench: '^8.0'
+          - php: '8.2'
+            laravel: '10.*'
+            testbench: '^8.0'
+          - php: '8.3'
+            laravel: '10.*'
+            testbench: '^8.0'
+          # Laravel 11 (PHP 8.2–8.4)
+          - php: '8.2'
+            laravel: '11.*'
+            testbench: '^9.0'
+          - php: '8.3'
+            laravel: '11.*'
+            testbench: '^9.0'
+          - php: '8.4'
+            laravel: '11.*'
+            testbench: '^9.0'
+          # Laravel 12 (PHP 8.2–8.5)
+          - php: '8.2'
+            laravel: '12.*'
+            testbench: '^10.0'
+          - php: '8.3'
+            laravel: '12.*'
+            testbench: '^10.0'
+          - php: '8.4'
+            laravel: '12.*'
+            testbench: '^10.0'
+          - php: '8.5'
+            laravel: '12.*'
+            testbench: '^10.0'
+          # Laravel 13 (PHP 8.3–8.5)
+          - php: '8.3'
             laravel: '13.*'
+            testbench: '^11.0'
+          - php: '8.4'
+            laravel: '13.*'
+            testbench: '^11.0'
+          - php: '8.5'
+            laravel: '13.*'
+            testbench: '^11.0'
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
         exclude:
           - php: '8.1'
             laravel: '13.*'
+          - php: '8.2'
+            laravel: '13.*'
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
             testbench: '^11.0'
         exclude:
           - php: '8.1'
+            laravel: '12.*'
+          - php: '8.1'
             laravel: '13.*'
           - php: '8.2'
             laravel: '13.*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.6.5
 
 ### Added
-- Laravel 13 support — `illuminate/*` constraints widened to `^9.0|^10.0|^11.0|^12.0|^13.0`; `orchestra/testbench` widened to `^7.0|^8.0|^9.0|^10.0`; CI matrix now tests PHP 8.2–8.4 against Laravel 12 and 13
+- Laravel 13 support — `illuminate/*` constraints widened to `^9.0|^10.0|^11.0|^12.0|^13.0`; `orchestra/testbench` widened to `^7.0|^8.0|^9.0|^10.0|^11.0`; CI matrix now tests PHP 8.2–8.4 against Laravel 12 and 13
 
 ## v1.6.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.6.5
+
+### Added
+- Laravel 13 support — `illuminate/*` constraints widened to `^9.0|^10.0|^11.0|^12.0|^13.0`; `orchestra/testbench` widened to `^7.0|^8.0|^9.0|^10.0`; CI matrix now tests PHP 8.2–8.4 against Laravel 12 and 13
+
 ## v1.6.4
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Built on top of [`shieldci/analyzers-core`](https://github.com/ShieldCI/analyzer
 
 ## Requirements
 
-- PHP 8.1 or higher
-- Laravel 9.x, 10.x, 11.x, 12.x, 13.x
+- PHP 8.1–8.5
+- Laravel 9.x (PHP 8.1–8.2), 10.x (PHP 8.1–8.3), 11.x (PHP 8.2–8.4), 12.x (PHP 8.2–8.5), 13.x (PHP 8.3–8.5)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Built on top of [`shieldci/analyzers-core`](https://github.com/ShieldCI/analyzer
 
 ## Requirements
 
-- PHP 8.1–8.5
-- Laravel 9.x (PHP 8.1–8.2), 10.x (PHP 8.1–8.3), 11.x (PHP 8.2–8.4), 12.x (PHP 8.2–8.5), 13.x (PHP 8.3–8.5)
+- PHP 8.1 or higher
+- Laravel 9.x, 10.x, 11.x, 12.x, 13.x
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/shieldci/laravel.svg)](https://packagist.org/packages/shieldci/laravel)
 [![PHP Version](https://img.shields.io/packagist/php-v/shieldci/laravel.svg)](https://packagist.org/packages/shieldci/laravel)
-[![Laravel Version](https://img.shields.io/badge/laravel-9.x--12.x-red.svg)](https://packagist.org/packages/shieldci/laravel)
+[![Laravel Version](https://img.shields.io/badge/laravel-9.x--13.x-red.svg)](https://packagist.org/packages/shieldci/laravel)
 [![License](https://img.shields.io/packagist/l/shieldci/laravel.svg)](https://packagist.org/packages/shieldci/laravel)
 [![Tests](https://github.com/ShieldCI/laravel/actions/workflows/tests.yml/badge.svg)](https://github.com/ShieldCI/laravel/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/ShieldCI/laravel/branch/master/graph/badge.svg)](https://codecov.io/gh/ShieldCI/laravel)
@@ -17,7 +17,7 @@ Built on top of [`shieldci/analyzers-core`](https://github.com/ShieldCI/analyzer
 ## Requirements
 
 - PHP 8.1 or higher
-- Laravel 9.x, 10.x, 11.x, 12.x
+- Laravel 9.x, 10.x, 11.x, 12.x, 13.x
 
 ## Architecture
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "shieldci/analyzers-core": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0|^13.0",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.6",
         "laravel/pint": "^1.13"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.6",
         "laravel/pint": "^1.13"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,18 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.0",
-        "illuminate/console": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/http": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/view": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/console": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/http": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/view": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "larastan/larastan": "^2.0|^3.0",
         "phpstan/phpstan": "^1.10|^2.0",
         "shieldci/analyzers-core": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "mockery/mockery": "^1.6",
         "laravel/pint": "^1.13"
     },

--- a/tests/Unit/Analyzers/Performance/HorizonSuggestionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/HorizonSuggestionAnalyzerTest.php
@@ -318,7 +318,7 @@ class HorizonSuggestionAnalyzerTest extends AnalyzerTestCase
     public function test_skips_when_vapor_yml_exists(): void
     {
         // Create a temporary vapor.yml file
-        $vaporConfig = $this->getBasePath().DIRECTORY_SEPARATOR.'vapor.yml';
+        $vaporConfig = $this->app->basePath().DIRECTORY_SEPARATOR.'vapor.yml';
         file_put_contents($vaporConfig, "id: 123\nname: my-app\nenvironments:\n  production:\n    build:\n      - 'composer install'\n");
 
         try {
@@ -351,7 +351,7 @@ class HorizonSuggestionAnalyzerTest extends AnalyzerTestCase
     public function test_skips_when_vapor_core_directory_exists(): void
     {
         // Create a temporary vendor/laravel/vapor-core directory
-        $vaporCoreDir = $this->getBasePath().DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'laravel'.DIRECTORY_SEPARATOR.'vapor-core';
+        $vaporCoreDir = $this->app->basePath().DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'laravel'.DIRECTORY_SEPARATOR.'vapor-core';
 
         if (! is_dir(dirname(dirname($vaporCoreDir)))) {
             mkdir(dirname(dirname($vaporCoreDir)), 0755, true);
@@ -390,7 +390,7 @@ class HorizonSuggestionAnalyzerTest extends AnalyzerTestCase
     public function test_skip_reason_explains_vapor_incompatibility(): void
     {
         // Create vapor.yml to trigger Vapor detection
-        $vaporConfig = $this->getBasePath().DIRECTORY_SEPARATOR.'vapor.yml';
+        $vaporConfig = $this->app->basePath().DIRECTORY_SEPARATOR.'vapor.yml';
         file_put_contents($vaporConfig, "id: 123\nname: my-app\n");
 
         try {
@@ -431,7 +431,7 @@ class HorizonSuggestionAnalyzerTest extends AnalyzerTestCase
         }
 
         // Ensure no Vapor indicators exist
-        $vaporConfig = $this->getBasePath().DIRECTORY_SEPARATOR.'vapor.yml';
+        $vaporConfig = $this->app->basePath().DIRECTORY_SEPARATOR.'vapor.yml';
         if (file_exists($vaporConfig)) {
             unlink($vaporConfig);
         }

--- a/tests/Unit/Analyzers/Security/StableDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/StableDependencyAnalyzerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ShieldCI\Tests\Unit\Analyzers\Security;
 
 use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use ShieldCI\Analyzers\Security\StableDependencyAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
@@ -999,9 +1000,7 @@ class StableDependencyAnalyzerTest extends AnalyzerTestCase
         $this->assertTrue($found, 'Should find unstable package issue');
     }
 
-    /**
-     * @dataProvider unstableVersionFormatsProvider
-     */
+    #[DataProvider('unstableVersionFormatsProvider')]
     public function test_detects_all_composer_unstable_version_formats(string $version, string $description): void
     {
         $composerJson = json_encode([
@@ -1064,9 +1063,7 @@ class StableDependencyAnalyzerTest extends AnalyzerTestCase
         ];
     }
 
-    /**
-     * @dataProvider stableVersionFormatsProvider
-     */
+    #[DataProvider('stableVersionFormatsProvider')]
     public function test_does_not_flag_stable_version_formats(string $version, string $description): void
     {
         $composerJson = json_encode([


### PR DESCRIPTION
## Summary

- Widens all `illuminate/*` constraints to `^9.0|^10.0|^11.0|^12.0|^13.0`
- Widens `orchestra/testbench` to `^7.0|^8.0|^9.0|^10.0|^11.0` and `phpunit/phpunit` to `^10.0|^11.0|^12.0|^13.0` to satisfy testbench v11 (Laravel 13) requirements
- Full CI matrix covering all supported PHP/Laravel combinations: L10 (8.1–8.3), L11 (8.2–8.4), L12 (8.2–8.5), L13 (8.3–8.5) — 13 jobs, L9 excluded due to security advisories PKSA-8qx3-n5y5-vvnd and PKSA-w7xr-vk7n-rstm
- Replaces `@dataProvider` annotations with `#[DataProvider]` attributes — PHPUnit 12 (used by testbench v11) removed annotation support
- Replaces `$this->getBasePath()` with `$this->app->basePath()` — Orchestra Testbench v10+ removed `getBasePath()` from `TestCase`
- Adds v1.6.5 changelog entry