### PR TITLE
fix: skip Vapor-affected analyzers in Vapor/serverless environments

### DIFF
--- a/src/Analyzers/Performance/MinificationAnalyzer.php
+++ b/src/Analyzers/Performance/MinificationAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Detects unminified assets in production.
@@ -27,6 +28,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class MinificationAnalyzer extends AbstractFileAnalyzer
 {
+    use DetectsDeploymentPlatform;
+
     /**
      * Asset minification checks require compiled assets, not applicable in CI.
      */
@@ -94,6 +97,10 @@ class MinificationAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
+        if ($this->isVaporOrServerless()) {
+            return false;
+        }
+
         // Check environment relevance first
         if (! $this->isRelevantForCurrentEnvironment()) {
             return false;
@@ -107,6 +114,10 @@ class MinificationAnalyzer extends AbstractFileAnalyzer
 
     public function getSkipReason(): string
     {
+        if ($this->isVaporOrServerless()) {
+            return 'Vapor removes webpack.mix.js from the deployment; assets must be pre-compiled and uploaded before deploying to Vapor';
+        }
+
         if (! $this->isRelevantForCurrentEnvironment()) {
             $currentEnv = $this->getEnvironment();
             $relevantEnvs = implode(', ', $this->relevantEnvironments ?? []);

--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -11,10 +11,10 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
-use ShieldCI\AnalyzersCore\Support\PlatformDetector;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Concerns\AnalyzesMiddleware;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Checks write permissions for critical Laravel directories and symlinks.
@@ -29,6 +29,7 @@ use ShieldCI\Concerns\AnalyzesMiddleware;
 class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
 {
     use AnalyzesMiddleware;
+    use DetectsDeploymentPlatform;
 
     public static bool $runInCI = false;
 
@@ -36,8 +37,6 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
      * Allows tests to override API-only app detection.
      */
     protected ?bool $statelessOverride = null;
-
-    private ?string $deploymentPlatformOverride = null;
 
     public function __construct(
         Router $router,
@@ -51,14 +50,6 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
     public function setStatelessOverride(?bool $stateless): void
     {
         $this->statelessOverride = $stateless;
-    }
-
-    /**
-     * Override deployment platform detection (testing only).
-     */
-    public function setDeploymentPlatform(string $platform): void
-    {
-        $this->deploymentPlatformOverride = $platform;
     }
 
     public function shouldRun(): bool
@@ -625,18 +616,5 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
         }
 
         return false;
-    }
-
-    /**
-     * Check if the deployment platform is Laravel Vapor or another serverless environment.
-     */
-    private function isVaporOrServerless(): bool
-    {
-        if ($this->deploymentPlatformOverride !== null) {
-            return in_array($this->deploymentPlatformOverride, ['vapor', 'serverless'], true);
-        }
-
-        return PlatformDetector::isLaravelVapor($this->getBasePath())
-            || PlatformDetector::isServerless();
     }
 }

--- a/src/Analyzers/Reliability/EnvExampleAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvExampleAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Checks that all environment variables from .env are documented in .env.example.
@@ -22,7 +23,19 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class EnvExampleAnalyzer extends AbstractFileAnalyzer
 {
+    use DetectsDeploymentPlatform;
+
     public static bool $runInCI = false;
+
+    public function shouldRun(): bool
+    {
+        return ! $this->isVaporOrServerless();
+    }
+
+    public function getSkipReason(): string
+    {
+        return 'Vapor removes .env and .env.example from the deployment; environment variables are provided via Vapor UI (SSM Parameter Store, plaintext vars, or encrypted environment files)';
+    }
 
     protected function metadata(): AnalyzerMetadata
     {

--- a/src/Analyzers/Reliability/EnvFileAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvFileAnalyzer.php
@@ -9,6 +9,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Checks if .env file exists in the application.
@@ -19,7 +20,19 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
  */
 class EnvFileAnalyzer extends AbstractFileAnalyzer
 {
+    use DetectsDeploymentPlatform;
+
     public static bool $runInCI = false;
+
+    public function shouldRun(): bool
+    {
+        return ! $this->isVaporOrServerless();
+    }
+
+    public function getSkipReason(): string
+    {
+        return 'Vapor removes the plain .env file from the deployment; environment variables are provided via Vapor UI (SSM Parameter Store, plaintext vars, or encrypted environment files)';
+    }
 
     protected function metadata(): AnalyzerMetadata
     {

--- a/src/Analyzers/Reliability/EnvVariableAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvVariableAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Checks that all environment variables from .env.example are defined in .env.
@@ -22,7 +23,19 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class EnvVariableAnalyzer extends AbstractFileAnalyzer
 {
+    use DetectsDeploymentPlatform;
+
     public static bool $runInCI = false;
+
+    public function shouldRun(): bool
+    {
+        return ! $this->isVaporOrServerless();
+    }
+
+    public function getSkipReason(): string
+    {
+        return 'Vapor removes the plain .env file from the deployment; environment variables are provided via Vapor UI (SSM Parameter Store, plaintext vars, or encrypted environment files)';
+    }
 
     protected function metadata(): AnalyzerMetadata
     {

--- a/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
+++ b/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Validates .env file security and location.
@@ -24,6 +25,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 {
+    use DetectsDeploymentPlatform;
+
     public static bool $runInCI = false;
 
     private const WORLD_READABLE = 0x0004;
@@ -75,6 +78,10 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
+        if ($this->isVaporOrServerless()) {
+            return false;
+        }
+
         $envFile = $this->buildPath('.env');
         $envExample = $this->buildPath('.env.example');
         $gitignore = $this->buildPath('.gitignore');
@@ -105,6 +112,10 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
     public function getSkipReason(): string
     {
+        if ($this->isVaporOrServerless()) {
+            return 'Vapor removes the plain .env file from the deployment; environment variables are provided via Vapor UI (SSM Parameter Store, plaintext vars, or encrypted environment files)';
+        }
+
         return 'No environment files, git repository, or public directories found to analyze';
     }
 

--- a/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Detects vulnerable frontend dependencies (npm/yarn) with known security issues.
@@ -22,6 +23,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 {
+    use DetectsDeploymentPlatform;
+
     /**
      * @var array<string>
      */
@@ -51,6 +54,10 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
+        if ($this->isVaporOrServerless()) {
+            return false;
+        }
+
         $packageJson = $this->buildPath('package.json');
 
         if (! file_exists($packageJson)) {
@@ -75,6 +82,10 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     public function getSkipReason(): string
     {
+        if ($this->isVaporOrServerless()) {
+            return 'Vapor removes frontend lock files (yarn.lock, package-lock.json) from the deployment package; frontend dependencies are managed outside the Lambda runtime';
+        }
+
         return 'No package.json found or no dependencies declared';
     }
 

--- a/src/Concerns/DetectsDeploymentPlatform.php
+++ b/src/Concerns/DetectsDeploymentPlatform.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Concerns;
+
+use ShieldCI\AnalyzersCore\Support\PlatformDetector;
+
+/**
+ * Provides Vapor/serverless platform detection with test-override support.
+ */
+trait DetectsDeploymentPlatform
+{
+    private ?string $deploymentPlatformOverride = null;
+
+    /**
+     * Override deployment platform detection (testing only).
+     */
+    public function setDeploymentPlatform(string $platform): void
+    {
+        $this->deploymentPlatformOverride = $platform;
+    }
+
+    private function isVaporOrServerless(): bool
+    {
+        if ($this->deploymentPlatformOverride !== null) {
+            return in_array($this->deploymentPlatformOverride, ['vapor', 'serverless'], true);
+        }
+
+        return PlatformDetector::isLaravelVapor($this->getBasePath())
+            || PlatformDetector::isServerless();
+    }
+}

--- a/tests/Unit/Analyzers/Performance/MinificationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/MinificationAnalyzerTest.php
@@ -1776,4 +1776,27 @@ JS;
         // Should pass - .min. files are always skipped
         $this->assertPassed($result);
     }
+
+    // =========================================================================
+    // Vapor / Serverless Skip Tests
+    // =========================================================================
+
+    public function test_skips_on_vapor(): void
+    {
+        /** @var \ShieldCI\Analyzers\Performance\MinificationAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Vapor', $analyzer->getSkipReason());
+    }
+
+    public function test_skips_on_serverless(): void
+    {
+        /** @var \ShieldCI\Analyzers\Performance\MinificationAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('serverless');
+
+        $this->assertFalse($analyzer->shouldRun());
+    }
 }

--- a/tests/Unit/Analyzers/Reliability/EnvExampleAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/EnvExampleAnalyzerTest.php
@@ -559,4 +559,27 @@ app_name=lowercase';
         // Only APP_NAME should be recognized, which is documented
         $this->assertPassed($result);
     }
+
+    // =========================================================================
+    // Vapor / Serverless Skip Tests
+    // =========================================================================
+
+    public function test_skips_on_vapor(): void
+    {
+        /** @var \ShieldCI\Analyzers\Reliability\EnvExampleAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Vapor', $analyzer->getSkipReason());
+    }
+
+    public function test_skips_on_serverless(): void
+    {
+        /** @var \ShieldCI\Analyzers\Reliability\EnvExampleAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('serverless');
+
+        $this->assertFalse($analyzer->shouldRun());
+    }
 }

--- a/tests/Unit/Analyzers/Reliability/EnvFileAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/EnvFileAnalyzerTest.php
@@ -260,4 +260,27 @@ APP_KEY=base64:test123',
         // Should not crash with empty basepath
         $this->assertInstanceOf(\ShieldCI\AnalyzersCore\Contracts\ResultInterface::class, $result);
     }
+
+    // =========================================================================
+    // Vapor / Serverless Skip Tests
+    // =========================================================================
+
+    public function test_skips_on_vapor(): void
+    {
+        /** @var \ShieldCI\Analyzers\Reliability\EnvFileAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Vapor', $analyzer->getSkipReason());
+    }
+
+    public function test_skips_on_serverless(): void
+    {
+        /** @var \ShieldCI\Analyzers\Reliability\EnvFileAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('serverless');
+
+        $this->assertFalse($analyzer->shouldRun());
+    }
 }

--- a/tests/Unit/Analyzers/Reliability/EnvVariableAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/EnvVariableAnalyzerTest.php
@@ -779,4 +779,27 @@ REQUIRED_VAR=',
     {
         $this->assertFalse(EnvVariableAnalyzer::$runInCI);
     }
+
+    // =========================================================================
+    // Vapor / Serverless Skip Tests
+    // =========================================================================
+
+    public function test_skips_on_vapor(): void
+    {
+        /** @var \ShieldCI\Analyzers\Reliability\EnvVariableAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Vapor', $analyzer->getSkipReason());
+    }
+
+    public function test_skips_on_serverless(): void
+    {
+        /** @var \ShieldCI\Analyzers\Reliability\EnvVariableAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('serverless');
+
+        $this->assertFalse($analyzer->shouldRun());
+    }
 }

--- a/tests/Unit/Analyzers/Security/EnvFileSecurityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/EnvFileSecurityAnalyzerTest.php
@@ -936,4 +936,27 @@ ENV;
             );
         }
     }
+
+    // =========================================================================
+    // Vapor / Serverless Skip Tests
+    // =========================================================================
+
+    public function test_skips_on_vapor(): void
+    {
+        /** @var \ShieldCI\Analyzers\Security\EnvFileSecurityAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Vapor', $analyzer->getSkipReason());
+    }
+
+    public function test_skips_on_serverless(): void
+    {
+        /** @var \ShieldCI\Analyzers\Security\EnvFileSecurityAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('serverless');
+
+        $this->assertFalse($analyzer->shouldRun());
+    }
 }

--- a/tests/Unit/Analyzers/Security/FrontendVulnerableDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FrontendVulnerableDependencyAnalyzerTest.php
@@ -763,4 +763,27 @@ TEXT;
 
         return $returnCode === 0;
     }
+
+    // =========================================================================
+    // Vapor / Serverless Skip Tests
+    // =========================================================================
+
+    public function test_skips_on_vapor(): void
+    {
+        /** @var \ShieldCI\Analyzers\Security\FrontendVulnerableDependencyAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Vapor', $analyzer->getSkipReason());
+    }
+
+    public function test_skips_on_serverless(): void
+    {
+        /** @var \ShieldCI\Analyzers\Security\FrontendVulnerableDependencyAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('serverless');
+
+        $this->assertFalse($analyzer->shouldRun());
+    }
 }


### PR DESCRIPTION
## Summary

- Extracts a shared `DetectsDeploymentPlatform` trait from the inline implementation in `DirectoryWritePermissionsAnalyzer`, providing `setDeploymentPlatform()` and `isVaporOrServerless()` for reuse
- Adds `shouldRun()` + `getSkipReason()` to `EnvFileAnalyzer`, `EnvExampleAnalyzer`, and `EnvVariableAnalyzer` — these three had no Vapor guard at all
- Prepends a Vapor check to the existing `shouldRun()` in `EnvFileSecurityAnalyzer`, `FrontendVulnerableDependencyAnalyzer`, and `MinificationAnalyzer`
- Adds 14 new tests (vapor + serverless skip per analyzer) across 7 test files

**Why:** Vapor removes `.env`, `.env.example`, `webpack.mix.js`, `yarn.lock`, and `package-lock.json` from deployments. Without these guards, the analyzers report false positives (e.g. "missing .env file") when run on a Vapor project.