### PR TITLE
fix: skip CSP header check for API-only (stateless) applications

### DIFF
--- a/src/Analyzers/Security/XssAnalyzer.php
+++ b/src/Analyzers/Security/XssAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ShieldCI\Analyzers\Security;
 
 use GuzzleHttp\Client;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Str;
 use PhpParser\Node;
@@ -24,6 +25,7 @@ use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Concerns\AnalyzesHeaders;
+use ShieldCI\Concerns\AnalyzesMiddleware;
 use ShieldCI\Concerns\FindsLoginRoute;
 use SplFileInfo;
 use Throwable;
@@ -45,12 +47,18 @@ use Throwable;
 class XssAnalyzer extends AbstractFileAnalyzer
 {
     use AnalyzesHeaders;
+    use AnalyzesMiddleware;
     use FindsLoginRoute;
 
     /**
      * Skip HTTP checks in CI (requires live server).
      */
     private bool $skipHttpChecks = false;
+
+    /**
+     * Allows tests to override API-only app detection.
+     */
+    private ?bool $statelessOverride = null;
 
     /**
      * Safe JavaScript no-op patterns that don't execute code.
@@ -92,13 +100,19 @@ class XssAnalyzer extends AbstractFileAnalyzer
      */
     private const SUPERGLOBAL_NAMES = ['_GET', '_POST', '_REQUEST', '_COOKIE', '_FILES'];
 
-    public function __construct(Router $router)
+    public function __construct(Router $router, Kernel $kernel)
     {
         $this->router = $router;
+        $this->kernel = $kernel;
         $this->client = new Client;
 
         // Skip HTTP checks in CI mode
         $this->skipHttpChecks = config('shieldci.ci_mode', false);
+    }
+
+    public function setStatelessOverride(?bool $stateless): void
+    {
+        $this->statelessOverride = $stateless;
     }
 
     protected function metadata(): AnalyzerMetadata
@@ -781,6 +795,12 @@ class XssAnalyzer extends AbstractFileAnalyzer
      */
     private function analyzeHttpHeaders(): array
     {
+        // Skip CSP header check for stateless (API-only) applications — CSP is a
+        // browser security mechanism and irrelevant to pure JSON APIs
+        if ($this->isApiOnlyApp()) {
+            return [];
+        }
+
         $issues = [];
 
         // Try to find a guest URL to check
@@ -846,6 +866,25 @@ class XssAnalyzer extends AbstractFileAnalyzer
         }
 
         return $issues;
+    }
+
+    /**
+     * Determine whether the app is API-only (stateless, no browser/session routes).
+     *
+     * CSP headers are a browser security mechanism and are irrelevant to pure JSON APIs,
+     * so the HTTP header check should be skipped for such applications.
+     */
+    private function isApiOnlyApp(): bool
+    {
+        if ($this->statelessOverride !== null) {
+            return $this->statelessOverride;
+        }
+
+        try {
+            return $this->appIsStateless();
+        } catch (Throwable) {
+            return false; // Can't inspect → assume web app to avoid missing real issues
+        }
     }
 
     /**

--- a/src/Concerns/AnalyzesMiddleware.php
+++ b/src/Concerns/AnalyzesMiddleware.php
@@ -7,6 +7,7 @@ namespace ShieldCI\Concerns;
 use Closure;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Str;
 use ReflectionClass;
@@ -19,10 +20,8 @@ trait AnalyzesMiddleware
 {
     /**
      * The router instance.
-     *
-     * @var \Illuminate\Routing\Router
      */
-    protected $router;
+    protected Router $router;
 
     /**
      * The HTTP kernel instance.

--- a/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
@@ -22,11 +22,14 @@ class XssAnalyzerTest extends AnalyzerTestCase
         /** @var \Illuminate\Routing\Router $router */
         $router = $this->app?->make('router');
 
