### PR TITLE
feat: suppress Laravel Cloud false positives via platform detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.2
+
+### Fixed
+- Seven analyzers no longer false-positive on Laravel Cloud — `EnvFileAnalyzer`, `EnvVariableAnalyzer`, `EnvFileSecurityAnalyzer`, and `EnvExampleAnalyzer` now skip entirely on Cloud because the platform writes a managed `.env` (permissions are fixed at 644 and cannot be changed by the application) and auto-injects `NIGHTWATCH_*`, `LOG_*`, and `REDIS_*` variables directly into the container rather than via `.env.example`; `DirectoryWritePermissionsAnalyzer` skips on Cloud because `php artisan storage:link` is explicitly listed as unnecessary (symlinks do not persist post-deploy); `FilePermissionsAnalyzer` removes only the `.env` entry from its paths-to-check on Cloud while continuing to check all directories; `PHPIniAnalyzer` no longer flags `allow_url_fopen`, `allow_url_include`, or `expose_php` on Cloud — these directives cannot be overridden in a Cloud container; `display_errors` and `log_errors` remain actionable and are still checked; detection uses the sole signal `LARAVEL_CLOUD=1`, which Cloud sets on all compute types (web, worker, scheduled task) (#178)
+
 ## v1.7.1
 
 ### Added

--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -55,11 +55,15 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
-        return ! $this->isVaporOrServerless();
+        return ! $this->isVaporOrServerless() && ! $this->isLaravelCloud();
     }
 
     public function getSkipReason(): string
     {
+        if ($this->isLaravelCloud()) {
+            return 'Laravel Cloud does not persist filesystem changes made during deploy commands — `php artisan storage:link` is explicitly listed as unnecessary. Use Laravel Object Storage (an attached bucket) for persistent file storage';
+        }
+
         return 'Directory write permissions are managed by Laravel Vapor and cannot be changed by the user';
     }
 

--- a/src/Analyzers/Reliability/EnvExampleAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvExampleAnalyzer.php
@@ -29,11 +29,15 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
-        return ! $this->isVaporOrServerless();
+        return ! $this->isVaporOrServerless() && ! $this->isLaravelCloud();
     }
 
     public function getSkipReason(): string
     {
+        if ($this->isLaravelCloud()) {
+            return 'Laravel Cloud injects environment variables (NIGHTWATCH_*, LOG_*, REDIS_*, etc.) directly into the container — these are platform-managed and should not be documented in .env.example';
+        }
+
         return 'Vapor removes .env and .env.example from the deployment; environment variables are provided via Vapor UI (SSM Parameter Store, plaintext vars, or encrypted environment files)';
     }
 

--- a/src/Analyzers/Reliability/EnvFileAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvFileAnalyzer.php
@@ -26,11 +26,15 @@ class EnvFileAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
-        return ! $this->isVaporOrServerless();
+        return ! $this->isVaporOrServerless() && ! $this->isLaravelCloud();
     }
 
     public function getSkipReason(): string
     {
+        if ($this->isLaravelCloud()) {
+            return 'Laravel Cloud writes a platform-managed .env; its existence and contents are controlled by the platform, not the application';
+        }
+
         return 'Vapor removes the plain .env file from the deployment; environment variables are provided via Vapor UI (SSM Parameter Store, plaintext vars, or encrypted environment files)';
     }
 

--- a/src/Analyzers/Reliability/EnvVariableAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvVariableAnalyzer.php
@@ -29,11 +29,15 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
-        return ! $this->isVaporOrServerless();
+        return ! $this->isVaporOrServerless() && ! $this->isLaravelCloud();
     }
 
     public function getSkipReason(): string
     {
+        if ($this->isLaravelCloud()) {
+            return 'Laravel Cloud writes a platform-managed .env; missing variables are provided via the Cloud dashboard, not .env.example';
+        }
+
         return 'Vapor removes the plain .env file from the deployment; environment variables are provided via Vapor UI (SSM Parameter Store, plaintext vars, or encrypted environment files)';
     }
 

