### PR TITLE
refactor: remove Issue::$code field, migrate identifiers to metadata['code']

### DIFF
--- a/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
+++ b/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
@@ -60,7 +60,6 @@ class ChunkMissingAnalyzer extends AbstractFileAnalyzer
                         lineNumber: $issue['line'],
                         severity: $issue['severity'],
                         recommendation: $issue['recommendation'],
-                        code: $issue['code'] ?? null,
                     );
                 }
             } catch (\Throwable $e) {

--- a/src/Analyzers/BestPractices/ConfigOutsideConfigAnalyzer.php
+++ b/src/Analyzers/BestPractices/ConfigOutsideConfigAnalyzer.php
@@ -85,7 +85,6 @@ class ConfigOutsideConfigAnalyzer extends AbstractFileAnalyzer
                         lineNumber: $issue['line'],
                         severity: $issue['severity'],
                         recommendation: $issue['recommendation'],
-                        code: $issue['code'] ?? null,
                     );
                 }
             } catch (PhpParserError $e) {

--- a/src/Analyzers/BestPractices/FatModelAnalyzer.php
+++ b/src/Analyzers/BestPractices/FatModelAnalyzer.php
@@ -97,7 +97,6 @@ class FatModelAnalyzer extends AbstractFileAnalyzer
                         lineNumber: $issue['line'],
                         severity: $issue['severity'],
                         recommendation: $issue['recommendation'],
-                        code: $issue['code'] ?? null,
                     );
                     $affectedModels[$file] = true;
                 }

--- a/src/Analyzers/BestPractices/FrameworkOverrideAnalyzer.php
+++ b/src/Analyzers/BestPractices/FrameworkOverrideAnalyzer.php
@@ -142,7 +142,6 @@ class FrameworkOverrideAnalyzer extends AbstractFileAnalyzer
                         lineNumber: $issue['line'],
                         severity: $issue['severity'],
                         recommendation: $issue['recommendation'],
-                        code: $issue['code'] ?? null,
                     );
                 }
             } catch (\Throwable $e) {

--- a/src/Analyzers/BestPractices/HardcodedStoragePathsAnalyzer.php
+++ b/src/Analyzers/BestPractices/HardcodedStoragePathsAnalyzer.php
@@ -155,7 +155,6 @@ class HardcodedStoragePathsAnalyzer extends AbstractFileAnalyzer
                         lineNumber: $issue['line'],
                         severity: $issue['severity'],
                         recommendation: $issue['recommendation'],
-                        code: $issue['code'] ?? null,
                     );
                 }
             } catch (\Throwable $e) {

--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -181,11 +181,11 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
                         lineNumber: $phpBlockStart,
                         severity: Severity::Medium,
                         recommendation: 'Move complex PHP logic to controllers, view composers, or presenter classes. Blade templates should focus on presentation only',
-                        code: 'blade-php-block-too-long',
                         metadata: [
                             'block_lines' => $phpBlockLines,
                             'max_lines' => $this->maxPhpBlockLines,
                             'block_start' => $phpBlockStart,
+                            'code' => 'blade-php-block-too-long',
                         ]
                     );
                 }
@@ -216,8 +216,7 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
                     lineNumber: $lineNumber + 1,
                     severity: Severity::Medium,
                     recommendation: 'Use Blade directives (@php...@endphp) instead of inline PHP for consistency',
-                    code: 'blade-inline-php',
-                    metadata: ['line' => $lineNumber + 1]
+                    metadata: ['line' => $lineNumber + 1, 'code' => 'blade-inline-php']
                 );
             }
         }
@@ -230,10 +229,10 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
                 lineNumber: $phpBlockStart,
                 severity: Severity::High,
                 recommendation: 'Every @php directive must have a matching @endphp',
-                code: 'blade-unclosed-php-block',
                 metadata: [
                     'block_start' => $phpBlockStart,
                     'lines_counted' => $phpBlockLines,
+                    'code' => 'blade-unclosed-php-block',
                 ]
             );
         }
@@ -283,7 +282,7 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
 
             $this->reportedLines[$lineKey] = true;
 
-            $metadata = array_merge(['line' => $originalLine], $astIssue['metadata'] ?? []);
+            $metadata = array_merge(['line' => $originalLine, 'code' => $astIssue['code']], $astIssue['metadata'] ?? []);
 
             $issues[] = $this->createIssueWithSnippet(
                 message: $astIssue['message'],
@@ -291,7 +290,6 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
                 lineNumber: $originalLine,
                 severity: $astIssue['severity'],
                 recommendation: $astIssue['recommendation'],
-                code: $astIssue['code'],
                 metadata: $metadata
             );
         }

--- a/src/Analyzers/BestPractices/LogicInRoutesAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInRoutesAnalyzer.php
@@ -89,8 +89,7 @@ class LogicInRoutesAnalyzer extends AbstractFileAnalyzer
                         lineNumber: $issue['line'],
                         severity: $issue['severity'],
                         recommendation: $issue['recommendation'],
-                        code: $issue['code'],
-                        metadata: $issue['metadata'] ?? []
+                        metadata: array_merge($issue['metadata'] ?? [], ['code' => $issue['code']])
                     );
                 }
             } catch (\Throwable $e) {

--- a/src/Analyzers/CodeQuality/CommentedCodeAnalyzer.php
+++ b/src/Analyzers/CodeQuality/CommentedCodeAnalyzer.php
@@ -152,13 +152,13 @@ class CommentedCodeAnalyzer extends AbstractFileAnalyzer
                     recommendation: $this->getRecommendation($block['lineCount']),
                     column: null,
                     contextLines: null,
-                    code: 'commented-code',
                     metadata: [
                         'startLine' => $block['startLine'],
                         'endLine' => $block['endLine'],
                         'lineCount' => $block['lineCount'],
                         'preview' => $block['preview'],
                         'file' => $file,
+                        'code' => 'commented-code',
                     ]
                 );
             }

--- a/src/Analyzers/CodeQuality/MethodLengthAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MethodLengthAnalyzer.php
@@ -102,7 +102,6 @@ class MethodLengthAnalyzer extends AbstractFileAnalyzer
                     recommendation: $this->getRecommendation($issue['lines'], $threshold, $issue['type']),
                     column: null,
                     contextLines: null,