-        if ($router === null) {
-            throw new \RuntimeException('Router not available in test application');
+        /** @var \Illuminate\Contracts\Http\Kernel $kernel */
+        $kernel = $this->app?->make(\Illuminate\Contracts\Http\Kernel::class);
+
+        if ($router === null || $kernel === null) {
+            throw new \RuntimeException('Router or Kernel not available in test application');
         }
 
-        return new XssAnalyzer($router);
+        return new XssAnalyzer($router, $kernel);
     }
 
     /**
@@ -45,11 +48,19 @@ class XssAnalyzerTest extends AnalyzerTestCase
         /** @var \Illuminate\Routing\Router $router */
         $router = $this->app?->make('router');
 
-        if ($router === null) {
-            throw new \RuntimeException('Router not available in test application');
+        /** @var \Illuminate\Contracts\Http\Kernel $kernel */
+        $kernel = $this->app?->make(\Illuminate\Contracts\Http\Kernel::class);
+
+        if ($router === null || $kernel === null) {
+            throw new \RuntimeException('Router or Kernel not available in test application');
         }
 
-        $analyzer = new XssAnalyzer($router);
+        $analyzer = new XssAnalyzer($router, $kernel);
+
+        // Explicitly mark as a web app so the HTTP header check is not skipped.
+        // The test environment has no session routes, so without this override
+        // isApiOnlyApp() would return true and bypass all HTTP header assertions.
+        $analyzer->setStatelessOverride(false);
 
         $mock = new MockHandler($responses);
         $handlerStack = HandlerStack::create($mock);
@@ -441,6 +452,26 @@ BLADE;
         $this->assertPassed($result);
         $this->assertStringNotContainsString('headers verified', $result->getMessage());
         $this->assertStringContainsString('in code', $result->getMessage());
+    }
+
+    public function test_skips_csp_check_for_api_only_app(): void
+    {
+        config(['app.url' => 'https://api.example.com']);
+        config(['shieldci.ci_mode' => false]);
+
+        $tempDir = $this->createTempDirectory(['test.blade.php' => '<div>{{ $safe }}</div>']);
+
+        /** @var XssAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(true); // Simulate an API-only app (no web/session routes)
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // CSP check is a browser mechanism — irrelevant to JSON APIs, so no issue reported
+        $this->assertPassed($result);
+        $this->assertEmpty($result->getIssues());
     }
 
     public function test_reports_both_code_and_header_issues_in_production(): void

--- a/tests/Unit/Concerns/AnalyzesMiddlewareTest.php
+++ b/tests/Unit/Concerns/AnalyzesMiddlewareTest.php
@@ -442,7 +442,7 @@ class AnalyzesMiddlewareTest extends TestCase
 
             /** @param array<int, string> $fixedGlobal */
             public function __construct(
-                protected $router,
+                protected \Illuminate\Routing\Router $router,
                 protected $kernel,
                 private array $fixedGlobal,
             ) {}
@@ -477,7 +477,7 @@ class AnalyzesMiddlewareTest extends TestCase
             use AnalyzesMiddleware;
 
             public function __construct(
-                protected $router,
+                protected \Illuminate\Routing\Router $router,
                 protected $kernel,
             ) {}
 


### PR DESCRIPTION
## Summary

- `XssAnalyzer::analyzeHttpHeaders()` was reporting a false positive missing CSP header on pure JSON API apps — CSP is a browser security mechanism irrelevant to stateless/API-only applications
- `findLoginRoute()` always falls back to the root URL `/` (never returns null), so the HTTP header check was always triggered
- Added `AnalyzesMiddleware` trait to `XssAnalyzer` and delegated API detection to `appIsStateless()`, following the same pattern as `DirectoryWritePermissionsAnalyzer`
- Typed `AnalyzesMiddleware::$router` as `Router` to resolve a PHP fatal trait property conflict with `FindsLoginRoute` (both traits now declare an identical typed property, which PHP 8 allows)