--- a/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
+++ b/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
@@ -78,7 +78,7 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
-        if ($this->isVaporOrServerless()) {
+        if ($this->isVaporOrServerless() || $this->isLaravelCloud()) {
             return false;
         }
 
@@ -112,6 +112,10 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
     public function getSkipReason(): string
     {
+        if ($this->isLaravelCloud()) {
+            return 'Laravel Cloud writes a platform-managed .env with 644 permissions; this is controlled by the platform and cannot be changed by the application';
+        }
+
         if ($this->isVaporOrServerless()) {
             return 'Vapor removes the plain .env file from the deployment; environment variables are provided via Vapor UI (SSM Parameter Store, plaintext vars, or encrypted environment files)';
         }

--- a/src/Analyzers/Security/FilePermissionsAnalyzer.php
+++ b/src/Analyzers/Security/FilePermissionsAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Validates file and directory permissions for security.
@@ -24,6 +25,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class FilePermissionsAnalyzer extends AbstractFileAnalyzer
 {
+    use DetectsDeploymentPlatform;
+
     public static bool $runInCI = false;
 
     /** Mask to isolate permission bits (strip file type and special bits) */
@@ -112,7 +115,7 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
      *
      * @return array<string, array{type: string, max: int, recommended: int, critical?: bool, executable?: bool}>
      */
-    private function getPathsToCheck(): array
+    protected function getPathsToCheck(): array
     {
         /** @var array<string, array{type: string, max: int, recommended: int, critical?: bool, executable?: bool}> $defaults */
         $defaults = [
@@ -137,6 +140,11 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
             // Executable files
             'artisan' => ['type' => 'file', 'max' => octdec('775'), 'recommended' => octdec('755'), 'executable' => true],
         ];
+
+        // On Laravel Cloud, .env is platform-managed (always 644 — unfixable by the application)
+        if ($this->isLaravelCloud()) {
+            unset($defaults['.env']);
+        }
 
         // Allow configuration override
         /** @var array<string, array{type: string, max: int, recommended: int, critical?: bool, executable?: bool}> $config */

--- a/src/Analyzers/Security/PHPIniAnalyzer.php
+++ b/src/Analyzers/Security/PHPIniAnalyzer.php
@@ -122,6 +122,18 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
             unset($secureSettings['log_errors'], $secureSettings['display_startup_errors']);
         }
 
+        // These three are PHP_INI_SYSTEM — confirmed unfixable on Laravel Cloud (serversideup/docker-php
+        // base image sets them and Cloud does not expose a way to override PHP_INI_SYSTEM directives).
+        // display_errors, log_errors, and ignore_repeated_errors are PHP_INI_ALL and remain actionable
+        // via public/.user.ini on Cloud.
+        if ($this->isLaravelCloud()) {
+            unset(
+                $secureSettings['allow_url_fopen'],
+                $secureSettings['allow_url_include'],
+                $secureSettings['expose_php'],
+            );
+        }
+
         $this->checkPhpIniSettings($issues, $phpIniPath, $secureSettings);
 
         if (empty($issues)) {
@@ -327,6 +339,18 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
 
         return PlatformDetector::isLaravelVapor($this->getBasePath())
             || PlatformDetector::isServerless();
+    }
+
+    /**
+     * Check if the deployment platform is Laravel Cloud.
+     */
+    private function isLaravelCloud(): bool
+    {
+        if ($this->deploymentPlatformOverride !== null) {
+            return $this->deploymentPlatformOverride === 'laravel-cloud';
+        }
+
+        return PlatformDetector::isLaravelCloud();
     }
 
     /**

--- a/src/Concerns/DetectsDeploymentPlatform.php
+++ b/src/Concerns/DetectsDeploymentPlatform.php
@@ -30,4 +30,13 @@ trait DetectsDeploymentPlatform
         return PlatformDetector::isLaravelVapor($this->getBasePath())
             || PlatformDetector::isServerless();
     }
+
+    private function isLaravelCloud(): bool
+    {
+        if ($this->deploymentPlatformOverride !== null) {
+            return $this->deploymentPlatformOverride === 'laravel-cloud';
+        }
+
+        return PlatformDetector::isLaravelCloud();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `isLaravelCloud()` to `DetectsDeploymentPlatform` trait (and inline to `PHPIniAnalyzer`) using the `LARAVEL_CLOUD=1` env var, which Cloud sets on all compute types (web, worker, scheduled task)
- Updates 7 analyzers to skip or narrow checks on Cloud, eliminating false positives caused by Cloud's managed runtime

## False positives suppressed

| Analyzer | Why skipped on Cloud |
|---|---|
| `EnvFileAnalyzer` | Cloud writes a platform-managed `.env`; existence and contents are controlled by the platform |
| `EnvVariableAnalyzer` | Variables provided via Cloud dashboard, not `.env.example` |
| `EnvFileSecurityAnalyzer` | Platform-managed `.env` is always 644; application cannot change permissions |
| `EnvExampleAnalyzer` | Cloud auto-injects `NIGHTWATCH_*`, `LOG_*`, `REDIS_*` vars; should not be in `.env.example` |
| `DirectoryWritePermissionsAnalyzer` | `storage:link` explicitly listed as unnecessary on Cloud; symlinks don't persist post-deploy |
| `FilePermissionsAnalyzer` | Removes `.env` from paths-to-check only; all directory permission checks remain active |
| `PHPIniAnalyzer` | Unsets `allow_url_fopen`, `allow_url_include`, `expose_php` — cannot be overridden in a Cloud container; `display_errors` and `log_errors` remain actionable and are still checked |