-                    code: $issue['name'],
                     metadata: [
                         'name' => $issue['name'],
                         'type' => $issue['type'],

--- a/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
@@ -76,7 +76,6 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
                     recommendation: $this->getRecommendation($issue['type'], $issue['method']),
                     column: null,
                     contextLines: null,
-                    code: $issue['method'],
                     metadata: [
                         'method' => $issue['method'],
                         'class' => $issue['class'],

--- a/src/Analyzers/CodeQuality/NamingConventionAnalyzer.php
+++ b/src/Analyzers/CodeQuality/NamingConventionAnalyzer.php
@@ -70,7 +70,6 @@ class NamingConventionAnalyzer extends AbstractFileAnalyzer
                     recommendation: $this->getRecommendation($issue['type'], $issue['name'], $issue['suggestion']),
                     column: null,
                     contextLines: null,
-                    code: $issue['name'],
                     metadata: [
                         'type' => $issue['type'],
                         'name' => $issue['name'],

--- a/src/Analyzers/CodeQuality/NestingDepthAnalyzer.php
+++ b/src/Analyzers/CodeQuality/NestingDepthAnalyzer.php
@@ -80,7 +80,6 @@ class NestingDepthAnalyzer extends AbstractFileAnalyzer
                     recommendation: $this->getRecommendation($issue['depth'], $threshold),
                     column: null,
                     contextLines: null,
-                    code: $issue['context'],
                     metadata: [
                         'depth' => $issue['depth'],
                         'threshold' => $threshold,

--- a/src/Analyzers/Performance/CacheHeaderAnalyzer.php
+++ b/src/Analyzers/Performance/CacheHeaderAnalyzer.php
@@ -223,11 +223,11 @@ class CacheHeaderAnalyzer extends AbstractAnalyzer
                 $this->formatUncachedAssets(),
                 $thresholdNote
             ),
-            code: 'cache-headers',
             metadata: [
                 'uncached_assets' => $this->uncachedAssets->toArray(),
                 'count' => $this->uncachedAssets->count(),
                 'hit_threshold' => $hitThreshold,
+                'code' => 'cache-headers',
             ]
         )];
 

--- a/src/Analyzers/Performance/DebugLogAnalyzer.php
+++ b/src/Analyzers/Performance/DebugLogAnalyzer.php
@@ -158,12 +158,12 @@ class DebugLogAnalyzer extends AbstractAnalyzer
                 lineNumber: $lineNumber,
                 severity: $this->metadata()->severity,
                 recommendation: "Change the log level to 'info' or higher in production. Debug logging causes significant performance degradation, generates massive log files that can exhaust disk space, and exposes sensitive data in logs. Update your logging configuration or set LOG_LEVEL environment variable to 'info', 'warning', or 'error'.",
-                code: 'debug-log-level',
                 metadata: [
                     'environment' => $environment,
                     'channel' => $channel,
                     'level' => $level,
                     'detection_method' => 'config_repository',
+                    'code' => 'debug-log-level',
                 ]
             );
         }

--- a/src/Analyzers/Performance/EnvCallAnalyzer.php
+++ b/src/Analyzers/Performance/EnvCallAnalyzer.php
@@ -112,7 +112,6 @@ class EnvCallAnalyzer extends AbstractFileAnalyzer
                 lineNumber: $line,
                 severity: $this->metadata()->severity,
                 recommendation: ConfigSuggester::getRecommendation($varNameString),
-                code: $callType === 'static' ? 'Env::get' : 'env',
                 metadata: [
                     'function' => $callType === 'static' ? 'Env::get' : 'env',
                     'variable' => $varNameString,

--- a/src/Analyzers/Performance/OpcacheAnalyzer.php
+++ b/src/Analyzers/Performance/OpcacheAnalyzer.php
@@ -496,8 +496,7 @@ class OpcacheAnalyzer extends AbstractAnalyzer
             lineNumber: $line,
             severity: $severity,
             recommendation: $recommendation,
-            code: 'opcache-setting',
-            metadata: $metadata
+            metadata: array_merge($metadata, ['code' => 'opcache-setting'])
         );
     }
 

--- a/src/Analyzers/Performance/SharedCacheLockAnalyzer.php
+++ b/src/Analyzers/Performance/SharedCacheLockAnalyzer.php
@@ -121,7 +121,6 @@ class SharedCacheLockAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($usage['file']), $usage['line']),
                 severity: $this->metadata()->severity,
                 recommendation: $this->getRecommendation(),
-                code: FileParser::getCodeSnippet($usage['file'], $usage['line']),
                 metadata: [
                     'file' => $usage['file'],
                     'line' => $usage['line'],

--- a/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
+++ b/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
@@ -88,7 +88,6 @@ class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
                 lineNumber: $middlewareLine,
                 severity: $this->metadata()->severity,
                 recommendation: $middleware['recommendation'],
-                code: $middleware['name'],
                 metadata: [
                     'middleware_class' => $middleware['class'],
                     'middleware_name' => $middleware['name'],

--- a/src/Analyzers/Reliability/CachePrefixAnalyzer.php
+++ b/src/Analyzers/Reliability/CachePrefixAnalyzer.php
@@ -10,7 +10,6 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
-use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
@@ -92,7 +91,6 @@ class CachePrefixAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($configFile), $prefixLine),
                     severity: $this->metadata()->severity,
                     recommendation: $this->getEmptyPrefixRecommendation(),
-                    code: FileParser::getCodeSnippet($configFile, $prefixLine),
                     metadata: [
                         'cache_driver' => $this->getDefaultDriver(),
                         'prefix' => $prefix,
@@ -110,7 +108,6 @@ class CachePrefixAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($configFile), $prefixLine),
                     severity: $this->metadata()->severity,
                     recommendation: $this->getGenericPrefixRecommendation($prefix),
-                    code: FileParser::getCodeSnippet($configFile, $prefixLine),
                     metadata: [
                         'cache_driver' => $this->getDefaultDriver(),
                         'prefix' => $prefix,

--- a/src/Analyzers/Reliability/CacheStatusAnalyzer.php
+++ b/src/Analyzers/Reliability/CacheStatusAnalyzer.php
@@ -11,7 +11,6 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
-use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Support\MessageHelper;
@@ -77,7 +76,6 @@ class CacheStatusAnalyzer extends AbstractFileAnalyzer
                         location: $configLocation,
                         severity: Severity::Critical,
                         recommendation: $this->getWriteReadFailureRecommendation(),
-                        code: $configLocation->line ? FileParser::getCodeSnippet($configLocation->file, $configLocation->line) : null,
                         metadata: [
                             'cache_driver' => $this->getCacheDriver(),
                             'expected' => $testValue,
@@ -100,7 +98,6 @@ class CacheStatusAnalyzer extends AbstractFileAnalyzer
                         location: $configLocation,
                         severity: Severity::Medium,
                         recommendation: $this->getEphemeralDriverRecommendation($driver),
-                        code: $configLocation->line ? FileParser::getCodeSnippet($configLocation->file, $configLocation->line) : null,
                         metadata: [
                             'cache_driver' => $driver,
                             'environment' => $this->getEnvironment(),
@@ -121,7 +118,6 @@ class CacheStatusAnalyzer extends AbstractFileAnalyzer
                     location: $configLocation,
                     severity: Severity::Critical,
                     recommendation: $this->getConnectionFailureRecommendation($e),
-                    code: $configLocation->line ? FileParser::getCodeSnippet($configLocation->file, $configLocation->line) : null,
                     metadata: [
                         'cache_driver' => $this->getCacheDriver(),
                         'exception' => get_class($e),

--- a/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
+++ b/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
@@ -80,7 +80,6 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($composerJsonPath)),
                     severity: $this->metadata()->severity,
                     recommendation: 'Run "composer validate" to see full details and resolve the reported issues. Ensure version constraints and schema match Composer expectations.',
-                    code: null,
                     metadata: ['composer_output' => trim($result->output)],
                 )]
             );
@@ -120,7 +119,6 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($composerJsonPath)),
                     severity: $this->metadata()->severity,
                     recommendation: 'Fix the JSON syntax errors in composer.json. Use a JSON validator or run "composer validate" to see specific errors. Common issues: missing commas, trailing commas, unescaped quotes.',
