### PR TITLE
fix: prevent CI false positives across 4 analyzers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.8
+
+### Fixed
+- `QueueDriverAnalyzer` no longer false-positives on the `database` queue driver in CI — `assessDatabaseDriver()` now calls `isTestingEnvironment()` before emitting the Low-severity warning, matching the guard already present in `assessSyncDriver()`; `$runInCI = false` is also added so the analyzer is skipped entirely when `--ci` is passed
+- `SessionDriverAnalyzer`, `EnvExampleAnalyzer`, and `EnvVariableAnalyzer` now set `$runInCI = false` — these analyzers inspect runtime environment conditions (session driver, `.env` file presence) that are intentionally different in CI runners; they are skipped when `--ci` is passed
+
 ## v1.6.7
 
 ### Fixed

--- a/src/Analyzers/Performance/QueueDriverAnalyzer.php
+++ b/src/Analyzers/Performance/QueueDriverAnalyzer.php
@@ -26,6 +26,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class QueueDriverAnalyzer extends AbstractAnalyzer
 {
+    public static bool $runInCI = false;
+
     public function __construct(
         private Config $config
     ) {
@@ -209,8 +211,8 @@ class QueueDriverAnalyzer extends AbstractAnalyzer
     {
         $environment = $this->getEnvironment();
 
-        // Database queue driver is acceptable for local development
-        if ($this->isLocalEnvironment($environment)) {
+        // Database queue driver is acceptable for local development and testing
+        if ($this->isLocalEnvironment($environment) || $this->isTestingEnvironment($environment)) {
             return;
         }
 

--- a/src/Analyzers/Performance/SessionDriverAnalyzer.php
+++ b/src/Analyzers/Performance/SessionDriverAnalyzer.php
@@ -34,6 +34,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class SessionDriverAnalyzer extends AbstractAnalyzer
 {
+    public static bool $runInCI = false;
+
     public function __construct(
         private Config $config,
         private Router $router,

--- a/src/Analyzers/Reliability/EnvExampleAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvExampleAnalyzer.php
@@ -22,6 +22,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class EnvExampleAnalyzer extends AbstractFileAnalyzer
 {
+    public static bool $runInCI = false;
+
     protected function metadata(): AnalyzerMetadata
     {
         return new AnalyzerMetadata(

--- a/src/Analyzers/Reliability/EnvVariableAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvVariableAnalyzer.php
@@ -22,6 +22,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class EnvVariableAnalyzer extends AbstractFileAnalyzer
 {
+    public static bool $runInCI = false;
+
     protected function metadata(): AnalyzerMetadata
     {
         return new AnalyzerMetadata(

--- a/tests/Unit/Analyzers/Performance/QueueDriverAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/QueueDriverAnalyzerTest.php
@@ -279,13 +279,13 @@ class QueueDriverAnalyzerTest extends AnalyzerTestCase
 
         $result = $analyzer->analyze();
 
-        $this->assertWarning($result);
-        $this->assertHasIssueContaining('database', $result);
+        $this->assertPassed($result);
+        $this->assertStringContainsString('testing environment', $result->getMessage());
+    }
 
-        $issues = $result->getIssues();
-        $this->assertNotEmpty($issues);
-        $this->assertEquals(\ShieldCI\AnalyzersCore\Enums\Severity::Low, $issues[0]->severity);
-        $this->assertEquals('testing', $issues[0]->metadata['environment'] ?? '');
+    public function test_is_not_run_in_ci_mode(): void
+    {
+        $this->assertFalse(QueueDriverAnalyzer::$runInCI);
     }
 
     public function test_fails_when_connection_not_defined(): void

--- a/tests/Unit/Analyzers/Performance/SessionDriverAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/SessionDriverAnalyzerTest.php
@@ -826,6 +826,11 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
         $this->assertEquals(30, $metadata->timeToFix);
     }
 
+    public function test_is_not_run_in_ci_mode(): void
+    {
+        $this->assertFalse(SessionDriverAnalyzer::$runInCI);
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();

--- a/tests/Unit/Analyzers/Reliability/EnvExampleAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/EnvExampleAnalyzerTest.php
@@ -533,6 +533,11 @@ APP_ENV=local';
         $this->assertContains('NEW_SECRET_KEY', $undocumentedVars);
     }
 
+    public function test_is_not_run_in_ci_mode(): void
+    {
+        $this->assertFalse(EnvExampleAnalyzer::$runInCI);
+    }
+
     public function test_case_sensitive_variable_matching(): void
     {
         $envContent = 'APP_NAME=MyApp

--- a/tests/Unit/Analyzers/Reliability/EnvVariableAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/EnvVariableAnalyzerTest.php
@@ -774,4 +774,9 @@ REQUIRED_VAR=',
         $this->assertSame('missing-variables', $issues[0]->code);
         $this->assertNotSame('parse-error-env', $issues[0]->code);
     }
+
+    public function test_is_not_run_in_ci_mode(): void
+    {
+        $this->assertFalse(EnvVariableAnalyzer::$runInCI);
+    }
 }


### PR DESCRIPTION
## Summary

- `QueueDriverAnalyzer`: adds `isTestingEnvironment()` guard to `assessDatabaseDriver()` (mirrors the guard already in `assessSyncDriver()`) and sets `$runInCI = false`
- `SessionDriverAnalyzer`, `EnvExampleAnalyzer`, `EnvVariableAnalyzer`: each sets `$runInCI = false` to skip entirely when `--ci` is passed — these analyzers inspect runtime conditions (session driver, `.env` presence) that are intentionally absent or different in CI runners