### PR TITLE
fix: skip symlink check for API-only apps in DirectoryWritePermissionsAnalyzer

### DIFF
--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Reliability;
 
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Routing\Router;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\AnalyzesMiddleware;
 
 /**
  * Checks write permissions for critical Laravel directories and symlinks.
@@ -19,16 +22,33 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  * - storage/ directory is writable
  * - bootstrap/cache/ directory is writable
  * - Configurable via shieldci.writable_directories
- * - Storage symlinks from config('filesystems.links') are valid
+ * - Storage symlinks from config('filesystems.links') are valid (skipped for API-only apps)
  * - Configurable via shieldci.check_symlinks
  */
 class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
 {
+    use AnalyzesMiddleware;
+
     public static bool $runInCI = false;
 
+    /**
+     * Allows tests to override API-only app detection.
+     */
+    protected ?bool $statelessOverride = null;
+
     public function __construct(
+        Router $router,
+        Kernel $kernel,
         private Filesystem $files
-    ) {}
+    ) {
+        $this->router = $router;
+        $this->kernel = $kernel;
+    }
+
+    public function setStatelessOverride(?bool $stateless): void
+    {
+        $this->statelessOverride = $stateless;
+    }
 
     protected function metadata(): AnalyzerMetadata
     {
@@ -53,8 +73,10 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
         // Find directories that are missing or not writable
         ['missing' => $missingDirs, 'non_writable' => $nonWritableDirs] = $this->findDirectoryIssues($directoriesToCheck);
 
-        // Check symlinks if enabled (default: true)
-        $brokenSymlinks = $this->isSymlinkCheckEnabled() ? $this->checkSymlinks() : [];
+        // Check symlinks if enabled and not an API-only app (symlinks are web-specific infrastructure)
+        $brokenSymlinks = ($this->isSymlinkCheckEnabled() && ! $this->isApiOnlyApp())
+            ? $this->checkSymlinks()
+            : [];
 
         $hasDirectoryIssues = ! empty($missingDirs) || ! empty($nonWritableDirs);
         $hasSymlinkIssues = ! empty($brokenSymlinks);
@@ -361,6 +383,21 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
         } catch (\Throwable $e) {
             return $default;
         }