-                    code: null,
                     metadata: [
                         'json_error' => json_last_error_msg(),
                     ]
@@ -138,7 +136,6 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($composerJsonPath)),
                     severity: $this->metadata()->severity,
                     recommendation: 'composer.json must be a valid JSON object. Ensure the root element is an object (wrapped in curly braces {}), not an array (square brackets []).',
-                    code: null,
                     metadata: []
                 )]
             );

--- a/src/Analyzers/Reliability/DatabaseStatusAnalyzer.php
+++ b/src/Analyzers/Reliability/DatabaseStatusAnalyzer.php
@@ -10,7 +10,6 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
-use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Support\DatabaseConnectionChecker;
@@ -75,7 +74,6 @@ class DatabaseStatusAnalyzer extends AbstractFileAnalyzer
                     location: $configLocation,
                     severity: $severity,
                     recommendation: $this->buildRecommendation($connectionName, $result),
-                    code: $configLocation->line ? FileParser::getCodeSnippet($configLocation->file, $configLocation->line) : null,
                     metadata: [
                         'connection' => $connectionName,
                         'driver' => $this->getConnectionDriver($connectionName),

--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -272,7 +272,6 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
             location: new Location($this->getRelativePath($locationPath)),
             severity: $this->metadata()->severity,
             recommendation: $this->buildRecommendation($formattedMissing, $formattedNonWritable),
-            code: null,
             metadata: [
                 'missing_directories' => $formattedMissing,
                 'non_writable_directories' => $formattedNonWritable,
@@ -534,7 +533,6 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
             location: new Location($this->getRelativePath($locationPath)),
             severity: $this->metadata()->severity,
             recommendation: $this->buildSymlinkRecommendation($formattedSymlinks),
-            code: null,
             metadata: [
                 'broken_symlinks' => $formattedSymlinks,
                 'broken_symlink_count' => count($brokenSymlinks),

--- a/src/Analyzers/Reliability/EnvExampleAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvExampleAnalyzer.php
@@ -96,10 +96,10 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
                 recommendation: $this->buildUndocumentedVariablesRecommendation($undocumentedVars),
                 column: null,
                 contextLines: null,
-                code: 'undocumented-variables',
                 metadata: [
                     'undocumented_count' => count($undocumentedVars),
                     'undocumented_variables' => array_keys($undocumentedVars),
+                    'code' => 'undocumented-variables',
                 ]
             )]
         );

--- a/src/Analyzers/Reliability/EnvFileAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvFileAnalyzer.php
@@ -65,12 +65,12 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
                     lineNumber: null,
                     severity: $this->metadata()->severity,
                     recommendation: sprintf('Fix the broken symlink. Target: %s', $target ?: 'unknown'),
-                    code: 'broken-symlink',
                     metadata: [
                         'env_path' => $envPath,
                         'is_symlink' => true,
                         'symlink_target' => $target ?: null,
                         'target_exists' => false,
+                        'code' => 'broken-symlink',
                     ]
                 )]
             );
@@ -91,10 +91,10 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
                     lineNumber: null,
                     severity: $this->metadata()->severity,
                     recommendation: 'Fix file permissions to make .env readable. Run: chmod 600 .env',
-                    code: 'not-readable',
                     metadata: [
                         'env_path' => $envPath,
                         'is_readable' => false,
+                        'code' => 'not-readable',
                     ]
                 )]
             );
@@ -111,10 +111,10 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
                     lineNumber: null,
                     severity: $this->metadata()->severity,
                     recommendation: 'Add environment variables to your .env file. At minimum, configure: APP_KEY, APP_ENV, APP_DEBUG, DB_CONNECTION',
-                    code: 'empty-file',
                     metadata: [
                         'env_path' => $envPath,
                         'is_empty' => true,
+                        'code' => 'empty-file',
                     ]
                 )]
             );
@@ -139,10 +139,10 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
                 lineNumber: null,
                 severity: Severity::Critical,
                 recommendation: $this->buildRecommendation($envExampleExists),
-                code: 'missing-file',
                 metadata: [
                     'env_path' => $envPath,
                     'env_example_exists' => $envExampleExists,
+                    'code' => 'missing-file',
                 ]
             )]
         );

--- a/src/Analyzers/Reliability/EnvVariableAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvVariableAnalyzer.php
@@ -70,7 +70,7 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($envPath)),
                     severity: Severity::Critical,
                     recommendation: $this->buildMissingEnvFileRecommendation(),
