### PR TITLE
fix: skip FrontendVulnerableDependencyAnalyzer when package.json has no dependencies

### DIFF
--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -536,13 +536,13 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
                 'not_directory' => 'target is not a directory',
                 default => 'is invalid',
             };
-            $linkDetails[] = sprintf('  - %s → %s (%s)', $symlink['link'], $symlink['target'], $reasonText);
+            $linkDetails[] = sprintf(' - %s → %s (%s)', $symlink['link'], $symlink['target'], $reasonText);
         }
 
         $recommendations[] = "Broken symlinks:\n".implode("\n", $linkDetails);
 
-        $rec = implode("\n\n", $recommendations);
-        $rec .= "\n\nStorage symlinks are required for serving publicly accessible files (uploads, images, etc.).";
+        $rec = implode("\n", $recommendations);
+        $rec .= "\nStorage symlinks are required for serving publicly accessible files (uploads, images, etc.).";
 
         return $rec;
     }

--- a/src/Analyzers/Reliability/EnvExampleAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvExampleAnalyzer.php
@@ -137,7 +137,6 @@ RECOMMENDATION;
         return sprintf(
             <<<'RECOMMENDATION'
 Add the following environment variables to your .env.example file: %s
-
 These variables are currently used in .env but not documented in .env.example.
 This makes it harder for team members to know what variables are required.
 RECOMMENDATION,

--- a/src/Analyzers/Reliability/EnvVariableAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvVariableAnalyzer.php
@@ -219,13 +219,11 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
         return sprintf(
             <<<'RECOMMENDATION'
 Create a .env file by copying .env.example.
-
 Unix/Linux:
   %s
 
 Windows:
   %s
-
 After creating the file, configure the environment variables with appropriate values for your environment.
 RECOMMENDATION,
             'cp .env.example .env',
@@ -246,9 +244,7 @@ RECOMMENDATION,
         return sprintf(
             <<<'RECOMMENDATION'
 Add the following environment variables to your .env file: %s
-
 These variables are defined in .env.example and may be required for the application to function correctly.
-
 RECOMMENDATION,
             $variablesList,
         );
@@ -267,10 +263,8 @@ RECOMMENDATION,
         return sprintf(
             <<<'RECOMMENDATION'
 The following environment variables are commented out in .env: %s
-
 These variables are defined in .env.example. If they're intentionally disabled, this is fine.
 If they should be active, uncomment them in your .env file.
-
 RECOMMENDATION,
             $variablesList,
         );

--- a/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
@@ -53,12 +53,29 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
     {
         $packageJson = $this->buildPath('package.json');
 
-        return file_exists($packageJson);
+        if (! file_exists($packageJson)) {
+            return false;
+        }
+
+        $content = file_get_contents($packageJson);
+        if ($content === false) {
+            return false;
+        }
+
+        $data = json_decode($content, true);
+        if (! is_array($data)) {
+            return false;
+        }
+
+        $deps = isset($data['dependencies']) && is_array($data['dependencies']) ? $data['dependencies'] : [];
+        $devDeps = isset($data['devDependencies']) && is_array($data['devDependencies']) ? $data['devDependencies'] : [];
+
+        return $deps !== [] || $devDeps !== [];
     }
 
     public function getSkipReason(): string
     {
-        return 'No package.json found - not a frontend project';
+        return 'No package.json found or no dependencies declared';
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/FrontendVulnerableDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FrontendVulnerableDependencyAnalyzerTest.php
@@ -69,13 +69,52 @@ class FrontendVulnerableDependencyAnalyzerTest extends AnalyzerTestCase
     public function test_should_run_returns_true_when_package_json_exists(): void
     {
         $tempDir = $this->createTempDirectory([
-            'package.json' => '{"name": "test"}',
+            'package.json' => '{"name": "test", "dependencies": {"vue": "^3.0.0"}}',
         ]);
 
         $analyzer = $this->createAnalyzer();
         $analyzer->setBasePath($tempDir);
 
         $this->assertTrue($analyzer->shouldRun());
+    }
+
+    public function test_should_run_returns_false_when_package_json_has_no_deps(): void
+    {
+        $packageJson = json_encode([
+            'private' => true,
+            'scripts' => [],
+            'devDependencies' => [],
+        ]);
+
+        $tempDir = $this->createTempDirectory([
+            'package.json' => $packageJson,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $this->assertFalse($analyzer->shouldRun());
+    }
+
+    public function test_skips_when_package_json_has_no_deps(): void
+    {
+        $packageJson = json_encode([
+            'private' => true,
+            'scripts' => [],
+            'devDependencies' => [],
+        ]);
+
+        $tempDir = $this->createTempDirectory([
+            'package.json' => $packageJson,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertSkipped($result);
     }
 
     public function test_get_skip_reason_returns_correct_message(): void
@@ -85,7 +124,7 @@ class FrontendVulnerableDependencyAnalyzerTest extends AnalyzerTestCase
         $reason = $analyzer->getSkipReason();
 
         $this->assertStringContainsString('No package.json found', $reason);
-        $this->assertStringContainsString('not a frontend project', $reason);
+        $this->assertStringContainsString('no dependencies declared', $reason);
     }
 
     public function test_fails_when_package_json_exists_without_lock_file(): void
@@ -209,7 +248,7 @@ YARN;
     {
         $packageJson = json_encode([
             'name' => 'test-app',
-            'dependencies' => [],
+            'dependencies' => ['vue' => '^3.0.0'],
         ]);
 
         $tempDir = $this->createTempDirectory([
@@ -232,6 +271,7 @@ YARN;
     {
         $packageJson = json_encode([
             'name' => 'test-app',
+            'dependencies' => ['vue' => '^3.0.0'],
         ]);
 
         $packageLock = json_encode([
@@ -287,7 +327,7 @@ YARN;
         $property->setAccessible(true);
 
         // Create a temp directory to trigger runAnalysis (which calls loadConfiguration)
-        $packageJson = json_encode(['name' => 'test']);
+        $packageJson = json_encode(['name' => 'test', 'dependencies' => ['vue' => '^3.0.0']]);
         $packageLock = json_encode(['lockfileVersion' => 2]);
 
         $tempDir = $this->createTempDirectory([
@@ -322,7 +362,7 @@ YARN;
         $property->setAccessible(true);
 
         // Trigger runAnalysis to load configuration
-        $packageJson = json_encode(['name' => 'test']);
+        $packageJson = json_encode(['name' => 'test', 'dependencies' => ['vue' => '^3.0.0']]);
         $packageLock = json_encode(['lockfileVersion' => 2]);
 
         $tempDir = $this->createTempDirectory([
@@ -672,7 +712,7 @@ TEXT;
 
     public function test_result_uses_result_by_severity(): void
     {
-        $packageJson = json_encode(['name' => 'test']);
+        $packageJson = json_encode(['name' => 'test', 'dependencies' => ['vue' => '^3.0.0']]);
         $packageLock = json_encode(['lockfileVersion' => 2]);
 
         $tempDir = $this->createTempDirectory([
@@ -695,7 +735,7 @@ TEXT;
 
     public function test_summary_message_format_singular(): void
     {
-        $packageJson = json_encode(['name' => 'test']);
+        $packageJson = json_encode(['name' => 'test', 'dependencies' => ['vue' => '^3.0.0']]);
 
         $tempDir = $this->createTempDirectory([
             'package.json' => $packageJson,


### PR DESCRIPTION
## Summary

- `FrontendVulnerableDependencyAnalyzer::shouldRun()` previously returned `true` for any project containing a `package.json`, regardless of content
- Projects with an empty `package.json` (e.g. `{"private": true, "scripts": {}, "devDependencies": {}}`) were incorrectly flagged with a spurious "No lock file found" warning
- `shouldRun()` now parses `package.json` and returns `false` when both `dependencies` and `devDependencies` are absent or empty — nothing to audit means nothing to warn about
- `getSkipReason()` updated to cover both the missing-file and no-dependencies cases