### PR TITLE
fix: resolve false positive in XssAnalyzer when style-src contains unsafe-inline

### DIFF
--- a/src/Analyzers/Security/XssAnalyzer.php
+++ b/src/Analyzers/Security/XssAnalyzer.php
@@ -891,20 +891,35 @@ class XssAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if CSP policy is valid (has script-src/default-src without unsafe).
+     *
+     * Parses directives individually so that 'unsafe-inline' in style-src does
+     * not trigger a false positive — only the script-governing directive matters
+     * for XSS protection (script-src, or default-src when script-src is absent).
      */
     private function isValidCspPolicy(string $policy): bool
     {
-        // Must contain script-src or default-src
-        if (! Str::contains($policy, ['default-src', 'script-src'])) {
+        $directives = array_filter(array_map('trim', explode(';', $policy)));
+
+        $scriptSrc = null;
+        $defaultSrc = null;
+
+        foreach ($directives as $directive) {
+            if (str_starts_with($directive, 'script-src')) {
+                $scriptSrc = $directive;
+            } elseif (str_starts_with($directive, 'default-src')) {
+                $defaultSrc = $directive;
+            }
+        }
+
+        // Policy must contain script-src or default-src
+        $relevantDirective = $scriptSrc ?? $defaultSrc;
+        if ($relevantDirective === null) {
             return false;
         }
 
-        // Must not contain unsafe-eval or unsafe-inline
-        if (Str::contains($policy, ['unsafe-eval', 'unsafe-inline'])) {
-            return false;
-        }
-
-        return true;
+        // Only the script-governing directive must not allow unsafe execution.
+        // 'unsafe-inline' in style-src is irrelevant to script XSS.
+        return ! Str::contains($relevantDirective, ["'unsafe-eval'", "'unsafe-inline'"]);
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
@@ -439,6 +439,66 @@ BLADE;
         $this->assertPassed($result);
     }
 
+    public function test_passes_when_style_src_has_unsafe_inline_but_script_src_is_clean(): void
+    {
+        config(['app.url' => 'https://example.com']);
+        config(['shieldci.guest_url' => '/']);
+        config(['shieldci.ci_mode' => false]);
+
+        // Mirrors the platform's real CSP: nonce-based script-src with unsafe-inline only in style-src
+        $responses = [
+            new Response(200, [
+                'Content-Security-Policy' => "default-src 'self'; script-src 'self' 'nonce-abc123' https://cdn.example.com; style-src 'self' 'unsafe-inline' https://fonts.example.com",
+            ], '<html></html>'),
+        ];
+
+        $analyzer = $this->createAnalyzerWithHttpMock($responses);
+        $result = $analyzer->analyze();
+
+        // unsafe-inline in style-src must not flag as XSS — only script-src matters
+        $this->assertPassed($result);
+    }
+
+    public function test_fails_when_script_src_itself_has_unsafe_inline(): void
+    {
+        config(['app.url' => 'https://example.com']);
+        config(['shieldci.guest_url' => '/']);
+        config(['shieldci.ci_mode' => false]);
+
+        $responses = [
+            new Response(200, [
+                'Content-Security-Policy' => "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'",
+            ], '<html></html>'),
+        ];
+
+        $analyzer = $this->createAnalyzerWithHttpMock($responses);
+        $result = $analyzer->analyze();
+
+        // script-src with unsafe-inline is still a genuine issue
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('inadequate', $result);
+    }
+
+    public function test_fails_when_default_src_has_unsafe_inline_and_no_script_src(): void
+    {
+        config(['app.url' => 'https://example.com']);
+        config(['shieldci.guest_url' => '/']);
+        config(['shieldci.ci_mode' => false]);
+
+        // No explicit script-src — default-src acts as fallback and it allows unsafe-inline
+        $responses = [
+            new Response(200, [
+                'Content-Security-Policy' => "default-src 'self' 'unsafe-inline'",
+            ], '<html></html>'),
+        ];
+
+        $analyzer = $this->createAnalyzerWithHttpMock($responses);
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('inadequate', $result);
+    }
+
     public function test_skips_http_checks_in_ci_mode(): void
     {
         config(['shieldci.ci_mode' => true]); // CI mode enabled


### PR DESCRIPTION
## Summary

- `isValidCspPolicy()` was scanning the entire CSP policy string for `unsafe-inline`/`unsafe-eval`, causing it to flag legitimate policies that restrict those keywords to `style-src` only
- A nonce-based `script-src` with `style-src 'unsafe-inline'` (common for font/icon libraries) was incorrectly reported as XSS-inadequate
- Refactored to parse CSP directives individually and evaluate only the script-governing directive (`script-src`, falling back to `default-src`)

## Root cause

```php
// Before: whole-string check — collapses all directive scopes
if (Str::contains($policy, ['unsafe-eval', 'unsafe-inline'])) {
    return false;
}
```

`style-src 'self' 'unsafe-inline'` is irrelevant to JavaScript XSS. Only `script-src` (or `default-src` when `script-src` is absent) controls script execution.

## Changes

- **`src/Analyzers/Security/XssAnalyzer.php`** — `isValidCspPolicy()` now splits by `;`, finds `script-src`/`default-src`, and checks only that directive
- **`tests/Unit/Analyzers/Security/XssAnalyzerTest.php`** — three new regression tests (73 total, all passing, PHPStan Level 9 clean)