### PR TITLE
fix: don't require @return for PHP 8 union types of concrete classes

### DIFF
--- a/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
@@ -394,9 +394,16 @@ class DocBlockVisitor extends NodeVisitorAbstract
             return $this->requiresReturnDocumentation($typeNode->type);
         }
 
-        // Union types ALWAYS require documentation (even string|int)
+        // Union types: require @return only if any member itself requires documentation
+        // (e.g. string|array needs @return to document array shape, but Response|JsonResponse does not)
         if ($typeNode instanceof Node\UnionType) {
-            return true;
+            foreach ($typeNode->types as $type) {
+                if ($this->requiresReturnDocumentation($type)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         // Intersection types ALWAYS require documentation

--- a/tests/Unit/Analyzers/CodeQuality/MissingDocBlockAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/MissingDocBlockAnalyzerTest.php
@@ -791,7 +791,7 @@ class UserService
     /** Doc */ public function needsReturnIterable(): iterable { return []; }
     /** Doc */ public function needsReturnCallable(): callable { return fn() => true; }
     /** Doc */ public function needsReturnObject(): object { return new \stdClass; }
-    /** Doc */ public function needsReturnUnion(): string|int { return 'test'; }
+    /** Doc */ public function needsReturnUnion(): string|array { return 'test'; }
 
     /** @return string */ public function scalarString(): string { return 'test'; }
     /** @return int */ public function scalarInt(): int { return 1; }
@@ -1062,6 +1062,44 @@ PHP;
         $result = $analyzer->analyze();
 
         // Should pass because @throws tag is present
+        $this->assertPassed($result);
+    }
+
+    #[Test]
+    public function test_union_of_concrete_class_types_doesnt_require_return_tag(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+
+class ExampleController
+{
+    /**
+     * Handle the request.
+     */
+    public function handle(): Response|JsonResponse
+    {
+        return response()->json([]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/ExampleController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass - both union members are concrete class names, fully self-documenting
+        // Adding @return would conflict with Pint which strips redundant type declarations
         $this->assertPassed($result);
     }
 }


### PR DESCRIPTION
## Summary

- `MissingDocBlockAnalyzer` was producing a false positive on methods with union return types like `Response|JsonResponse` when the docblock had no `@return` tag
- This created an unsolvable conflict: the analyzer flagged missing `@return`, but Laravel Pint's `no_superfluous_phpdoc_tags` rule would immediately strip any added `@return` that merely duplicated the native type declaration
- Fixed `requiresReturnDocumentation()` to recurse into union members instead of returning `true` unconditionally — `@return` is now only required when at least one member is a generic type (`array`, `mixed`, `callable`, `iterable`, `object`) that needs shape documentation