### PR TITLE
refactor: remove duplicate .env permission check from EnvFileSecurityAnalyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.7.6
+
+### Fixed
+- `XssDetectionAnalyzer` no longer false-positives on `style-src 'unsafe-inline'` in Content Security Policy headers — CSP directives are now parsed individually rather than matched against the full header string, so `style-src 'unsafe-inline'` is only flagged when it appears as its own directive; previously, a valid `default-src 'none'; style-src 'unsafe-inline'` policy was incorrectly passing because `'unsafe-inline'` was found anywhere in the string without checking which directive it belonged to (#183)
+
+### Changed
+- `EnvFileSecurityAnalyzer` no longer checks `.env` file permissions — `FilePermissionsAnalyzer` already owns this responsibility with a more thorough bitwise, multi-stage implementation; running both analyzers was producing two separate findings for the same problem; `EnvFileSecurityAnalyzer` continues to check for `.env` in public directories, real credentials in `.env.example`, and `.gitignore` / git-tracking hygiene (#184)
+
 ## v1.7.5
 
 ### Fixed

--- a/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
+++ b/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
@@ -29,14 +29,6 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
     public static bool $runInCI = false;
 
-    private const WORLD_READABLE = 0x0004;
-
-    private const WORLD_WRITABLE = 0x0002;
-
-    private const GROUP_READABLE = 0x0020;
-
-    private const GROUP_WRITABLE = 0x0040;
-
     private array $sensitiveKeys = [
         'APP_KEY',
         'DB_PASSWORD',
@@ -135,11 +127,6 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
         // Check if .env is in .gitignore
         $this->checkGitignore($issues);
-
-        // Check .env file permissions (skipped in Docker — permissions are host/image-controlled)
-        if (! $this->isDocker()) {
-            $this->checkEnvPermissions($issues);
-        }
 
         $summary = empty($issues)
             ? 'Environment files are properly secured'
@@ -344,59 +331,6 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
                     'file' => '.env',
                     'git_tracked' => true,
                     'code' => 'git-tracked',
-                ]
-            );
-        }
-    }
-
-    /**
-     * Check .env file permissions.
-     */
-    private function checkEnvPermissions(array &$issues): void
-    {
-        $envPath = $this->buildPath('.env');
-
-        if (! file_exists($envPath)) {
-            return;
-        }
-
-        $perms = @fileperms($envPath);
-        if ($perms === false) {
-            return;
-        }
-
-        $octal = substr(sprintf('%o', $perms), -3);
-
-        // Check if file is world-readable or world-writable (Critical)
-        if (($perms & self::WORLD_READABLE) || ($perms & self::WORLD_WRITABLE)) {
-            $issues[] = $this->createIssue(
-                message: sprintf('.env file has insecure permissions (%s)', $octal),
-                location: new Location($this->getRelativePath($envPath)),
-                severity: Severity::Critical,
-                recommendation: 'Restrict .env permissions: chmod 600 .env',
-                metadata: [
-                    'permissions' => $octal,
-                    'world_readable' => (bool) ($perms & self::WORLD_READABLE),
-                    'world_writable' => (bool) ($perms & self::WORLD_WRITABLE),
-                    'code' => 'permissions',
-                ]
-            );
-
-            return; // Don't check for less severe issues if Critical issue exists
-        }
-
-        // Check if file is group-readable or group-writable (Medium)
-        if (($perms & self::GROUP_READABLE) || ($perms & self::GROUP_WRITABLE)) {
-            $issues[] = $this->createIssue(
-                message: sprintf('.env file has overly permissive permissions (%s)', $octal),
-                location: new Location($this->getRelativePath($envPath)),
-                severity: Severity::Medium,
-                recommendation: 'Consider restricting .env permissions: chmod 600 .env (readable only by owner)',
-                metadata: [
-                    'permissions' => $octal,
-                    'group_readable' => (bool) ($perms & self::GROUP_READABLE),
-                    'group_writable' => (bool) ($perms & self::GROUP_WRITABLE),
-                    'code' => 'permissions',
                 ]
             );
         }

--- a/tests/Unit/Analyzers/Security/EnvFileSecurityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/EnvFileSecurityAnalyzerTest.php
@@ -227,10 +227,7 @@ ENV;
         $result = $analyzer->analyze();
 
         // Should not flag placeholders as real credentials
-        $issues = $result->getIssues();
-        foreach ($issues as $issue) {
-            $this->assertStringNotContainsString('real credentials', $issue->message);
-        }
+        $this->assertPassed($result);
     }
 
     public function test_allows_base64_encoded_values_in_env_example(): void
@@ -248,10 +245,7 @@ ENV;
         $result = $analyzer->analyze();
 
         // Should not flag base64 values as real credentials
-        $issues = $result->getIssues();
-        foreach ($issues as $issue) {
-            $this->assertNotEquals(Severity::High, $issue->severity);
-        }
+        $this->assertPassed($result);
     }
 
     public function test_allows_stripe_test_keys_in_env_example(): void
