### PR TITLE
fix: skip DirectoryWritePermissionsAnalyzer on Vapor/serverless

### DIFF
--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\PlatformDetector;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Concerns\AnalyzesMiddleware;
@@ -36,6 +37,8 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
      */
     protected ?bool $statelessOverride = null;
 
+    private ?string $deploymentPlatformOverride = null;
+
     public function __construct(
         Router $router,
         Kernel $kernel,
@@ -48,6 +51,24 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
     public function setStatelessOverride(?bool $stateless): void
     {
         $this->statelessOverride = $stateless;
+    }
+
+    /**
+     * Override deployment platform detection (testing only).
+     */
+    public function setDeploymentPlatform(string $platform): void
+    {
+        $this->deploymentPlatformOverride = $platform;
+    }
+
+    public function shouldRun(): bool
+    {
+        return ! $this->isVaporOrServerless();
+    }
+
+    public function getSkipReason(): string
+    {
+        return 'Directory write permissions are managed by Laravel Vapor and cannot be changed by the user';
     }
 
     protected function metadata(): AnalyzerMetadata
@@ -604,5 +625,18 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
         }
 
         return false;
+    }
+
+    /**
+     * Check if the deployment platform is Laravel Vapor or another serverless environment.
+     */
+    private function isVaporOrServerless(): bool
+    {
+        if ($this->deploymentPlatformOverride !== null) {
+            return in_array($this->deploymentPlatformOverride, ['vapor', 'serverless'], true);
+        }
+
+        return PlatformDetector::isLaravelVapor($this->getBasePath())
+            || PlatformDetector::isServerless();
     }
 }

--- a/tests/Unit/Analyzers/Reliability/DirectoryWritePermissionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/DirectoryWritePermissionsAnalyzerTest.php
@@ -1005,4 +1005,27 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
             $this->assertArrayNotHasKey('broken_symlinks', $issue->metadata ?? []);
         }
     }
+
+    // =========================================================================
+    // Vapor / Serverless Skip Tests
+    // =========================================================================
+
+    public function test_skips_on_vapor_environment(): void
+    {
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Vapor', $analyzer->getSkipReason());
+    }
+
+    public function test_skips_on_serverless_environment(): void
+    {
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('serverless');
+
+        $this->assertFalse($analyzer->shouldRun());
+    }
 }


### PR DESCRIPTION
## Summary

- `bootstrap/cache` is flagged as non-writable on Laravel Vapor because AWS Lambda mounts the deployment package read-only — PHP's `is_writable()` sees raw POSIX permissions, but Vapor overlays writable paths via `/tmp` bind mounts at runtime
- Adds `shouldRun()` override that returns `false` on Vapor/serverless, using the same `PlatformDetector` + `setDeploymentPlatform()` testing pattern already in `RouteCachingAnalyzer`, `PHPIniAnalyzer`, and `OpcacheAnalyzer`
- Adds two tests: `test_skips_on_vapor_environment()` and `test_skips_on_serverless_environment()`