-                    code: 'missing-env',
+                    metadata: ['code' => 'missing-env'],
                 )]
             );
         }
@@ -92,8 +92,7 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
                         "The .env.example file could not be parsed. Error: %s\n\nEnsure the file is readable and properly formatted.",
                         $exampleResult['error']
                     ),
-                    code: 'parse-error-example',
-                    metadata: ['error' => $exampleResult['error']]
+                    metadata: ['error' => $exampleResult['error'], 'code' => 'parse-error-example']
                 )]
             );
         }
@@ -109,8 +108,7 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
                         "The .env file could not be parsed. Error: %s\n\nEnsure the file is readable and properly formatted.",
                         $actualResult['error']
                     ),
-                    code: 'parse-error-env',
-                    metadata: ['error' => $actualResult['error']]
+                    metadata: ['error' => $actualResult['error'], 'code' => 'parse-error-env']
                 )]
             );
         }
@@ -154,10 +152,10 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($envPath)),
                     severity: Severity::Low,
                     recommendation: $this->buildCommentedVariablesRecommendation($commentedOnlyVars),
-                    code: 'commented-variables',
                     metadata: [
                         'commented_count' => count($commentedOnlyVars),
                         'commented_variables' => array_keys($commentedOnlyVars),
+                        'code' => 'commented-variables',
                     ]
                 )]
             );
@@ -172,10 +170,10 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($envPath)),
                 severity: Severity::High,
                 recommendation: $this->buildMissingVariablesRecommendation($missingVars),
-                code: 'missing-variables',
                 metadata: [
                     'missing_count' => count($missingVars),
                     'missing_variables' => array_keys($missingVars),
+                    'code' => 'missing-variables',
                 ]
             );
         }
@@ -186,10 +184,10 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($envPath)),
                 severity: Severity::Low,
                 recommendation: $this->buildCommentedVariablesRecommendation($commentedOnlyVars),
-                code: 'commented-variables',
                 metadata: [
                     'commented_count' => count($commentedOnlyVars),
                     'commented_variables' => array_keys($commentedOnlyVars),
+                    'code' => 'commented-variables',
                 ]
             );
         }

--- a/src/Analyzers/Reliability/UpToDateMigrationsAnalyzer.php
+++ b/src/Analyzers/Reliability/UpToDateMigrationsAnalyzer.php
@@ -85,10 +85,10 @@ class UpToDateMigrationsAnalyzer extends AbstractFileAnalyzer
                         lineNumber: null,
                         severity: $this->metadata()->severity,
                         recommendation: 'This appears to be a new installation. Run "php artisan migrate:install" to create the migrations table, then run "php artisan migrate" to execute all migrations.',
-                        code: 'migrations-table-missing',
                         metadata: [
                             'table' => 'migrations',
                             'exists' => false,
+                            'code' => 'migrations-table-missing',
                         ]
                     )]
                 );
@@ -125,10 +125,10 @@ class UpToDateMigrationsAnalyzer extends AbstractFileAnalyzer
                     lineNumber: null,
                     severity: Severity::High,
                     recommendation: $this->getPendingMigrationsRecommendation($pendingMigrations),
-                    code: 'pending-migrations',
                     metadata: [
                         'pending_count' => count($pendingMigrations),
                         'pending_migrations' => $pendingMigrations,
+                        'code' => 'pending-migrations',
                     ]
                 )]
             );
@@ -145,11 +145,11 @@ class UpToDateMigrationsAnalyzer extends AbstractFileAnalyzer
                         lineNumber: null,
                         severity: $this->metadata()->severity,
                         recommendation: $this->getDatabaseErrorRecommendation($e),
-                        code: 'database-error',
                         metadata: [
                             'exception' => get_class($e),
                             'error' => $e->getMessage(),
                             'error_type' => 'database_connection',
+                            'code' => 'database-error',
                         ]
                     )]
                 )
@@ -161,10 +161,10 @@ class UpToDateMigrationsAnalyzer extends AbstractFileAnalyzer
                         lineNumber: null,
                         severity: $this->metadata()->severity,
                         recommendation: 'Ensure the database connection is working and the migrations table exists. If this is a new installation, run "php artisan migrate:install" followed by "php artisan migrate". Error: '.$e->getMessage(),
-                        code: 'migration-check-error',
                         metadata: [
                             'exception' => get_class($e),
                             'error' => $e->getMessage(),
+                            'code' => 'migration-check-error',
                         ]
                     )]
                 );

--- a/src/Analyzers/Security/CookieSecurityAnalyzer.php
+++ b/src/Analyzers/Security/CookieSecurityAnalyzer.php
@@ -113,11 +113,11 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
                     lineNumber: $entry['line'],
                     severity: Severity::Critical,
                     recommendation: 'Set "http_only" => true in config/session.php to protect against XSS attacks',
-                    code: 'http_only',
                     metadata: [
                         'file' => 'session.php',
                         'config_key' => 'http_only',
                         'current_value' => $this->configValueToString($effectiveValue),
+                        'code' => 'http_only',
                     ]
                 );
             }
@@ -135,11 +135,11 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
                     lineNumber: $entry['line'],
                     severity: Severity::High,
                     recommendation: 'Set "secure" => env("SESSION_SECURE_COOKIE", true) for HTTPS-only applications',
-                    code: 'secure',
                     metadata: [
                         'file' => 'session.php',
                         'config_key' => 'secure',
                         'current_value' => $this->configValueToString($effectiveValue),
+                        'code' => 'secure',
                     ]
                 );
             }
@@ -164,11 +164,11 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
                         lineNumber: $entry['line'],
                         severity: Severity::Medium,
                         recommendation: 'Use "same_site" => "lax" or "strict" to protect against CSRF attacks',
-                        code: 'same_site',
                         metadata: [
                             'file' => 'session.php',
                             'config_key' => 'same_site',
                             'current_value' => $this->configValueToString($effectiveValue),
+                            'code' => 'same_site',
                         ]
                     );
                 }
@@ -212,11 +212,11 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
                 lineNumber: null,
                 severity: Severity::Critical,
                 recommendation: 'Add \\App\\Http\\Middleware\\EncryptCookies::class to $middleware array in app/Http/Kernel.php',
-                code: 'EncryptCookies',
                 metadata: [
                     'file' => 'Kernel.php',
                     'middleware' => 'EncryptCookies',
                     'status' => 'missing',
+                    'code' => 'EncryptCookies',
                 ]
             );
         }