@@ -269,10 +263,7 @@ ENV;
         $result = $analyzer->analyze();
 
         // Stripe test keys are safe to include in .env.example
-        $issues = $result->getIssues();
-        foreach ($issues as $issue) {
-            $this->assertStringNotContainsString('real credentials', $issue->message);
-        }
+        $this->assertPassed($result);
     }
 
     public function test_allows_sandbox_keys_in_env_example(): void
@@ -289,10 +280,7 @@ ENV;
 
         $result = $analyzer->analyze();
 
-        $issues = $result->getIssues();
-        foreach ($issues as $issue) {
-            $this->assertStringNotContainsString('real credentials', $issue->message);
-        }
+        $this->assertPassed($result);
     }
 
     public function test_allows_test_prefixed_bearer_tokens_in_env_example(): void
@@ -309,10 +297,7 @@ ENV;
 
         $result = $analyzer->analyze();
 
-        $issues = $result->getIssues();
-        foreach ($issues as $issue) {
-            $this->assertStringNotContainsString('real credentials', $issue->message);
-        }
+        $this->assertPassed($result);
     }
 
     public function test_allows_short_values_in_env_example(): void
@@ -334,10 +319,7 @@ ENV;
         $result = $analyzer->analyze();
 
         // Short values shouldn't be flagged as real credentials
-        $issues = $result->getIssues();
-        foreach ($issues as $issue) {
-            $this->assertStringNotContainsString('real credentials', $issue->message);
-        }
+        $this->assertPassed($result);
     }
 
     // ==========================================

--- a/tests/Unit/Analyzers/Security/EnvFileSecurityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/EnvFileSecurityAnalyzerTest.php
@@ -477,185 +477,7 @@ GITIGNORE;
     }
 
     // ==========================================
-    // E. Permission Tests (7 tests)
-    // ==========================================
-
-    public function test_passes_when_env_has_600_permissions(): void
-    {
-        $tempDir = $this->createTempDirectory([
-            '.env' => 'APP_KEY=test',
-        ]);
-
-        $envPath = $tempDir.'/.env';
-        chmod($envPath, 0600);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-
-        $result = $analyzer->analyze();
-
-        // Should have only non-permission issues
-        $issues = $result->getIssues();
-        foreach ($issues as $issue) {
-            $this->assertStringNotContainsString('permissions', $issue->message);
-        }
-    }
-
-    public function test_detects_644_permissions_as_critical(): void
-    {
-        $tempDir = $this->createTempDirectory([
-            '.env' => 'APP_KEY=test',
-        ]);
-
-        $envPath = $tempDir.'/.env';
-        chmod($envPath, 0644);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-
-        $result = $analyzer->analyze();
-
-        $this->assertFailed($result);
-        $this->assertHasIssueContaining('permissions', $result);
-        $issues = $result->getIssues();
-
-        // Find the permission issue
-        $permissionIssue = null;
-        foreach ($issues as $issue) {
-            if (str_contains($issue->message, 'permissions')) {
-                $permissionIssue = $issue;
-                break;
-            }
-        }
-
-        $this->assertNotNull($permissionIssue);
-        $this->assertEquals(Severity::Critical, $permissionIssue->severity);
-    }
-
-    public function test_detects_640_permissions_as_medium(): void
-    {
-        $tempDir = $this->createTempDirectory([
-            '.env' => 'APP_KEY=test',
-        ]);
-
-        $envPath = $tempDir.'/.env';
-        chmod($envPath, 0640);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-
-        $result = $analyzer->analyze();
-
-        $this->assertWarning($result);
-        $this->assertHasIssueContaining('permissions', $result);
-        $issues = $result->getIssues();
-
-        // Find the permission issue
-        $permissionIssue = null;
-        foreach ($issues as $issue) {
-            if (str_contains($issue->message, 'permissions')) {
-                $permissionIssue = $issue;
-                break;
-            }
-        }
-
-        $this->assertNotNull($permissionIssue);
-        $this->assertEquals(Severity::Medium, $permissionIssue->severity);
-    }
-
-    public function test_detects_666_permissions_as_critical(): void
-    {
-        $tempDir = $this->createTempDirectory([
-            '.env' => 'APP_KEY=test',
-        ]);
-
-        $envPath = $tempDir.'/.env';
-        chmod($envPath, 0666);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-
-        $result = $analyzer->analyze();
-
-        $this->assertFailed($result);
-        $this->assertHasIssueContaining('permissions', $result);
-        $issues = $result->getIssues();
-
-        $permissionIssue = null;
-        foreach ($issues as $issue) {
-            if (str_contains($issue->message, 'permissions')) {
-                $permissionIssue = $issue;
-                break;
-            }
-        }
-
-        $this->assertNotNull($permissionIssue);
-        $this->assertEquals(Severity::Critical, $permissionIssue->severity);
-    }
-
-    public function test_detects_777_permissions_as_critical(): void
-    {
-        $tempDir = $this->createTempDirectory([
-            '.env' => 'APP_KEY=test',
-        ]);
-
-        $envPath = $tempDir.'/.env';
-        chmod($envPath, 0777);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-
-        $result = $analyzer->analyze();
-
-        $this->assertFailed($result);
-        $this->assertHasIssueContaining('permissions', $result);
-    }
-
-    public function test_skips_permission_check_when_env_does_not_exist(): void
-    {
-        $tempDir = $this->createTempDirectory([]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-
-        $result = $analyzer->analyze();
-
-        // Analyzer should be skipped when nothing exists
-        $this->assertSkipped($result);
-    }
-
-    public function test_detects_660_permissions_as_medium(): void
-    {
-        $tempDir = $this->createTempDirectory([
-            '.env' => 'APP_KEY=test',
-        ]);
-
-        $envPath = $tempDir.'/.env';
-        chmod($envPath, 0660);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-
-        $result = $analyzer->analyze();
-
-        $this->assertWarning($result);
-        $this->assertHasIssueContaining('permissions', $result);
-        $issues = $result->getIssues();
-
-        $permissionIssue = null;
-        foreach ($issues as $issue) {
-            if (str_contains($issue->message, 'permissions')) {
-                $permissionIssue = $issue;
-                break;
-            }
-        }
-
-        $this->assertNotNull($permissionIssue);
-        $this->assertEquals(Severity::Medium, $permissionIssue->severity);
-    }
-
-    // ==========================================
-    // F. shouldRun Tests (6 tests)
+    // E. shouldRun Tests (6 tests)
     // ==========================================
 
     public function test_should_run_when_env_file_exists(): void
@@ -804,36 +626,8 @@ GITIGNORE;
         $this->assertArrayHasKey('missing_pattern', $gitignoreIssue->metadata);
     }
 
