### PR TITLE
fix: replace custom route walker in CsrfAnalyzer; fix PHPStan nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.6
+
+### Fixed
+- `CsrfAnalyzer::getRouteFiles()` now delegates to `getPhpFiles()` instead of a hand-rolled `DirectoryIterator` — configured `excludePatterns` are respected and route files in subdirectories (e.g. `routes/api/`) are now picked up
+- `HorizonSuggestionAnalyzerTest` — added `assertNotNull($this->app)` guards before `basePath()` calls to resolve PHPStan Level 9 `Application|null` errors
+
 ## v1.6.5
 
 ### Added

--- a/src/Analyzers/Security/CsrfAnalyzer.php
+++ b/src/Analyzers/Security/CsrfAnalyzer.php
@@ -947,24 +947,10 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
      */
     private function getRouteFiles(): array
     {
-        $files = [];
-        $routePath = $this->buildPath('routes');
-
-        if (! is_dir($routePath)) {
-            return $files;
-        }
-
-        try {
-            foreach (new \DirectoryIterator($routePath) as $file) {
-                if ($file->isFile() && $file->getExtension() === 'php') {
-                    $files[] = $file->getPathname();
-                }
-            }
-        } catch (\Throwable $e) {
-            // Silently fail if directory iterator fails
-        }
-
-        return $files;
+        return array_filter(
+            $this->getPhpFiles(),
+            fn (string $f) => str_contains($f, '/routes/')
+        );
     }
 
     /**

--- a/tests/Unit/Analyzers/Performance/HorizonSuggestionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/HorizonSuggestionAnalyzerTest.php
@@ -318,6 +318,7 @@ class HorizonSuggestionAnalyzerTest extends AnalyzerTestCase
     public function test_skips_when_vapor_yml_exists(): void
     {
         // Create a temporary vapor.yml file
+        $this->assertNotNull($this->app);
         $vaporConfig = $this->app->basePath().DIRECTORY_SEPARATOR.'vapor.yml';
         file_put_contents($vaporConfig, "id: 123\nname: my-app\nenvironments:\n  production:\n    build:\n      - 'composer install'\n");
 
@@ -351,6 +352,7 @@ class HorizonSuggestionAnalyzerTest extends AnalyzerTestCase
     public function test_skips_when_vapor_core_directory_exists(): void
     {
         // Create a temporary vendor/laravel/vapor-core directory
+        $this->assertNotNull($this->app);
         $vaporCoreDir = $this->app->basePath().DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'laravel'.DIRECTORY_SEPARATOR.'vapor-core';
 
         if (! is_dir(dirname(dirname($vaporCoreDir)))) {
@@ -390,6 +392,7 @@ class HorizonSuggestionAnalyzerTest extends AnalyzerTestCase
     public function test_skip_reason_explains_vapor_incompatibility(): void
     {
         // Create vapor.yml to trigger Vapor detection
+        $this->assertNotNull($this->app);
         $vaporConfig = $this->app->basePath().DIRECTORY_SEPARATOR.'vapor.yml';
         file_put_contents($vaporConfig, "id: 123\nname: my-app\n");
 
@@ -431,6 +434,7 @@ class HorizonSuggestionAnalyzerTest extends AnalyzerTestCase
         }
 
         // Ensure no Vapor indicators exist
+        $this->assertNotNull($this->app);
         $vaporConfig = $this->app->basePath().DIRECTORY_SEPARATOR.'vapor.yml';
         if (file_exists($vaporConfig)) {
             unlink($vaporConfig);


### PR DESCRIPTION
## Summary

- **`CsrfAnalyzer::getRouteFiles()`** — replaces the hand-rolled `DirectoryIterator` with `getPhpFiles()` + `array_filter`. This ensures configured `excludePatterns` are respected and picks up route files in subdirectories (e.g. `routes/api/`).
- **`HorizonSuggestionAnalyzerTest`** — adds `$this->assertNotNull($this->app)` before each `$this->app->basePath()` call to narrow the `Application|null` type and resolve 4 PHPStan Level 9 errors.