### PR TITLE
feat: suppress false positives for Docker container environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.3
+
+### Fixed
+- Five analyzers no longer false-positive inside Docker containers — `FilePermissionsAnalyzer` and `DirectoryWritePermissionsAnalyzer` skip entirely on Docker because file ownership is controlled by the image and host volume mounts, making `chmod` recommendations unactionable and `is_writable()` results unreliable; `MysqlSingleServerAnalyzer` skips on Docker because MySQL runs in a separate container and inter-container communication correctly uses TCP, making Unix socket recommendations inapplicable; `EnvFileSecurityAnalyzer` skips only its `checkEnvPermissions()` sub-check on Docker while continuing to check for `.env` in public directories, sensitive data in `.env.example`, and `.gitignore` hygiene; `PHPIniAnalyzer` no longer flags `allow_url_fopen`, `allow_url_include`, or `expose_php` on Docker — these are PHP_INI_SYSTEM directives set by the Docker base image and cannot be overridden at the application level, mirroring the existing Laravel Cloud suppression; `display_errors`, `log_errors`, and `ignore_repeated_errors` remain actionable and are still checked; Docker detection is added to the shared `DetectsDeploymentPlatform` trait via `isDocker()` backed by `PlatformDetector::isDocker()`, and all affected analyzers support `setDeploymentPlatform('docker')` for unit testing without a real Docker environment (#179)
+
 ## v1.7.2
 
 ### Fixed

--- a/src/Analyzers/Performance/MysqlSingleServerAnalyzer.php
+++ b/src/Analyzers/Performance/MysqlSingleServerAnalyzer.php
@@ -13,6 +13,7 @@ use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Checks MySQL connection configuration for single-server setups.
@@ -31,6 +32,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class MysqlSingleServerAnalyzer extends AbstractAnalyzer
 {
+    use DetectsDeploymentPlatform;
+
     /**
      * MySQL SSL-related PDO attributes (constants 1007–1011).
      *
@@ -95,6 +98,10 @@ class MysqlSingleServerAnalyzer extends AbstractAnalyzer
 
     public function shouldRun(): bool
     {
+        if ($this->isDocker()) {
+            return false;
+        }
+
         // Check environment relevance first
         if (! $this->isRelevantForCurrentEnvironment()) {
             return false;
@@ -114,6 +121,10 @@ class MysqlSingleServerAnalyzer extends AbstractAnalyzer
 
     public function getSkipReason(): string
     {
+        if ($this->isDocker()) {
+            return 'MySQL runs in a separate container in Docker environments; Unix socket optimization is not applicable as inter-container communication uses TCP';
+        }
+
         if (! $this->isRelevantForCurrentEnvironment()) {
             $currentEnv = $this->getEnvironment();
             $relevantEnvs = implode(', ', $this->relevantEnvironments ?? []);

--- a/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
+++ b/src/Analyzers/Reliability/DirectoryWritePermissionsAnalyzer.php
@@ -55,11 +55,15 @@ class DirectoryWritePermissionsAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
-        return ! $this->isVaporOrServerless() && ! $this->isLaravelCloud();
+        return ! $this->isVaporOrServerless() && ! $this->isLaravelCloud() && ! $this->isDocker();
     }
 
     public function getSkipReason(): string
     {
+        if ($this->isDocker()) {
+            return 'Directory write permissions and symlinks are managed by the Docker image and container entrypoint; these checks are not reliable inside containers';
+        }
+
         if ($this->isLaravelCloud()) {
             return 'Laravel Cloud does not persist filesystem changes made during deploy commands — `php artisan storage:link` is explicitly listed as unnecessary. Use Laravel Object Storage (an attached bucket) for persistent file storage';
         }

--- a/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
+++ b/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
@@ -136,8 +136,10 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
         // Check if .env is in .gitignore
         $this->checkGitignore($issues);
 
-        // Check .env file permissions
-        $this->checkEnvPermissions($issues);
+        // Check .env file permissions (skipped in Docker — permissions are host/image-controlled)
+        if (! $this->isDocker()) {
+            $this->checkEnvPermissions($issues);
+        }
 
         $summary = empty($issues)
             ? 'Environment files are properly secured'

--- a/src/Analyzers/Security/FilePermissionsAnalyzer.php
+++ b/src/Analyzers/Security/FilePermissionsAnalyzer.php
@@ -61,6 +61,10 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
+        if ($this->isDocker()) {
+            return false;
+        }
+
         // Check if at least one configured path exists
         foreach ($this->getPathsToCheck() as $relativePath => $config) {
             $path = $this->buildPath($relativePath);
@@ -74,6 +78,10 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
 
     public function getSkipReason(): string
     {
+        if ($this->isDocker()) {
+            return 'File permissions are managed by the Docker image and host volume mounts; chmod recommendations are not actionable inside containers';
+        }
+
         return 'No configured files or directories found to analyze';
     }
 

--- a/src/Analyzers/Security/PHPIniAnalyzer.php
+++ b/src/Analyzers/Security/PHPIniAnalyzer.php
@@ -124,9 +124,11 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
 
         // These three are PHP_INI_SYSTEM — confirmed unfixable on Laravel Cloud (serversideup/docker-php
         // base image sets them and Cloud does not expose a way to override PHP_INI_SYSTEM directives).
+        // The same applies in Docker containers generally: the base image controls these settings and
+        // there is no application-level override mechanism for PHP_INI_SYSTEM directives.
         // display_errors, log_errors, and ignore_repeated_errors are PHP_INI_ALL and remain actionable
-        // via public/.user.ini on Cloud.
-        if ($this->isLaravelCloud()) {
+        // via public/.user.ini on Cloud or ini_set() in Docker.
+        if ($this->isLaravelCloud() || $this->isDocker()) {
             unset(
                 $secureSettings['allow_url_fopen'],
                 $secureSettings['allow_url_include'],
@@ -351,6 +353,18 @@ class PHPIniAnalyzer extends AbstractFileAnalyzer
         }
 
         return PlatformDetector::isLaravelCloud();
+    }
+
+    /**
+     * Check if running inside a Docker container.
+     */
+    private function isDocker(): bool
+    {
+        if ($this->deploymentPlatformOverride !== null) {
+            return $this->deploymentPlatformOverride === 'docker';
+        }
+
+        return PlatformDetector::isDocker();
     }
 
     /**

--- a/src/Concerns/DetectsDeploymentPlatform.php
+++ b/src/Concerns/DetectsDeploymentPlatform.php
@@ -39,4 +39,13 @@ trait DetectsDeploymentPlatform
 
         return PlatformDetector::isLaravelCloud();
     }
+
+    private function isDocker(): bool
+    {
+        if ($this->deploymentPlatformOverride !== null) {
+            return $this->deploymentPlatformOverride === 'docker';
+        }
+
+        return PlatformDetector::isDocker();
+    }
 }

--- a/tests/Unit/Analyzers/Performance/MysqlSingleServerAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/MysqlSingleServerAnalyzerTest.php
@@ -1183,6 +1183,20 @@ class MysqlSingleServerAnalyzerTest extends AnalyzerTestCase
         $this->assertHasIssueContaining('Unix socket', $result);
     }
 
+    // =========================================================================
+    // Docker Skip Tests
+    // =========================================================================
+
+    public function test_skips_on_docker(): void
+    {
+        /** @var MysqlSingleServerAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('docker');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Docker', $analyzer->getSkipReason());
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();

--- a/tests/Unit/Analyzers/Reliability/DirectoryWritePermissionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/DirectoryWritePermissionsAnalyzerTest.php
@@ -1029,4 +1029,18 @@ class DirectoryWritePermissionsAnalyzerTest extends AnalyzerTestCase
 
         $this->assertFalse($analyzer->shouldRun());
     }
+
+    // =========================================================================
+    // Docker Skip Tests
+    // =========================================================================
+
+    public function test_skips_on_docker(): void
+    {
+        /** @var DirectoryWritePermissionsAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('docker');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Docker', $analyzer->getSkipReason());
+    }
 }

--- a/tests/Unit/Analyzers/Security/EnvFileSecurityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/EnvFileSecurityAnalyzerTest.php
@@ -960,4 +960,36 @@ ENV;
 
         $this->assertFalse($analyzer->shouldRun());
     }
+
+    // =========================================================================
+    // Docker Skip Tests
+    // =========================================================================
+
+    public function test_skips_env_permissions_check_on_docker(): void
+    {
+        // World-readable .env would normally trigger a Critical permissions issue
+        $tempDir = $this->createTempDirectory([
+            '.env' => "APP_KEY=base64:abc123\n",
+            '.env.example' => "APP_KEY=\n",
+            '.gitignore' => ".env\n",
+        ]);
+
+        chmod($tempDir.'/.env', 0644); // world-readable — would flag without Docker skip
+
+        /** @var EnvFileSecurityAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setDeploymentPlatform('docker');
+
+        // shouldRun() still returns true — other checks (git, public dir, .env.example) are valid
+        $this->assertTrue($analyzer->shouldRun());
+
+        $result = $analyzer->analyze();
+
+        // No permission-related issues — permissions check is skipped in Docker
+        foreach ($result->getIssues() as $issue) {
+            $this->assertStringNotContainsString('permissions', strtolower($issue->message));
+            $this->assertStringNotContainsString('chmod', strtolower($issue->recommendation));
+        }
+    }
 }

--- a/tests/Unit/Analyzers/Security/FilePermissionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FilePermissionsAnalyzerTest.php
@@ -73,6 +73,21 @@ class FilePermissionsAnalyzerTest extends AnalyzerTestCase
         $this->assertStringContainsString('No configured files', $reason);
     }
 
+    public function test_skips_on_docker(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            'app/Models/User.php' => '<?php class User {}',
+        ]);
+
+        /** @var FilePermissionsAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setDeploymentPlatform('docker');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Docker', $analyzer->getSkipReason());
+    }
+
     // ==================== Directory Permission Tests ====================
 
     public function test_detects_world_writable_directory(): void

--- a/tests/Unit/Analyzers/Security/PHPIniAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/PHPIniAnalyzerTest.php
@@ -894,6 +894,46 @@ class PHPIniAnalyzerTest extends AnalyzerTestCase
         $this->assertIssueCount(0, $result);
     }
 
+    // ── Docker Skip Tests ────────────────────────────────────────────
+
+    public function test_skips_php_ini_system_settings_on_docker(): void
+    {
+        // All three PHP_INI_SYSTEM settings are "insecure" at runtime
+        $iniPath = $this->createPhpIniFixture([
+            'allow_url_fopen = On',
+            'allow_url_include = On',
+            'expose_php = On',
+            'display_errors = On',  // PHP_INI_ALL — still checked in Docker
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setPhpIniPath($iniPath);
+        $analyzer->setBasePath(dirname($iniPath));
+        $analyzer->setDeploymentPlatform('docker');
+        $analyzer->setIniValues($this->secureIniValues([
+            'allow_url_fopen' => '1',
+            'allow_url_include' => '1',
+            'expose_php' => '1',
+            'display_errors' => '1',
+        ]));
+
+        $result = $analyzer->analyze();
+
+        $issues = $result->getIssues();
+        $issueMessages = array_map(fn (Issue $i) => $i->message, $issues);
+
+        // PHP_INI_SYSTEM settings are suppressed on Docker (unfixable from base image)
+        foreach ($issueMessages as $message) {
+            $this->assertStringNotContainsString('allow_url_fopen', $message);
+            $this->assertStringNotContainsString('allow_url_include', $message);
+            $this->assertStringNotContainsString('expose_php', $message);
+        }
+
+        // PHP_INI_ALL setting (display_errors) is still reported — app can fix it
+        $displayErrorsIssue = $this->findIssueContaining('display_errors', $issues);
+        $this->assertNotNull($displayErrorsIssue, 'display_errors should still be reported in Docker');
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────
 
     /**


### PR DESCRIPTION
## Summary

- Extends `DetectsDeploymentPlatform` trait with `isDocker()` backed by `PlatformDetector::isDocker()`
- **Full skip** on Docker: `FilePermissionsAnalyzer`, `DirectoryWritePermissionsAnalyzer`, `MysqlSingleServerAnalyzer` — the entire analyzer premise breaks down in containers (image-controlled ownership, separate-container TCP topology)
- **Partial skip** on Docker: `EnvFileSecurityAnalyzer` skips `checkEnvPermissions()` only; `PHPIniAnalyzer` suppresses `allow_url_fopen`, `allow_url_include`, `expose_php` (PHP_INI_SYSTEM, set by Docker base image — same logic as existing Laravel Cloud suppression)
- All 5 affected analyzers support `setDeploymentPlatform('docker')` for unit testing without a real Docker environment
- 5 new tests covering each skip behavior; 4018 tests pass, 0 new PHPStan errors