-    public function test_permission_issue_has_metadata(): void
-    {
-        $tempDir = $this->createTempDirectory([
-            '.env' => 'APP_KEY=test',
-        ]);
-
-        $envPath = $tempDir.'/.env';
-        chmod($envPath, 0644);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-
-        $result = $analyzer->analyze();
-
-        $issues = $result->getIssues();
-        $permissionIssue = null;
-        foreach ($issues as $issue) {
-            if (str_contains($issue->message, 'permissions')) {
-                $permissionIssue = $issue;
-                break;
-            }
-        }
-
-        $this->assertNotNull($permissionIssue);
-        $this->assertArrayHasKey('permissions', $permissionIssue->metadata);
-        $this->assertArrayHasKey('world_readable', $permissionIssue->metadata);
-    }
-
     // ==========================================
-    // H. Edge Cases (3 tests)
+    // F. Edge Cases (3 tests)
     // ==========================================
 
     public function test_detects_multiple_issues_at_once(): void
@@ -870,9 +664,6 @@ GITIGNORE;
             '.env.example' => $envExample,
             '.gitignore' => $gitignore,
         ]);
-
-        // Set secure permissions
-        chmod($tempDir.'/.env', 0600);
 
         $analyzer = $this->createAnalyzer();
         $analyzer->setBasePath($tempDir);
@@ -959,37 +750,5 @@ ENV;
         $analyzer->setDeploymentPlatform('serverless');
 
         $this->assertFalse($analyzer->shouldRun());
-    }
-
-    // =========================================================================
-    // Docker Skip Tests
-    // =========================================================================
-
-    public function test_skips_env_permissions_check_on_docker(): void
-    {
-        // World-readable .env would normally trigger a Critical permissions issue
-        $tempDir = $this->createTempDirectory([
-            '.env' => "APP_KEY=base64:abc123\n",
-            '.env.example' => "APP_KEY=\n",
-            '.gitignore' => ".env\n",
-        ]);
-
-        chmod($tempDir.'/.env', 0644); // world-readable — would flag without Docker skip
-
-        /** @var EnvFileSecurityAnalyzer $analyzer */
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setDeploymentPlatform('docker');
-
-        // shouldRun() still returns true — other checks (git, public dir, .env.example) are valid
-        $this->assertTrue($analyzer->shouldRun());
-
-        $result = $analyzer->analyze();
-
-        // No permission-related issues — permissions check is skipped in Docker
-        foreach ($result->getIssues() as $issue) {
-            $this->assertStringNotContainsString('permissions', strtolower($issue->message));
-            $this->assertStringNotContainsString('chmod', strtolower($issue->recommendation));
-        }
     }
 }


### PR DESCRIPTION
## Summary

- `EnvFileSecurityAnalyzer` and `FilePermissionsAnalyzer` both checked `.env` file permissions, producing two separate findings for the same problem
- Removed `checkEnvPermissions()` and its four permission-bit constants from `EnvFileSecurityAnalyzer` — `FilePermissionsAnalyzer` already owns this with a more thorough bitwise, multi-stage implementation
- Deleted 9 permission test methods and cleaned up indirect references in 3 other tests
- `EnvFileSecurityAnalyzer` retains its three unique checks: public directory exposure, `.env.example` credential leaks, and git tracking