### PR TITLE
fix: skip composer validate subprocess on serverless runtimes

### DIFF
--- a/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
+++ b/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
@@ -9,6 +9,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
+use ShieldCI\AnalyzersCore\Support\PlatformDetector;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Support\ComposerValidator;
@@ -60,6 +61,12 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
         $jsonValidationResult = $this->validateJsonSyntax($composerJsonPath);
         if ($jsonValidationResult !== null) {
             return $jsonValidationResult;
+        }
+
+        // Skip `composer validate` subprocess on serverless runtimes — composer binary
+        // is not installed on Lambda/Cloud Functions/etc. JSON syntax already validated above.
+        if (PlatformDetector::isServerless()) {
+            return $this->passed('composer.json is valid');
         }
 
         $basePath = $this->getBasePath();

--- a/tests/Unit/Analyzers/Reliability/ComposerValidationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/ComposerValidationAnalyzerTest.php
@@ -313,6 +313,33 @@ class ComposerValidationAnalyzerTest extends AnalyzerTestCase
         $this->assertNotEmpty($issues[0]->metadata['json_error']);
     }
 
+    // =========================================================================
+    // Serverless Runtime Tests
+    // =========================================================================
+
+    public function test_skips_composer_validate_on_serverless_runtime(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            'composer.json' => json_encode(['name' => 'test/app', 'description' => 'test']),
+        ]);
+
+        putenv('VAPOR_SSM_PATH=/app/production');
+
+        /** @var ComposerValidator&\Mockery\MockInterface $mockValidator */
+        $mockValidator = Mockery::mock(ComposerValidator::class);
+        $mockValidator->shouldNotReceive('validate');
+
+        $analyzer = new ComposerValidationAnalyzer($mockValidator);
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        putenv('VAPOR_SSM_PATH');
+
+        $this->assertPassed($result);
+    }
+
     public function test_location_points_to_composer_json(): void
     {
         $tempDir = $this->createTempDirectory([


### PR DESCRIPTION
## Summary

- `ComposerValidationAnalyzer` now skips the `composer validate` subprocess when running on a serverless runtime (AWS Lambda, Vapor, Cloud Functions)
- JSON syntax validation via pure PHP (`FileParser` + `json_decode`) still runs — only the subprocess is bypassed
- Uses `PlatformDetector::isServerless()` (runtime env vars: `AWS_LAMBDA_FUNCTION_NAME`, `VAPOR_SSM_PATH`, etc.) so Vapor projects analyzed locally or in CI still get the full `composer validate` check

**Why `isServerless()` not `isLaravelVapor()`**

`isLaravelVapor()` detects the presence of `vendor/laravel/vapor-core`, which is true locally and in CI too. `isServerless()` only fires on the actual Lambda runtime where `composer` is not installed, avoiding false positives there while preserving validation everywhere else.