### PR TITLE
fix: resolve PHPIniAnalyzer false positive when boolean setting is explicitly Off

### DIFF
--- a/src/Analyzers/Security/PHPIniAnalyzer.php
+++ b/src/Analyzers/Security/PHPIniAnalyzer.php
@@ -176,6 +176,46 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
 
             // Handle ambiguous empty values
             if ($isAmbiguous) {
+                // ini_get() returns '' for both explicit Off and genuinely empty values.
+                // Check the source file to distinguish between the two.
+                $source = $this->findSettingSource($setting);
+                if ($source !== null) {
+                    $rawFileValue = $this->readSettingValueFromFile($source['file'], $setting);
+                    if ($rawFileValue !== false && $rawFileValue !== '') {
+                        // The file has an explicit value (e.g. 'Off', 'No', 'False') — not ambiguous.
+                        $normalizedFile = strtolower($rawFileValue);
+                        $isEnabled = in_array($normalizedFile, ['1', 'on', 'yes', 'true'], true);
+                        $isDisabled = in_array($normalizedFile, ['0', 'off', 'no', 'false'], true);
+
+                        if ($isEnabled || $isDisabled) {
+                            $actual = $isEnabled ? 'enabled' : 'disabled';
+                            if ($expectedValue && ! $isEnabled) {
+                                $issues[] = $this->createPhpIniIssueWithValue(
+                                    phpIniPath: $phpIniPath,
+                                    setting: $setting,
+                                    expectedValue: true,
+                                    message: sprintf('PHP ini setting "%s" should be enabled but is %s', $setting, $actual),
+                                    severity: $this->getSeverityForSetting($setting),
+                                    metadata: ['setting' => $setting, 'current_value' => $rawFileValue, 'expected_value' => 'enabled'],
+                                );
+                            } elseif (! $expectedValue && $isEnabled) {
+                                $issues[] = $this->createPhpIniIssueWithValue(
+                                    phpIniPath: $phpIniPath,
+                                    setting: $setting,
+                                    expectedValue: false,
+                                    message: sprintf('PHP ini setting "%s" should be disabled but is %s', $setting, $actual),
+                                    severity: $this->getSeverityForSetting($setting),
+                                    metadata: ['setting' => $setting, 'current_value' => $rawFileValue, 'expected_value' => 'disabled'],
+                                );
+                            }
+
+                            // else: value matches expectation, no issue
+                            continue;
+                        }
+                    }
+                }
+
+                // Genuinely ambiguous (file has empty value or setting not found in any file)
                 $issues[] = $this->createPhpIniIssueWithValue(
                     phpIniPath: $phpIniPath,
                     setting: $setting,
@@ -544,6 +584,33 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
     private function settingExistsInFile(string $file, string $setting): bool
     {
         return $this->findSettingInFile($file, $setting)['found'];
+    }
+
+    /**
+     * Read the raw text value of a setting from an ini file.
+     *
+     * Returns the trimmed value string (e.g. 'Off', '1', '16'), empty string if
+     * the setting is present but has no value, or false if not found (uncommented).
+     */
+    private function readSettingValueFromFile(string $file, string $setting): string|false
+    {
+        $lines = $this->getPhpIniLines($file);
+
+        foreach ($lines as $line) {
+            if (! is_string($line)) {
+                continue;
+            }
+
+            $lineWithoutComments = preg_replace('/[;#].*$/', '', $line);
+            $lineWithoutComments = preg_replace('/\/\/.*$/', '', $lineWithoutComments ?? '');
+
+            $pattern = '/^\s*'.preg_quote($setting, '/').'\s*=\s*(.*)$/i';
+            if (preg_match($pattern, $lineWithoutComments ?? '', $matches) === 1) {
+                return trim($matches[1]);
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/PHPIniAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/PHPIniAnalyzerTest.php
@@ -568,6 +568,38 @@ class PHPIniAnalyzerTest extends AnalyzerTestCase
         $this->assertEquals('', $allowUrlFopenIssue->metadata['current_value']);
     }
 
+    public function test_it_does_not_flag_explicit_off_as_ambiguous(): void
+    {
+        $iniPath = $this->createPhpIniFixture([
+            'allow_url_fopen = Off',
+            'expose_php = Off',
+            'allow_url_include = Off',
+            'display_errors = Off',
+            'display_startup_errors = Off',
+            'log_errors = On',
+            'ignore_repeated_errors = Off',
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setPhpIniPath($iniPath);
+        $analyzer->setBasePath(dirname($iniPath));
+        // Simulate what PHP actually returns for boolean Off settings
+        $analyzer->setIniValues([
+            'allow_url_fopen' => '',
+            'allow_url_include' => '',
+            'expose_php' => '',
+            'display_errors' => '',
+            'display_startup_errors' => '',
+            'log_errors' => '1',
+            'ignore_repeated_errors' => '',
+        ]);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertIssueCount(0, $result);
+    }
+
     public function test_it_distinguishes_between_zero_and_empty(): void
     {
         $iniPath = $this->createPhpIniFixture([


### PR DESCRIPTION
## Summary

- PHP's `ini_get()` returns `''` for boolean directives set to `Off`/`No`/`False`/`0`, which was incorrectly classified as an ambiguous empty value and raised a false positive
- When `$isAmbiguous` is triggered, `PHPIniAnalyzer` now reads the raw text value from the source ini file via a new `readSettingValueFromFile()` method; if the file contains an explicit boolean keyword the setting is classified correctly (enabled/disabled) rather than flagged
- Genuinely empty values (e.g. `allow_url_fopen = ` with nothing after `=`) still trigger the ambiguous warning as before
- Adds regression test `test_it_does_not_flag_explicit_off_as_ambiguous` covering the Vapor/serverless scenario where `allow_url_fopen = Off` and `expose_php = Off` live in `/var/task/php/conf.d/php.ini`