### PR TITLE
fix: align SessionDriverAnalyzer.shouldRun() with CustomErrorPageAnalyzer pattern

### DIFF
--- a/src/Analyzers/Performance/SessionDriverAnalyzer.php
+++ b/src/Analyzers/Performance/SessionDriverAnalyzer.php
@@ -36,6 +36,11 @@ class SessionDriverAnalyzer extends AbstractAnalyzer
 
     public static bool $runInCI = false;
 
+    /**
+     * Allows tests to override stateless detection.
+     */
+    protected ?bool $statelessOverride = null;
+
     public function __construct(
         private Config $config,
         Router $router,
@@ -61,13 +66,25 @@ class SessionDriverAnalyzer extends AbstractAnalyzer
 
     public function shouldRun(): bool
     {
-        // Only run if the app actually uses sessions
-        return ! $this->appIsStateless();
+        try {
+            if ($this->statelessOverride !== null) {
+                return ! $this->statelessOverride;
+            }
+
+            return ! $this->appIsStateless();
+        } catch (\ReflectionException $e) {
+            return true;
+        }
     }
 
     public function getSkipReason(): string
     {
-        return 'Application does not use sessions (stateless)';
+        return 'Not applicable for stateless/API-only applications (no session middleware detected)';
+    }
+
+    public function setStatelessOverride(?bool $stateless): void
+    {
+        $this->statelessOverride = $stateless;
     }
 
     protected function runAnalysis(): ResultInterface

--- a/tests/Unit/Analyzers/Performance/SessionDriverAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/SessionDriverAnalyzerTest.php
@@ -293,7 +293,7 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
         );
 
         $this->assertFalse($analyzer->shouldRun());
-        $this->assertSame('Application does not use sessions (stateless)', $analyzer->getSkipReason());
+        $this->assertSame('Not applicable for stateless/API-only applications (no session middleware detected)', $analyzer->getSkipReason());
 
         $result = $analyzer->analyze();
 
@@ -778,7 +778,7 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
         );
 
         $this->assertFalse($analyzer->shouldRun());
-        $this->assertSame('Application does not use sessions (stateless)', $analyzer->getSkipReason());
+        $this->assertSame('Not applicable for stateless/API-only applications (no session middleware detected)', $analyzer->getSkipReason());
     }
 
     public function test_handles_empty_middleware_groups(): void
@@ -813,7 +813,57 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
         );
 
         $this->assertFalse($analyzer->shouldRun());
-        $this->assertSame('Application does not use sessions (stateless)', $analyzer->getSkipReason());
+        $this->assertSame('Not applicable for stateless/API-only applications (no session middleware detected)', $analyzer->getSkipReason());
+    }
+
+    // ============================================================
+    // Category 6: statelessOverride and Defensive Fallback (3 tests)
+    // ============================================================
+
+    public function test_stateless_override_true_skips_analyzer(): void
+    {
+        /** @var SessionDriverAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(true);
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertSame(
+            'Not applicable for stateless/API-only applications (no session middleware detected)',
+            $analyzer->getSkipReason()
+        );
+    }
+
+    public function test_stateless_override_false_forces_run_even_when_stateless(): void
+    {
+        // App is wired as stateless (no session middleware), but override forces run
+        /** @var SessionDriverAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer(usesSession: false);
+        $analyzer->setStatelessOverride(false);
+
+        $this->assertTrue($analyzer->shouldRun());
+    }
+
+    public function test_reflection_exception_defaults_to_running(): void
+    {
+        /** @var \Illuminate\Contracts\Config\Repository&\Mockery\MockInterface $config */
+        $config = Mockery::mock(\Illuminate\Contracts\Config\Repository::class);
+        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
+        $config->shouldReceive('get')->andReturn('redis');
+
+        /** @var \Illuminate\Routing\Router&\Mockery\MockInterface $router */
+        $router = Mockery::mock(\Illuminate\Routing\Router::class);
+        /** @var \Illuminate\Contracts\Http\Kernel&\Mockery\MockInterface $kernel */
+        $kernel = Mockery::mock(\Illuminate\Contracts\Http\Kernel::class);
+
+        $analyzer = new class($config, $router, $kernel) extends SessionDriverAnalyzer
+        {
+            protected function appIsStateless(): bool
+            {
+                throw new \ReflectionException('simulated reflection failure');
+            }
+        };
+
+        $this->assertTrue($analyzer->shouldRun());
     }
 
     public function test_analyzer_metadata_values(): void


### PR DESCRIPTION
## Summary

- Add `$statelessOverride` property and `setStatelessOverride()` to `SessionDriverAnalyzer`, mirroring `CustomErrorPageAnalyzer`
- Wrap `shouldRun()` in `try/catch \ReflectionException` so unusual DI configurations fail open (run) rather than crashing
- Update `getSkipReason()` message to the shared wording used by `CustomErrorPageAnalyzer`
- Add 3 new tests: override-true skips, override-false forces run even when stateless, `ReflectionException` defaults to running
- Update 3 existing skip-reason assertions to match the new message