### PR TITLE
fix: suppress false positive in ConfigCachingAnalyzer on Vapor/serverless

### DIFF
--- a/src/Analyzers/Performance/ConfigCachingAnalyzer.php
+++ b/src/Analyzers/Performance/ConfigCachingAnalyzer.php
@@ -13,6 +13,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Analyzes configuration caching setup using Laravel's proper API.
@@ -26,6 +27,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class ConfigCachingAnalyzer extends AbstractAnalyzer
 {
+    use DetectsDeploymentPlatform;
+
     /**
      * Config caching checks are not applicable in CI environments.
      */
@@ -98,7 +101,8 @@ class ConfigCachingAnalyzer extends AbstractAnalyzer
         $issues = [];
 
         // Config cached in local/development environment - not recommended
-        if ($this->isDevelopmentEnvironment($environment) && $configIsCached) {
+        // Skip this check on Vapor/serverless: config is always cached by the platform regardless of environment
+        if ($this->isDevelopmentEnvironment($environment) && $configIsCached && ! $this->isVaporOrServerless()) {
             $configPath = $this->getCachedConfigPath();
 
             $issues[] = $this->createIssue(

--- a/tests/Unit/Analyzers/Performance/ConfigCachingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/ConfigCachingAnalyzerTest.php
@@ -519,6 +519,28 @@ class ConfigCachingAnalyzerTest extends AnalyzerTestCase
         $this->assertEquals('bootstrap/cache/config.php', $issues[0]->metadata['detected_via']);
     }
 
+    public function test_passes_when_config_cached_in_local_on_vapor(): void
+    {
+        /** @var ConfigCachingAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer(environment: 'local', configIsCached: true);
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_when_config_cached_in_development_on_vapor(): void
+    {
+        /** @var ConfigCachingAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer(environment: 'development', configIsCached: true);
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();


### PR DESCRIPTION
## Summary

- On Vapor, config is always cached by the platform during bootstrap (regardless of `APP_ENV`), so the analyzer was incorrectly flagging cached config in dev/local environments as an issue
- Replaced a hand-rolled `isVaporEnvironment()` (`$_ENV`/`$_SERVER` check) with the existing `DetectsDeploymentPlatform` trait, consistent with how `EnvFileSecurityAnalyzer` and `EnvFileAnalyzer` handle the same concern
- Updated tests to use `setDeploymentPlatform('vapor')` instead of mutating superglobals