@@ -236,12 +236,12 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
                     lineNumber: $lineNumber + 1,
                     severity: Severity::Critical,
                     recommendation: 'Uncomment the EncryptCookies middleware to enable cookie encryption',
-                    code: 'EncryptCookies',
                     metadata: [
                         'file' => 'Kernel.php',
                         'middleware' => 'EncryptCookies',
                         'status' => 'commented',
                         'line' => $lineNumber + 1,
+                        'code' => 'EncryptCookies',
                     ]
                 );
             }
@@ -344,12 +344,12 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
                         lineNumber: null,
                         severity: Severity::Critical,
                         recommendation: 'Register EncryptCookies middleware globally in app/Http/Kernel.php (Laravel 9/10) or bootstrap/app.php (Laravel 11+) to enable cookie encryption',
-                        code: 'EncryptCookies',
                         metadata: [
                             'file' => file_exists($kernelFile) ? 'Kernel.php' : 'bootstrap/app.php',
                             'middleware' => 'EncryptCookies',
                             'status' => 'missing',
                             'detection_method' => 'runtime',
+                            'code' => 'EncryptCookies',
                         ]
                     );
                 }
@@ -427,12 +427,12 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
                 lineNumber: null,
                 severity: Severity::High,
                 recommendation: 'Add EncryptCookies middleware using ->withMiddleware() in bootstrap/app.php to enable cookie encryption',
-                code: 'EncryptCookies',
                 metadata: [
                     'file' => 'bootstrap/app.php',
                     'laravel_version' => '11+',
                     'middleware' => 'EncryptCookies',
                     'detection_method' => 'file_analysis',
+                    'code' => 'EncryptCookies',
                 ]
             );
         }

--- a/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
+++ b/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
@@ -240,11 +240,11 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
                             location: new Location($this->getRelativePath($envExample), $lineNumber + 1),
                             severity: Severity::High,
                             recommendation: 'Replace with placeholder value. .env.example should not contain real credentials',
-                            code: $key,
                             metadata: [
                                 'key' => $key,
                                 'value_length' => strlen($value),
                                 'file' => '.env.example',
+                                'code' => $key,
                             ]
                         );
                     }
@@ -277,10 +277,10 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($gitignorePath)),
                 severity: Severity::Critical,
                 recommendation: 'Add ".env" to .gitignore to prevent accidentally committing secrets to version control',
-                code: '.env',
                 metadata: [
                     'file' => '.gitignore',
                     'missing_pattern' => '.env',
+                    'code' => '.env',
                 ]
             );
         }
@@ -334,10 +334,10 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($envPath)),
                 severity: Severity::Critical,
                 recommendation: 'Remove .env from git: "git rm --cached .env" and ensure it\'s in .gitignore',
-                code: 'git-tracked',
                 metadata: [
                     'file' => '.env',
                     'git_tracked' => true,
+                    'code' => 'git-tracked',
                 ]
             );
         }
@@ -368,11 +368,11 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($envPath)),
                 severity: Severity::Critical,
                 recommendation: 'Restrict .env permissions: chmod 600 .env',
-                code: 'permissions',
                 metadata: [
                     'permissions' => $octal,
                     'world_readable' => (bool) ($perms & self::WORLD_READABLE),
                     'world_writable' => (bool) ($perms & self::WORLD_WRITABLE),
+                    'code' => 'permissions',
                 ]
             );
 
@@ -386,11 +386,11 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($envPath)),
                 severity: Severity::Medium,
                 recommendation: 'Consider restricting .env permissions: chmod 600 .env (readable only by owner)',
-                code: 'permissions',
                 metadata: [
                     'permissions' => $octal,
                     'group_readable' => (bool) ($perms & self::GROUP_READABLE),
                     'group_writable' => (bool) ($perms & self::GROUP_WRITABLE),
+                    'code' => 'permissions',
                 ]
             );
         }

--- a/src/Analyzers/Security/FilePermissionsAnalyzer.php
+++ b/src/Analyzers/Security/FilePermissionsAnalyzer.php
@@ -200,7 +200,6 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
                     decoct($recommended),
                     $relativePath
                 ),
-                code: null,
                 metadata: [
                     'path' => $relativePath,
                     'permissions' => $permissions['octal'],
@@ -234,7 +233,6 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
                     decoct($recommended),
                     $relativePath
                 ),
-                code: null,
                 metadata: [
                     'path' => $relativePath,
                     'permissions' => $permissions['octal'],
@@ -264,7 +262,6 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
                     decoct($recommended),
                     $relativePath
                 ),
-                code: null,
                 metadata: [
                     'path' => $relativePath,
                     'permissions' => $permissions['octal'],
@@ -291,7 +288,6 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
                     decoct($recommended),
                     $relativePath
                 ),
-                code: null,
                 metadata: [
                     'path' => $relativePath,
                     'permissions' => $permissions['octal'],
@@ -319,7 +315,6 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
                     decoct($recommended),
                     $relativePath
                 ),
-                code: null,
                 metadata: [
                     'path' => $relativePath,
                     'permissions' => $permissions['octal'],

--- a/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
@@ -378,7 +378,6 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($packageLock)),
                     severity: $severity,
                     recommendation: 'Run "npm audit" to see details and "npm audit fix" to automatically fix vulnerabilities',
