### PR TITLE
fix: skip RouteCachingAnalyzer on Vapor/serverless runtimes

### DIFF
--- a/src/Analyzers/Performance/RouteCachingAnalyzer.php
+++ b/src/Analyzers/Performance/RouteCachingAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\PlatformDetector;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 
 /**
@@ -31,11 +32,21 @@ class RouteCachingAnalyzer extends AbstractAnalyzer
      */
     public static bool $runInCI = false;
 
+    private ?string $deploymentPlatformOverride = null;
+
     public function __construct(
         private Application $app,
         Config $config
     ) {
         $this->configRepository = $config;
+    }
+
+    /**
+     * Override deployment platform detection (testing only).
+     */
+    public function setDeploymentPlatform(string $platform): void
+    {
+        $this->deploymentPlatformOverride = $platform;
     }
 
     protected function metadata(): AnalyzerMetadata
@@ -53,12 +64,19 @@ class RouteCachingAnalyzer extends AbstractAnalyzer
 
     public function shouldRun(): bool
     {
-        // Check if the application implements CachesRoutes interface
+        if ($this->isVaporOrServerless()) {
+            return false;
+        }
+
         return $this->app instanceof CachesRoutes;
     }
 
     public function getSkipReason(): string
     {
+        if ($this->isVaporOrServerless()) {
+            return 'Route caching is not applicable on serverless runtimes';
+        }
+
         return 'Application does not implement CachesRoutes interface';
     }
 
@@ -121,5 +139,18 @@ class RouteCachingAnalyzer extends AbstractAnalyzer
     private function isProductionOrStaging(string $environment): bool
     {
         return in_array($environment, ['production', 'staging'], true);
+    }
+
+    /**
+     * Check if the deployment platform is Laravel Vapor or another serverless environment.
+     */
+    private function isVaporOrServerless(): bool
+    {
+        if ($this->deploymentPlatformOverride !== null) {
+            return in_array($this->deploymentPlatformOverride, ['vapor', 'serverless'], true);
+        }
+
+        return PlatformDetector::isLaravelVapor($this->getBasePath())
+            || PlatformDetector::isServerless();
     }
 }

--- a/src/Analyzers/Performance/RouteCachingAnalyzer.php
+++ b/src/Analyzers/Performance/RouteCachingAnalyzer.php
@@ -74,7 +74,7 @@ class RouteCachingAnalyzer extends AbstractAnalyzer
     public function getSkipReason(): string
     {
         if ($this->isVaporOrServerless()) {
-            return 'Route caching is not applicable on serverless runtimes';
+            return 'Route caching is not supported on Laravel Vapor (blocked by Vapor CLI build process)';
         }
 
         return 'Application does not implement CachesRoutes interface';

--- a/tests/Unit/Analyzers/Performance/RouteCachingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/RouteCachingAnalyzerTest.php
@@ -239,6 +239,16 @@ class RouteCachingAnalyzerTest extends AnalyzerTestCase
         $this->assertSame('Application does not implement CachesRoutes interface', $analyzer->getSkipReason());
     }
 
+    public function test_skips_on_serverless_runtime(): void
+    {
+        /** @var RouteCachingAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('serverless', $analyzer->getSkipReason());
+    }
+
     // ============================================================
     // Category 1: Result Type and Severity Validation (3 tests)
     // ============================================================

--- a/tests/Unit/Analyzers/Performance/RouteCachingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/RouteCachingAnalyzerTest.php
@@ -246,7 +246,7 @@ class RouteCachingAnalyzerTest extends AnalyzerTestCase
         $analyzer->setDeploymentPlatform('vapor');
 
         $this->assertFalse($analyzer->shouldRun());
-        $this->assertStringContainsString('serverless', $analyzer->getSkipReason());
+        $this->assertStringContainsString('Vapor', $analyzer->getSkipReason());
     }
 
     // ============================================================


### PR DESCRIPTION
## Summary

- `RouteCachingAnalyzer` now returns `shouldRun() = false` when `PlatformDetector` identifies a Laravel Vapor or serverless environment
- `getSkipReason()` returns a message explaining that Vapor CLI explicitly blocks `route:cache`
- Follows the existing pattern used by `HorizonSuggestionAnalyzer`
- Adds `setDeploymentPlatform()` override for testability (same pattern as other analyzers with platform guards)

## Context

`route:cache` is in Vapor CLI's explicit `$unsupportedCommands` list ([source](https://github.com/laravel/vapor-cli/blob/3b528a1bebe2c128f402c822f850ffde8ff34175/src/BuildProcess/ExecuteBuildCommands.php#L10)) — it is actively filtered out even from build hooks, not just blocked at runtime by the read-only filesystem. Route caching is completely unsupported on Vapor, so the analyzer skips with a clear message rather than reporting misleading results.