### PR TITLE
fix: skip log_errors and display_startup_errors checks on Vapor/serverless

### DIFF
--- a/src/Analyzers/Security/PHPIniAnalyzer.php
+++ b/src/Analyzers/Security/PHPIniAnalyzer.php
@@ -113,9 +113,16 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
         $issues = [];
         $phpIniPath = $this->getPhpIniPath();
         $configuration = $this->getConfiguration();
+        $secureSettings = $configuration['secure_settings'];
 
-        // Check PHP ini settings
-        $this->checkPhpIniSettings($issues, $phpIniPath, $configuration['secure_settings']);
+        // These checks are not applicable on Vapor/serverless:
+        // - log_errors: platform captures stderr via CloudWatch
+        // - display_startup_errors: no user-facing output; errors go to internal logs
+        if ($this->isVaporOrServerless()) {
+            unset($secureSettings['log_errors'], $secureSettings['display_startup_errors']);
+        }
+
+        $this->checkPhpIniSettings($issues, $phpIniPath, $secureSettings);
 
         if (empty($issues)) {
             return $this->passed('PHP configuration is secure');

--- a/tests/Unit/Analyzers/Security/PHPIniAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/PHPIniAnalyzerTest.php
@@ -813,6 +813,29 @@ class PHPIniAnalyzerTest extends AnalyzerTestCase
         }
     }
 
+    public function test_it_skips_log_errors_and_display_startup_errors_on_vapor(): void
+    {
+        $tempDir = $this->createVaporFixture(iniLines: []);
+
+        $analyzer = new PHPIniAnalyzer;
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPhpIniPath($tempDir.'/php.ini');
+        $analyzer->setDeploymentPlatform('vapor');
+        $analyzer->setIniValues([
+            'allow_url_fopen' => '0',
+            'allow_url_include' => '0',
+            'expose_php' => '0',
+            'display_errors' => '0',
+            'display_startup_errors' => '1',  // On — should be ignored on Vapor
+            'log_errors' => '0',  // Off — should be ignored on Vapor
+            'ignore_repeated_errors' => '0',
+        ]);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
     public function test_vapor_passes_when_all_settings_secure(): void
     {
         $tempDir = $this->createVaporFixture(


### PR DESCRIPTION
## Summary

- On Lambda/Vapor, stderr is captured by CloudWatch automatically — PHP's file-based `log_errors` setting is irrelevant and produces false positives
- `display_startup_errors` on serverless sends errors to internal logs, never to user-facing HTTP responses — the information-disclosure risk doesn't apply
- `allow_url_fopen` is intentionally kept — SSRF risk applies regardless of platform
- Follows the same false-positive suppression pattern as #155–#159