-                    code: null,
                     metadata: [
                         'total_vulnerabilities' => $total,
                         'issue_type' => 'summary',
@@ -445,7 +444,6 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
                         location: new Location($this->getRelativePath($yarnLock)),
                         severity: $severity,
                         recommendation: 'Run "yarn audit" to see details and upgrade vulnerable packages',
-                        code: null,
                         metadata: [
                             'total_vulnerabilities' => $total,
                             'issue_type' => 'summary',
@@ -467,7 +465,6 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
                         location: new Location($this->getRelativePath($yarnLock)),
                         severity: Severity::High,
                         recommendation: 'Run "yarn audit" to see details and upgrade vulnerable packages',
-                        code: null,
                         metadata: [
                             'total_vulnerabilities' => $total,
                             'issue_type' => 'summary',
@@ -608,7 +605,6 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
             location: new Location($this->getRelativePath($lockFile)),
             severity: $severity,
             recommendation: $recommendation,
-            code: null,
             metadata: $metadata
         );
     }

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -290,7 +290,6 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
                             location: new Location($this->getRelativePath($file), $lineNumber + 1),
                             severity: Severity::High,
                             recommendation: sprintf('Set HSTS max-age to at least %d (6 months) or 31536000 (1 year)', $minMaxAge),
-                            code: FileParser::getCodeSnippet($file, $lineNumber + 1),
                             metadata: [
                                 'issue_type' => 'weak_max_age',
                                 'max_age' => $maxAge,
@@ -308,7 +307,6 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
                         location: new Location($this->getRelativePath($file), $lineNumber + 1),
                         severity: Severity::Medium,
                         recommendation: 'Add "includeSubDomains" to HSTS header for complete subdomain protection',
-                        code: FileParser::getCodeSnippet($file, $lineNumber + 1),
                         metadata: [
                             'issue_type' => 'missing_directive',
                             'missing_directive' => 'includeSubDomains',
@@ -324,7 +322,6 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
                         location: new Location($this->getRelativePath($file), $lineNumber + 1),
                         severity: Severity::Low,
                         recommendation: 'Add "preload" to HSTS header and submit to https://hstspreload.org/ for browser preload list inclusion',
-                        code: FileParser::getCodeSnippet($file, $lineNumber + 1),
                         metadata: [
                             'issue_type' => 'missing_directive',
                             'missing_directive' => 'preload',
@@ -366,7 +363,6 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($sessionConfig), $entry['line']),
                     severity: Severity::High,
                     recommendation: 'Set "secure" => true in config/session.php for HTTPS-only applications',
-                    code: FileParser::getCodeSnippet($sessionConfig, $entry['line']),
                     metadata: [
                         'issue_type' => 'insecure_cookies',
                         'https_only' => true,

--- a/src/Analyzers/Security/LicenseAnalyzer.php
+++ b/src/Analyzers/Security/LicenseAnalyzer.php
@@ -179,7 +179,6 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
                         location: new Location($composerLock),
                         severity: Severity::Medium,
                         recommendation: sprintf('Investigate license for "%s" or contact the package maintainer', $packageName),
-                        code: null,
                         metadata: [
                             'package' => $packageName,
                             'issue_type' => 'missing_license',
@@ -250,7 +249,6 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
                         : ($isConjunctive
                             ? sprintf('Package "%s" has conjunctive license (AND) including GPL/AGPL - ALL licenses apply simultaneously. You must comply with GPL/AGPL terms. Consider finding an alternative package', $packageName)
                             : sprintf('GPL/AGPL licenses may require your application to be open-source. Review "%s" license implications or find an alternative package', $packageName)),
-                    code: null,
                     metadata: [
                         'package' => $packageName,
                         'licenses' => $licenses,
@@ -278,7 +276,6 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
                             $packageName,
                             $isConjunctive ? 'Note: This is a conjunctive license (AND) - ALL licenses apply simultaneously.' : ''
                         ),
-                        code: null,
                         metadata: [
                             'package' => $packageName,
                             'licenses' => $licenses,

--- a/src/Analyzers/Security/PHPIniAnalyzer.php
+++ b/src/Analyzers/Security/PHPIniAnalyzer.php
@@ -627,7 +627,6 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
             location: new Location($actualFile, $line),
             severity: $severity,
             recommendation: $recommendation,
-            code: FileParser::getCodeSnippet($actualFile, $line),
             metadata: $metadata
         );
     }

--- a/src/Analyzers/Security/StableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/StableDependencyAnalyzer.php
@@ -87,7 +87,6 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
                         location: new Location($this->getRelativePath($filePath)),
                         severity: Severity::Low,
                         recommendation: 'Run "composer update --prefer-stable" and ensure all dependencies resolve to stable releases.',
-                        code: $isLockFile ? null : FileParser::getCodeSnippet($filePath, 1),
                         metadata: [
                             'composer_version_check' => 'update --dry-run --prefer-stable',
                         ]
@@ -160,7 +159,6 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($composerJson), 1),
                     severity: Severity::Low,
                     recommendation: 'Explicitly set "minimum-stability": "stable" in composer.json to document your stability requirements',
-                    code: FileParser::getCodeSnippet($composerJson, 1),
                     metadata: [
                         'minimum_stability' => 'implicit_default',
                         'composer_default' => 'stable',
@@ -179,7 +177,6 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($composerJson), $line),
                 severity: Severity::Medium,
                 recommendation: 'Set "minimum-stability": "stable" in composer.json to prefer stable package versions',
-                code: FileParser::getCodeSnippet($composerJson, $line),
                 metadata: [
                     'minimum_stability' => $minimumStability,
                     'issue_type' => 'unstable_minimum_stability',
@@ -196,7 +193,6 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($composerJson), $line),
                 severity: Severity::Low,
                 recommendation: 'Set "prefer-stable": true in composer.json to prefer stable versions when possible',
-                code: FileParser::getCodeSnippet($composerJson, $line),
                 metadata: []
             );
         }
@@ -298,7 +294,6 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($composerJson), $line),
                     severity: $severity,
                     recommendation: sprintf('Update "%s" to use a stable version constraint', $package),
-                    code: FileParser::getCodeSnippet($composerJson, $line),
                     metadata: ['package' => $package, 'version' => $version, 'section' => $section]
                 );
 
@@ -314,7 +309,6 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
                     location: new Location($this->getRelativePath($composerJson), $line),
                     severity: $severity,
                     recommendation: sprintf('Remove @%s flag and use stable version for "%s"', $stabilityFlag, $package),
-                    code: FileParser::getCodeSnippet($composerJson, $line),
                     metadata: ['package' => $package, 'version' => $version, 'stability' => $stabilityFlag, 'section' => $section]
                 );
             }
@@ -374,7 +368,6 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
                     $examples,
                     $count > 3 ? sprintf(' and %d more', $count - 3) : ''
                 ),
