### PR TITLE
fix: skip dry-run in StableDependencyAnalyzer when prefer-stable is configured

### DIFF
--- a/src/Analyzers/Security/StableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/StableDependencyAnalyzer.php
@@ -61,6 +61,7 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
 
         // Get composer.json path (we know it exists from shouldRun())
         $composerJson = $this->buildPath('composer.json');
+        $composerJsonData = $this->parseJsonFile($composerJson);
 
         $this->checkComposerConfiguration($composerJson, $issues);
 
@@ -70,26 +71,33 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
             $this->checkComposerLock($composerLock, $issues);
         }
 
-        try {
-            $preferStableOutput = $this->composer->updateDryRun(['--prefer-stable']);
-            if ($this->preferStableRunChangesDependencies($preferStableOutput)) {
-                $filePath = file_exists($composerLock) ? $composerLock : $composerJson;
-                $isLockFile = file_exists($composerLock);
-                $issues[] = $this->createIssue(
-                    message: 'Composer update --prefer-stable would modify installed packages',
-                    location: new Location($this->getRelativePath($filePath)),
-                    severity: Severity::Low,
-                    recommendation: 'Run "composer update --prefer-stable" and ensure all dependencies resolve to stable releases.',
-                    code: $isLockFile ? null : FileParser::getCodeSnippet($filePath, 1),
-                    metadata: [
-                        'composer_version_check' => 'update --dry-run --prefer-stable',
-                    ]
+        // When prefer-stable is already configured, composer update --prefer-stable only detects
+        // available stable→stable upgrades, not genuine instability. Skip the dry-run to avoid
+        // false positives; checkComposerLock() already covers any unstable installed versions.
+        $preferStableConfigured = isset($composerJsonData['prefer-stable']) && $composerJsonData['prefer-stable'] === true;
+
+        if (! $preferStableConfigured) {
+            try {
+                $preferStableOutput = $this->composer->updateDryRun(['--prefer-stable']);
+                if ($this->preferStableRunChangesDependencies($preferStableOutput)) {
+                    $filePath = file_exists($composerLock) ? $composerLock : $composerJson;
+                    $isLockFile = file_exists($composerLock);
+                    $issues[] = $this->createIssue(
+                        message: 'Composer update --prefer-stable would modify installed packages',
+                        location: new Location($this->getRelativePath($filePath)),
+                        severity: Severity::Low,
+                        recommendation: 'Run "composer update --prefer-stable" and ensure all dependencies resolve to stable releases.',
+                        code: $isLockFile ? null : FileParser::getCodeSnippet($filePath, 1),
+                        metadata: [
+                            'composer_version_check' => 'update --dry-run --prefer-stable',
+                        ]
+                    );
+                }
+            } catch (Throwable $exception) {
+                return $this->error(
+                    sprintf('Unable to verify dependency stability: %s', $exception->getMessage())
                 );
             }
-        } catch (Throwable $exception) {
-            return $this->error(
-                sprintf('Unable to verify dependency stability: %s', $exception->getMessage())
-            );
         }
 
         if (empty($issues)) {

--- a/tests/Unit/Analyzers/Security/StableDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/StableDependencyAnalyzerTest.php
@@ -563,7 +563,6 @@ class StableDependencyAnalyzerTest extends AnalyzerTestCase
         $composerJson = json_encode([
             'name' => 'test/app',
             'minimum-stability' => 'stable',
-            'prefer-stable' => true,
             'require' => [
                 'php' => '^8.1',
                 'vendor/package' => '^1.0',
@@ -601,7 +600,6 @@ class StableDependencyAnalyzerTest extends AnalyzerTestCase
         $composerJson = json_encode([
             'name' => 'test/app',
             'minimum-stability' => 'stable',
-            'prefer-stable' => true,
             'require' => [
                 'php' => '^8.1',
             ],
@@ -631,6 +629,39 @@ class StableDependencyAnalyzerTest extends AnalyzerTestCase
 
         $this->assertError($result);
         $this->assertStringContainsString('Unable to verify dependency stability', $result->getMessage());
+    }
+
+    public function test_does_not_flag_stable_updates_when_prefer_stable_is_configured(): void
+    {
+        // When prefer-stable:true is already set, composer update --prefer-stable
+        // detects available stable-to-stable updates, which must NOT be flagged as stability issues.
+        $composerJson = json_encode([
+            'name' => 'test/app',
+            'minimum-stability' => 'stable',
+            'prefer-stable' => true,
+            'require' => ['php' => '^8.1', 'vendor/package' => '^1.0'],
+        ]);
+        $composerLock = json_encode([
+            'packages' => [['name' => 'vendor/package', 'version' => '1.0.0']],
+            'packages-dev' => [],
+        ]);
+
+        $tempDir = $this->createTempDirectory([
+            'composer.json' => $composerJson,
+            'composer.lock' => $composerLock,
+        ]);
+
+        /** @var Composer&\Mockery\MockInterface $composer */
+        $composer = Mockery::mock(Composer::class);
+        $composer->shouldNotReceive('updateDryRun'); // dry-run must be skipped entirely
+
+        $analyzer = $this->createAnalyzer($composer);
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
     }
 
     public function test_handles_invalid_json_in_composer_json_gracefully(): void
@@ -835,7 +866,6 @@ class StableDependencyAnalyzerTest extends AnalyzerTestCase
         $composerJson = json_encode([
             'name' => 'test/app',
             'minimum-stability' => 'stable',
-            'prefer-stable' => true,
             'require' => [
                 'php' => '^8.1',
                 'vendor/package' => '^1.0',


### PR DESCRIPTION
## Summary

- `StableDependencyAnalyzer` was emitting false-positive warnings on projects with `prefer-stable: true` because the `composer update --prefer-stable` dry-run detects available stable→stable upgrades, which it treated as genuine instability
- Added a guard: when `prefer-stable: true` is already set in `composer.json`, the dry-run is skipped entirely — `checkComposerLock()` already covers any genuinely unstable installed versions
- Updated three existing tests that had `prefer-stable: true` but were testing dry-run behaviour (removed the flag so the dry-run code path is actually exercised)
- Added `test_does_not_flag_stable_updates_when_prefer_stable_is_configured` regression test using `shouldNotReceive('updateDryRun')` to enforce the skip at the Mockery level