### PR TITLE
fix: invert DebugModeAnalyzer env check to blocklist production/staging

### DIFF
--- a/src/Analyzers/Security/DebugModeAnalyzer.php
+++ b/src/Analyzers/Security/DebugModeAnalyzer.php
@@ -182,7 +182,9 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
-     * Check if environment is local/development.
+     * Check if environment is non-production (i.e. debug check should be skipped).
+     *
+     * Uses an inverted approach: only flag when the environment is explicitly 'production' or 'staging'.
      */
     private function isLocalEnvironment(?string $env): bool
     {
@@ -190,7 +192,7 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
             return false;
         }
 
-        return in_array(strtolower($env), ['local', 'development', 'testing'], true);
+        return ! in_array(strtolower($env), ['production', 'staging'], true);
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/DebugModeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/DebugModeAnalyzerTest.php
@@ -128,6 +128,23 @@ ENV;
         $this->assertPassed($result);
     }
 
+    public function test_passes_when_app_env_is_unrecognized_non_production(): void
+    {
+        // 'test', 'dev', 'qa', 'sandbox' etc. are not in ['production','staging']
+        // so they should be treated as non-production and the check should be skipped.
+        foreach (['test', 'dev', 'qa', 'sandbox'] as $env) {
+            $envContent = "APP_DEBUG=true\nAPP_ENV={$env}";
+            $tempDir = $this->createTempDirectory(['.env' => $envContent]);
+
+            $analyzer = $this->createAnalyzer();
+            $analyzer->setBasePath($tempDir);
+
+            $result = $analyzer->analyze();
+
+            $this->assertPassed($result);
+        }
+    }
+
     public function test_includes_metadata_for_env_issues(): void
     {
         $envContent = <<<'ENV'


### PR DESCRIPTION
## Summary

- `isLocalEnvironment()` previously used an allowlist `['local', 'development', 'testing']` — any non-standard name (`test`, `dev`, `qa`, `sandbox`, `local-test`) fell through and triggered the debug check as if it were production
- Inverted to a blocklist: only `production` and `staging` trigger the check; everything else is treated as non-production
- Removes false positives for teams using custom environment names without needing any `environment_mapping` configuration
- `null` (no `APP_ENV` in `.env`) still triggers the check — having `APP_DEBUG=true` with no environment set is itself a concern