-                code: null,
                 metadata: [
                     'count' => $count,
                     'examples' => array_slice($unstablePackages, 0, 3),

--- a/src/Analyzers/Security/UpToDateDependencyAnalyzer.php
+++ b/src/Analyzers/Security/UpToDateDependencyAnalyzer.php
@@ -129,7 +129,6 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
                     location: new Location($this->getRelativePath($composerLockPath)),
                     severity: Severity::Medium,
                     recommendation: $this->getBothDepsRecommendation(),
-                    code: null,
                     metadata: [
                         'scope' => 'unknown',
                         'composer_version_check' => 'install --dry-run',
@@ -152,7 +151,6 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
                         location: new Location($this->getRelativePath($composerLockPath)),
                         severity: Severity::Medium,
                         recommendation: $this->getBothDepsRecommendation(),
-                        code: null,
                         metadata: [
                             'scope' => 'production and dev',
                             'composer_version_check' => 'install --dry-run',
@@ -167,7 +165,6 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
                         location: new Location($this->getRelativePath($composerLockPath)),
                         severity: Severity::Medium,
                         recommendation: $this->getProductionDepsRecommendation(),
-                        code: null,
                         metadata: [
                             'scope' => 'production',
                             'composer_version_check' => 'install --dry-run',
@@ -181,7 +178,6 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
                         location: new Location($this->getRelativePath($composerLockPath)),
                         severity: Severity::Low,
                         recommendation: $this->getDevDepsRecommendation(),
-                        code: null,
                         metadata: [
                             'scope' => 'dev',
                             'composer_version_check' => 'install --dry-run',

--- a/src/Analyzers/Security/VulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/VulnerableDependencyAnalyzer.php
@@ -148,7 +148,6 @@ class VulnerableDependencyAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($composerLock)),
                 severity: Severity::Critical,
                 recommendation: $recommendation,
-                code: null,
                 metadata: [
                     'package' => $package,
                     'version' => $version,
@@ -207,7 +206,6 @@ class VulnerableDependencyAnalyzer extends AbstractFileAnalyzer
                 location: new Location($this->getRelativePath($composerLock)),
                 severity: Severity::Medium,
                 recommendation: $recommendation,
-                code: null,
                 metadata: [
                     'package' => $packageName,
                     'replacement' => $replacement,

--- a/src/Concerns/ParsesPHPStanAnalysis.php
+++ b/src/Concerns/ParsesPHPStanAnalysis.php
@@ -36,10 +36,10 @@ trait ParsesPHPStanAnalysis
                 lineNumber: $trace['line'],
                 severity: Severity::High,
                 recommendation: $this->getRecommendationFromMessage($trace['message']),
-                code: 'phpstan',
                 metadata: [
                     'phpstan_message' => $trace['message'],
                     'detection_method' => 'phpstan',
+                    'code' => 'phpstan',
                 ]
             );
         }
@@ -60,10 +60,10 @@ trait ParsesPHPStanAnalysis
                 lineNumber: $trace['line'],
                 severity: Severity::High,
                 recommendation: $this->getRecommendationFromMessage($trace['message']),
-                code: 'phpstan',
                 metadata: [
                     'phpstan_message' => $trace['message'],
                     'detection_method' => 'phpstan',
+                    'code' => 'phpstan',
                 ]
             );
         }
@@ -92,10 +92,10 @@ trait ParsesPHPStanAnalysis
                 lineNumber: $trace['line'],
                 severity: Severity::High,
                 recommendation: $this->getRecommendationFromMessage($trace['message']),
-                code: 'phpstan',
                 metadata: [
                     'phpstan_message' => $trace['message'],
                     'detection_method' => 'phpstan',
+                    'code' => 'phpstan',
                 ]
             );
         }

--- a/src/Concerns/ParsesPHPStanResults.php
+++ b/src/Concerns/ParsesPHPStanResults.php
@@ -58,11 +58,11 @@ trait ParsesPHPStanResults
                 lineNumber: $line,
                 severity: $severity,
                 recommendation: $recommendationCallback($message),
-                code: 'phpstan',
                 metadata: [
                     'phpstan_message' => $message,
                     'file' => $file,
                     'line' => $line,
+                    'code' => 'phpstan',
                 ]
             );
         }
@@ -100,12 +100,11 @@ trait ParsesPHPStanResults
     abstract protected function createIssueWithSnippet(
         string $message,
         string $filePath,
-        int $lineNumber,
+        ?int $lineNumber,
         Severity $severity,
         string $recommendation,
         ?int $column = null,
         ?int $contextLines = null,
-        ?string $code = null,
         array $metadata = []
     ): \ShieldCI\AnalyzersCore\ValueObjects\Issue;
 }

--- a/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
@@ -699,7 +699,7 @@ BLADE;
 
         $this->assertFailed($result);
         $issues = $result->getIssues();
-        $this->assertEquals('blade-has-db-query', $issues[0]->code);
+        $this->assertEquals('blade-has-db-query', $issues[0]->metadata['code']);
     }
 
     public function test_prevents_duplicate_issues_on_same_line(): void
