### PR TITLE
feat: warn when APP_ENV is non-standard and has no environment_mapping

### DIFF
--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -120,6 +120,7 @@ class AnalyzeCommand extends Command
 
         // Validate ignore_errors config early (before analysis starts)
         $this->validateIgnoreErrorsConfig($manager);
+        $this->warnIfUnrecognizedEnvironment();
 
         // Check if any categories are enabled
         $analyzersConfig = config('shieldci.analyzers', []);
@@ -1164,6 +1165,27 @@ class AnalyzeCommand extends Command
         }
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Warn if APP_ENV is non-standard and has no environment_mapping entry.
+     */
+    private function warnIfUnrecognizedEnvironment(): void
+    {
+        $standardEnvs = ['local', 'development', 'staging', 'production', 'testing'];
+        $rawEnv = config('app.env');
+
+        if (! is_string($rawEnv) || $rawEnv === '' || in_array($rawEnv, $standardEnvs, true)) {
+            return;
+        }
+
+        $mapping = config('shieldci.environment_mapping', []);
+        if (is_array($mapping) && isset($mapping[$rawEnv])) {
+            return;
+        }
+
+        $this->warn("⚠️  APP_ENV '{$rawEnv}' is not a recognized standard environment. Environment-scoped analyzers may be skipped. Add a mapping in config/shieldci.php.");
+        $this->newLine();
     }
 
     /**

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -4255,4 +4255,39 @@ PHP);
 
         @unlink($outputPath);
     }
+
+    #[Test]
+    public function it_warns_when_app_env_is_unrecognized_and_not_mapped(): void
+    {
+        config(['app.env' => 'production-eu']);
+        config(['shieldci.environment_mapping' => []]);
+        $this->registerTestAnalyzers();
+
+        $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful()
+            ->expectsOutputToContain("APP_ENV 'production-eu' is not a recognized standard environment");
+    }
+
+    #[Test]
+    public function it_does_not_warn_when_app_env_is_standard(): void
+    {
+        config(['app.env' => 'production']);
+        $this->registerTestAnalyzers();
+
+        $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful()
+            ->doesntExpectOutputToContain('is not a recognized standard environment');
+    }
+
+    #[Test]
+    public function it_does_not_warn_when_custom_env_has_mapping(): void
+    {
+        config(['app.env' => 'production-eu']);
+        config(['shieldci.environment_mapping' => ['production-eu' => 'production']]);
+        $this->registerTestAnalyzers();
+
+        $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful()
+            ->doesntExpectOutputToContain('is not a recognized standard environment');
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `warnIfUnrecognizedEnvironment()` to `AnalyzeCommand` that fires when `APP_ENV` is a non-standard value (anything outside `local`, `development`, `staging`, `production`, `testing`) and no matching key exists in `shieldci.environment_mapping`
- Follows the same pattern as the existing `validateIgnoreErrorsConfig` warning — called once in `executeAnalysis()` before analysis runs
- Warning is suppressed as soon as the developer adds the correct mapping entry, so there is no noise for correctly configured projects
- Covers all reachable branches with 3 new tests (warns when unmapped, silent for standard env, silent when mapping present)