+    }
+
+    /**
+     * Determine whether this is an API-only (stateless) application.
+     *
+     * When true, symlink checks are skipped — storage symlinks are web-specific
+     * infrastructure and produce false positives in API-only apps.
+     */
+    private function isApiOnlyApp(): bool
+    {
+        if ($this->statelessOverride !== null) {
+            return $this->statelessOverride;
+        }
+
+        return $this->safeExecute(fn () => $this->appIsStateless(), false);
     }
 
     /**

--- a/tests/Unit/Analyzers/Reliability/DirectoryWritePermissionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/DirectoryWritePermissionsAnalyzerTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace ShieldCI\Tests\Unit\Analyzers\Reliability;
 
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Routing\Router;
 use ShieldCI\Analyzers\Reliability\DirectoryWritePermissionsAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
 use ShieldCI\Tests\AnalyzerTestCase;
@@ -13,7 +15,11 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
 {
     protected function createAnalyzer(): AnalyzerInterface
     {
-        return new DirectoryWritePermissionsAnalyzer(new Filesystem);
+        return new DirectoryWritePermissionsAnalyzer(
+            app(Router::class),
+            app(Kernel::class),
+            new Filesystem
+        );
     }
 
     // =========================================================================
@@ -610,7 +616,9 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
             'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
         $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false); // Force web app mode
         $analyzer->setBasePath($tempDir);
 
         $result = $analyzer->analyze();
@@ -641,7 +649,9 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
             'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
         $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false); // Force web app mode
         $analyzer->setBasePath($tempDir);
 
         $result = $analyzer->analyze();
@@ -688,7 +698,9 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
             'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
         $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false); // Force web app mode
         $analyzer->setBasePath($tempDir);
 
         $result = $analyzer->analyze();
@@ -732,7 +744,9 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
             'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
         $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false); // Force web app mode
         $analyzer->setBasePath($tempDir);
 
         $result = $analyzer->analyze();
@@ -771,7 +785,9 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
             'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
         $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false); // Force web app mode
         $analyzer->setBasePath($tempDir);
 
         $result = $analyzer->analyze();
@@ -810,7 +826,9 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
             'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
         $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false); // Force web app mode
         $analyzer->setBasePath($tempDir);
 
         $result = $analyzer->analyze();
@@ -867,7 +885,9 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
             'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
         $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false); // Force web app mode
         $analyzer->setBasePath($tempDir);
 
         $result = $analyzer->analyze();
@@ -906,7 +926,9 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
             'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
         ]);
 
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
         $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false); // Force web app mode
         $analyzer->setBasePath($tempDir);
 
         $result = $analyzer->analyze();
@@ -923,5 +945,64 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
         }
         $this->assertNotNull($symlinkIssue);
         $this->assertEquals(2, $symlinkIssue->metadata['broken_symlink_count']);
+    }
+
+    // =========================================================================
+    // API-Only App Tests
+    // =========================================================================
+
+    public function test_skips_symlink_check_for_api_only_apps(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            'storage/.gitkeep' => '',
+            'bootstrap/cache/.gitkeep' => '',
+        ]);
+
+        config([
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
+                $tempDir.'/storage',
+                $tempDir.'/bootstrap/cache',
+            ],
+            'filesystems.links' => [
+                $tempDir.'/public/storage' => $tempDir.'/storage/app/public',
+            ],
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
+        ]);
+
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(true); // API-only app
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        // Should pass even though the symlink is missing — symlink check was skipped
+        $this->assertPassed($result);
+    }
+
+    public function test_still_checks_directories_for_api_only_apps(): void
+    {
+        config([
+            'shieldci.analyzers.reliability.directory-write-permissions.writable_directories' => [
+                '/nonexistent/storage',
+                '/nonexistent/bootstrap/cache',
+            ],
+            'shieldci.analyzers.reliability.directory-write-permissions.check_symlinks' => true,
+        ]);
+
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(true); // API-only app
+        $analyzer->setBasePath('/nonexistent/path');
+
+        $result = $analyzer->analyze();
+
+        // Fails because storage/ and bootstrap/cache/ are missing
+        $this->assertFailed($result);
+
+        // No symlink issues — only directory issues
+        foreach ($result->getIssues() as $issue) {
+            $this->assertArrayNotHasKey('broken_symlinks', $issue->metadata ?? []);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Storage symlinks (`public/storage → storage/app/public`) are web-specific infrastructure and produce false positives in API-only Laravel apps
- Adds `AnalyzesMiddleware` trait + Router/Kernel injection to `DirectoryWritePermissionsAnalyzer`, gating the symlink branch on `!isApiOnlyApp()`
- Directory write permission checks always run regardless of app type
- Mirrors the pattern established in `CustomErrorPageAnalyzer` (#151)

## Changes

**`DirectoryWritePermissionsAnalyzer`**
- Uses `AnalyzesMiddleware` trait with Router + Kernel constructor injection
- Adds `isApiOnlyApp()` private helper (respects `statelessOverride` for testing, calls `appIsStateless()` in production)
- Adds `setStatelessOverride(?bool)` for test control
- Symlink branch gated: `isSymlinkCheckEnabled() && !isApiOnlyApp()`

**`DirectoryWritePermissionsAnalyzerTest`**
- Updates `createAnalyzer()` to inject Router and Kernel
- Adds `setStatelessOverride(false)` to all 8 existing symlink tests (Orchestra Testbench has no session middleware, so `appIsStateless()` returns `true` by default)
- Adds 2 new tests: `test_skips_symlink_check_for_api_only_apps` and `test_still_checks_directories_for_api_only_apps`