### PR TITLE
refactor: migrate SessionDriverAnalyzer to AnalyzesMiddleware trait

### DIFF
--- a/src/Analyzers/Performance/SessionDriverAnalyzer.php
+++ b/src/Analyzers/Performance/SessionDriverAnalyzer.php
@@ -7,9 +7,6 @@ namespace ShieldCI\Analyzers\Performance;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Router;
-use Illuminate\Session\Middleware\StartSession;
-use Illuminate\Support\Str;
-use ReflectionClass;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
@@ -18,6 +15,7 @@ use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\AnalyzesMiddleware;
 
 /**
  * Analyzes session driver configuration for performance and scalability.
@@ -34,14 +32,18 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class SessionDriverAnalyzer extends AbstractAnalyzer
 {
+    use AnalyzesMiddleware;
+
     public static bool $runInCI = false;
 
     public function __construct(
         private Config $config,
-        private Router $router,
-        private Kernel $kernel
+        Router $router,
+        Kernel $kernel
     ) {
         $this->configRepository = $config;
+        $this->router = $router;
+        $this->kernel = $kernel;
     }
 
     protected function metadata(): AnalyzerMetadata
@@ -181,249 +183,6 @@ class SessionDriverAnalyzer extends AbstractAnalyzer
                 'environment' => $environment,
             ]
         );
-    }
-
-    /**
-     * Check if the application is stateless (doesn't use sessions).
-     *
-     * Optimized detection order:
-     * 1. Check global middleware (fast, usually empty or few items)
-     * 2. Check if any session-containing middleware group is used by routes
-     */
-    private function appIsStateless(): bool
-    {
-        // 1. Check global middleware first (fast)
-        if ($this->hasSessionInGlobalMiddleware()) {
-            return false;
-        }
-
-        // 2. Check if any session-containing group is actually used by routes
-        if ($this->hasSessionGroupUsedByRoutes()) {
-            return false;
-        }
-
-        return true; // App is stateless
-    }
-
-    /**
-     * Check if StartSession middleware is in global middleware.
-     */
-    private function hasSessionInGlobalMiddleware(): bool
-    {
-        $globalMiddleware = $this->getGlobalMiddleware();
-
-        foreach ($globalMiddleware as $middleware) {
-            if ($this->isStartSessionMiddleware($middleware)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Check if any route uses middleware that resolves to StartSession.
-     *
-     * This avoids false positives where a group (e.g., 'web') contains StartSession
-     * but no routes actually use that group (e.g., API-only apps).
-     *
-     * Uses gatherRouteMiddleware() for reliable alias/group expansion.
-     */
-    private function hasSessionGroupUsedByRoutes(): bool
-    {
-        // Early exit: if no middleware group contains StartSession,
-        // routes can't possibly use sessions via groups
-        $sessionGroups = $this->getGroupsContainingSession();
-
-        // If no groups have sessions, we still need to check for direct StartSession assignment
-        // but we can skip the expensive gatherRouteMiddleware if no routes exist
-        $routes = $this->router->getRoutes();
-
-        // Check each route's resolved middleware for StartSession
-        /** @phpstan-ignore-next-line RouteCollection implements Traversable */
-        foreach ($routes as $route) {
-            if (! $route instanceof \Illuminate\Routing\Route) {
-                continue;
-            }
-
-            if ($this->routeUsesSession($route, $sessionGroups)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Check if a route uses session middleware.
-     * Uses gatherRouteMiddleware() for reliable alias/group expansion.
-     *
-     * @param  array<int, string>  $sessionGroups  Groups known to contain StartSession
-     */
-    private function routeUsesSession(\Illuminate\Routing\Route $route, array $sessionGroups): bool
-    {
-        // Use gatherRouteMiddleware to properly resolve all middleware
-        if (! method_exists($this->router, 'gatherRouteMiddleware')) {
-            // Fallback for older Laravel: check raw middleware
-            return $this->routeMiddlewareContainsSession($route->middleware(), $sessionGroups);
-        }
-
-        try {
-            $gathered = $this->router->gatherRouteMiddleware($route);
-        } catch (\Throwable) {
-            // Fallback on error
-            return $this->routeMiddlewareContainsSession($route->middleware(), $sessionGroups);
-        }
-
-        if (! is_array($gathered)) {
-            return false;
-        }
-
-        foreach ($gathered as $middleware) {
-            if (! is_string($middleware)) {
-                continue;
-            }
-
-            $middlewareClass = Str::before($middleware, ':');
-
-            if ($this->isStartSessionMiddleware($middlewareClass)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Check if raw middleware array contains session middleware.
-     * Used as fallback when gatherRouteMiddleware is not available.
-     *
-     * @param  array<int, string>  $sessionGroups
-     */
-    private function routeMiddlewareContainsSession(mixed $middleware, array $sessionGroups): bool
-    {
-        if (! is_array($middleware)) {
-            return false;
-        }
-
-        foreach ($middleware as $m) {
-            if (! is_string($m)) {
-                continue;
-            }
-
-            $middlewareName = Str::before($m, ':');
-
-            // Check if this middleware is a session-containing group
-            if ($sessionGroups !== [] && in_array($middlewareName, $sessionGroups, true)) {
-                return true;
-            }
-
-            // Check for StartSession directly assigned
-            if ($this->isStartSessionMiddleware($middlewareName)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Get the names of middleware groups that contain StartSession.
-     *
-     * @return array<int, string> Group names like ['web', 'admin']
-     */
-    private function getGroupsContainingSession(): array
-    {
-        if (! method_exists($this->router, 'getMiddlewareGroups')) {
-            return [];
-        }
-
-        $groups = $this->router->getMiddlewareGroups();
-
-        if (! is_array($groups)) {
-            return [];
-        }
-
-        $sessionGroups = [];
-
-        foreach ($groups as $groupName => $middlewareList) {
-            if (! is_string($groupName) || ! is_array($middlewareList)) {
-                continue;
-            }
-
-            foreach ($middlewareList as $middleware) {
-                if (! is_string($middleware)) {
-                    continue;
-                }
-
-                $middlewareClass = Str::before($middleware, ':');
-                if ($this->isStartSessionMiddleware($middlewareClass)) {
-                    $sessionGroups[] = $groupName;
-                    break; // Found in this group, move to next
-                }
-            }
-        }
-
-        return $sessionGroups;
-    }
-
-    /**
-     * Get the global middleware from the kernel.
-     *
-     * @return array<int, string>
-     */
-    private function getGlobalMiddleware(): array
-    {
-        // Try the public method first (Laravel 10+)
-        if (method_exists($this->kernel, 'getGlobalMiddleware')) {
-            $middleware = $this->kernel->getGlobalMiddleware();
-
-            return is_array($middleware) ? $middleware : [];
-        }
-
-        // Fall back to reflection for older Laravel versions
-        try {
-            $mirror = new ReflectionClass($this->kernel);
-            $property = $mirror->getProperty('middleware');
-            $property->setAccessible(true);
-
-            $middlewareList = $property->getValue($this->kernel);
-
-            if (! is_array($middlewareList)) {
-                return [];
-            }
-
-            /** @var array<int, string> */
-            return array_values(array_filter(array_map(
-                fn ($m): string => is_string($m) ? Str::before($m, ':') : '',
-                $middlewareList
-            )));
-        } catch (\ReflectionException) {
-            return [];
-        }
-    }
-
-    /**
-     * Check if a middleware class is StartSession or a subclass of it.
-     */
-    private function isStartSessionMiddleware(string $middleware): bool
-    {
-        // Exact match
-        if ($middleware === StartSession::class) {
-            return true;
-        }
-
-        // Check basename match (e.g., "StartSession" without namespace)
-        if (class_basename($middleware) === 'StartSession') {
-            return true;
-        }
-
-        // Check if it's a subclass of StartSession
-        if (str_contains($middleware, '\\') && class_exists($middleware) && is_subclass_of($middleware, StartSession::class)) {
-            return true;
-        }
-
-        return false;
     }
 
     /**

--- a/tests/Unit/Analyzers/Performance/SessionDriverAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/SessionDriverAnalyzerTest.php
@@ -90,6 +90,10 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
             /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $route->shouldReceive('middleware')
                 ->andReturn($routeMiddleware);
+            // isVendorRoute() calls getAction('uses') — null means closure = app-defined route
+            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
+            $route->shouldReceive('getAction')
+                ->andReturn(null);
             $mockRoutes[] = $route;
         }
 


### PR DESCRIPTION
## Summary

- Removes ~140 lines of duplicated private middleware-detection methods from `SessionDriverAnalyzer` by delegating to the shared `AnalyzesMiddleware` trait
- Fixes a latent false-positive: the private implementation was missing the `isVendorRoute()` filter added to the trait, which could incorrectly detect session usage when Vapor/serverless packages inject web-group routes the app developer didn't define
- Updates the test's route mock to stub `getAction('uses')`, required by the trait's `isVendorRoute()` check
- No logic changes to `shouldRun()` — it still calls `appIsStateless()`, now resolved via the trait