### PR TITLE
fix: skip Auth::user() patterns inside string literals in AuthenticationAnalyzer

### DIFF
--- a/src/Analyzers/Security/AuthenticationAnalyzer.php
+++ b/src/Analyzers/Security/AuthenticationAnalyzer.php
@@ -1012,6 +1012,7 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
         $stringLines = $this->parser->collectStringLines($ast);
 
         foreach ($lines as $lineNumber => $line) {
+            // $lines is 0-indexed (FileParser::getLines); $stringLines keys are 1-indexed (AST lines).
             if (isset($stringLines[$lineNumber + 1])) {
                 continue;
             }

--- a/src/Analyzers/Security/AuthenticationAnalyzer.php
+++ b/src/Analyzers/Security/AuthenticationAnalyzer.php
@@ -1009,7 +1009,13 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
             $namespace = $namespaceNodes[0]->name->toString();
         }
 
+        $stringLines = $this->parser->collectStringLines($ast);
+
         foreach ($lines as $lineNumber => $line) {
+            if (isset($stringLines[$lineNumber + 1])) {
+                continue;
+            }
+
             // Check for Auth::user()-> (but NOT Auth::user()?-> which is safe)
             if (preg_match('/Auth::user\(\)\s*->/i', $line) && ! preg_match('/Auth::user\(\)\s*\?->/i', $line)) {
                 $this->checkAuthUsageWithNullSafety(

--- a/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
@@ -4097,4 +4097,36 @@ PHP;
         $this->assertFalse($result->isSuccess());
         $this->assertHasIssueContaining('$request->user()', $result);
     }
+
+    public function test_does_not_flag_auth_usage_inside_heredoc_string(): void
+    {
+        $service = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class DocumentationHelper
+{
+    public function getAuthDocs(): string
+    {
+        return <<<'MD'
+        Use Auth::user()->name to display the user's name.
+        Or use auth()->user()->name for the helper form.
+        MD;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => '<?php',
+            'app/Services/DocumentationHelper.php' => $service,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+        $result = $analyzer->analyze();
+
+        $this->assertEmpty($result->getIssues());
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes a false positive in `AuthenticationAnalyzer` where `Auth::user()->` (and `auth()->user()->` / `$request->user()->`) inside a heredoc or string-literal documentation block was flagged as unsafe auth usage
- Uses the new `collectStringLines()` utility from `analyzers-core` v1.4.0 to build a set of line numbers that fall inside string literals, then skips those lines before applying the three `preg_match` checks in `checkUnsafeAuthUsage()`

## Root cause

`checkUnsafeAuthUsage()` scans raw source lines with `preg_match` and has no awareness of token context. A line like:

```php
$docs = <<<'MD'
Use Auth::user()->name to display the user's name.
MD;
```

matched the regex `/Auth::user\(\)\s*->/i` and produced an issue even though the pattern is inside a string literal.

## Fix

```php
$stringLines = $this->parser->collectStringLines($ast);

foreach ($lines as $lineNumber => $line) {
    // $lines is 0-indexed (FileParser::getLines); $stringLines keys are 1-indexed (AST lines).
    if (isset($stringLines[$lineNumber + 1])) {
        continue;
    }
    // ... existing checks unchanged
}
```