@@ -2256,7 +2256,7 @@ BLADE;
         $issues = $result->getIssues();
         $nestedIssue = null;
         foreach ($issues as $issue) {
-            if ($issue->code === 'blade-nested-foreach') {
+            if (($issue->metadata['code'] ?? null) === 'blade-nested-foreach') {
                 $nestedIssue = $issue;
                 break;
             }
@@ -2442,7 +2442,7 @@ BLADE;
         $issues = $result->getIssues();
         $computeIssue = null;
         foreach ($issues as $issue) {
-            if ($issue->code === 'blade-expensive-computation') {
+            if (($issue->metadata['code'] ?? null) === 'blade-expensive-computation') {
                 $computeIssue = $issue;
                 break;
             }
@@ -2472,7 +2472,7 @@ BLADE;
 
         $nestedIssue = null;
         foreach ($result->getIssues() as $issue) {
-            if ($issue->code === 'blade-nested-foreach') {
+            if (($issue->metadata['code'] ?? null) === 'blade-nested-foreach') {
                 $nestedIssue = $issue;
                 break;
             }

--- a/tests/Unit/Analyzers/BestPractices/LogicInRoutesAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/LogicInRoutesAnalyzerTest.php
@@ -559,7 +559,7 @@ PHP;
 
         $this->assertFailed($result);
         $issues = $result->getIssues();
-        $this->assertEquals('route-has-raw-queries', $issues[0]->code);
+        $this->assertEquals('route-has-raw-queries', $issues[0]->metadata['code']);
     }
 
     public function test_issue_code_for_business_logic(): void
@@ -589,7 +589,7 @@ PHP;
 
         $this->assertFailed($result);
         $issues = $result->getIssues();
-        $this->assertEquals('route-has-business-logic', $issues[0]->code);
+        $this->assertEquals('route-has-business-logic', $issues[0]->metadata['code']);
     }
 
     public function test_issue_code_for_long_closure(): void
@@ -620,7 +620,7 @@ PHP;
 
         $this->assertWarning($result);
         $issues = $result->getIssues();
-        $this->assertEquals('route-closure-too-long', $issues[0]->code);
+        $this->assertEquals('route-closure-too-long', $issues[0]->metadata['code']);
     }
 
     public function test_false_positive_config_get_not_flagged_as_query(): void
@@ -1751,7 +1751,7 @@ PHP;
 
         $this->assertFailed($result);
         $issues = $result->getIssues();
-        $this->assertEquals('route-has-db-writes', $issues[0]->code);
+        $this->assertEquals('route-has-db-writes', $issues[0]->metadata['code']);
     }
 
     public function test_issue_code_for_complex_queries(): void
@@ -1777,7 +1777,7 @@ PHP;
 
         $this->assertWarning($result);
         $issues = $result->getIssues();
-        $this->assertEquals('route-has-complex-queries', $issues[0]->code);
+        $this->assertEquals('route-has-complex-queries', $issues[0]->metadata['code']);
     }
 
     public function test_allows_simple_first_by_default(): void

--- a/tests/Unit/Analyzers/Reliability/EnvVariableAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/EnvVariableAnalyzerTest.php
@@ -688,7 +688,7 @@ APP_NAME=MyApp';
 
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
-        $this->assertSame('parse-error-example', $issues[0]->code);
+        $this->assertSame('parse-error-example', $issues[0]->metadata['code']);
         $this->assertArrayHasKey('error', $issues[0]->metadata);
 
         $error = $issues[0]->metadata['error'];
@@ -720,7 +720,7 @@ APP_NAME=MyApp';
 
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
-        $this->assertSame('parse-error-env', $issues[0]->code);
+        $this->assertSame('parse-error-env', $issues[0]->metadata['code']);
         $this->assertArrayHasKey('error', $issues[0]->metadata);
     }
 
@@ -771,8 +771,8 @@ REQUIRED_VAR=',
         $this->assertFailed($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
-        $this->assertSame('missing-variables', $issues[0]->code);
-        $this->assertNotSame('parse-error-env', $issues[0]->code);
+        $this->assertSame('missing-variables', $issues[0]->metadata['code']);
+        $this->assertNotSame('parse-error-env', $issues[0]->metadata['code']);
     }
 
     public function test_is_not_run_in_ci_mode(): void

--- a/tests/Unit/Analyzers/Reliability/MaintenanceModeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/MaintenanceModeAnalyzerTest.php
@@ -167,8 +167,8 @@ class MaintenanceModeAnalyzerTest extends AnalyzerTestCase
         $issues = $result->getIssues();
         $issue = $issues[0];
 
-        // Code should be null since maintenance file is not PHP code
-        $this->assertNull($issue->code);
+        // No issue type code for maintenance mode issues
+        $this->assertArrayNotHasKey('code', $issue->metadata);
     }
 
     #[Test]

--- a/tests/Unit/Analyzers/Reliability/UpToDateMigrationsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/UpToDateMigrationsAnalyzerTest.php
@@ -274,7 +274,7 @@ OUTPUT;
         // verify the message is correct
         if ($result->getStatus() === \ShieldCI\AnalyzersCore\Enums\Status::Failed) {
             $issues = $result->getIssues();
-            if (! empty($issues) && isset($issues[0]->code) && $issues[0]->code === 'migrations-table-missing') {
+            if (! empty($issues) && isset($issues[0]->metadata['code']) && $issues[0]->metadata['code'] === 'migrations-table-missing') {
                 $this->assertStringContainsString('migrations table', strtolower($issues[0]->message));
                 $this->assertStringContainsString('migrate:install', $issues[0]->recommendation);
             }

--- a/tests/Unit/Concerns/ParsesPHPStanAnalysisTest.php
+++ b/tests/Unit/Concerns/ParsesPHPStanAnalysisTest.php
@@ -182,12 +182,11 @@ class ParsesPHPStanAnalysisTest extends TestCase
             protected function createIssueWithSnippet(
                 string $message,
                 string $filePath,
-                int $lineNumber,
+                ?int $lineNumber,
                 Severity $severity,
                 string $recommendation,
                 ?int $column = null,
                 ?int $contextLines = null,
-                ?string $code = null,
                 array $metadata = []
             ): Issue {
                 return new Issue(
@@ -195,7 +194,6 @@ class ParsesPHPStanAnalysisTest extends TestCase
                     location: new Location($filePath, $lineNumber),
                     severity: $severity,
                     recommendation: $recommendation,
-                    code: $code,
                     metadata: $metadata,
                 );
             }

--- a/tests/Unit/Concerns/ParsesPHPStanResultsTest.php
+++ b/tests/Unit/Concerns/ParsesPHPStanResultsTest.php
@@ -216,20 +216,18 @@ class ParsesPHPStanResultsTest extends TestCase
             protected function createIssueWithSnippet(
                 string $message,
                 string $filePath,
-                int $lineNumber,
+                ?int $lineNumber,
                 Severity $severity,
                 string $recommendation,
                 ?int $column = null,
                 ?int $contextLines = null,
-                ?string $code = null,
-                array $metadata = []
+                array $metadata = [],
             ): Issue {
                 return new Issue(
                     message: $message,
                     location: new Location($filePath, $lineNumber),
                     severity: $severity,
                     recommendation: $recommendation,
-                    code: $code,
                     metadata: $metadata,
                 );
             }


### PR DESCRIPTION
## Summary

- Removes all `code:` named argument usages from `createIssue()` and `createIssueWithSnippet()` calls across 37 analyzers, following the `analyzers-core` update that dropped the legacy `?string $code` property from the `Issue` value object
- Issue-type string identifiers (e.g. `'missing-env'`, `'http_only'`, `'blade-has-db-query'`, `'phpstan'`) are moved into `metadata['code']` so consumers can still distinguish issue subtypes
- `ParsesPHPStanResults` and `ParsesPHPStanAnalysis` abstract method signatures updated to remove the `$code` parameter
- All affected tests updated to read `$issue->metadata['code']` instead of `$issue->code`