### PR TITLE
fix: suppress CacheHeaderAnalyzer on Laravel Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.7
+
+### Fixed
+- `CacheHeaderAnalyzer` no longer runs on Laravel Cloud — Cloud manages asset cache headers at the CDN level with no configuration mechanism available to the application, making any finding unactionable; the analyzer now skips with a clear reason rather than reporting a false positive (#185)
+
 ## v1.7.6
 
 ### Fixed

--- a/src/Analyzers/Performance/CacheHeaderAnalyzer.php
+++ b/src/Analyzers/Performance/CacheHeaderAnalyzer.php
@@ -158,6 +158,12 @@ class CacheHeaderAnalyzer extends AbstractAnalyzer
             return false;
         }
 
+        // On Laravel Cloud, asset cache headers are managed by the platform and
+        // cannot be altered. No actionable fix exists, so suppress this check.
+        if ($this->isLaravelCloud()) {
+            return false;
+        }
+
         // Only run if an asset build system is present
         return $this->hasMixManifest() || $this->hasViteManifest();
     }
@@ -169,6 +175,10 @@ class CacheHeaderAnalyzer extends AbstractAnalyzer
             $relevantEnvs = implode(', ', $this->relevantEnvironments ?? []);
 
             return "Not relevant in '{$currentEnv}' environment (only relevant in: {$relevantEnvs})";
+        }
+
+        if ($this->isLaravelCloud()) {
+            return 'Laravel Cloud manages asset cache headers. No configuration is possible.';
         }
 
         return 'No asset build system detected (Laravel Mix or Vite)';
@@ -208,23 +218,13 @@ class CacheHeaderAnalyzer extends AbstractAnalyzer
 
         // Check if we hit the threshold (early bailout)
         $hitThreshold = $this->uncachedAssets->count() >= $this->maxUncachedAssets;
-        $isCloud = $this->isLaravelCloud();
 
-        // On Cloud, assets always receive Cache-Control headers (default: max-age=7200).
-        // The issue is a short-lived cache, not a missing one. Use accurate language.
         $thresholdNote = $hitThreshold
-            ? ($isCloud
-                ? ' Note: Analysis stopped after finding '.$this->maxUncachedAssets.' assets with short-lived cache headers. Additional assets may also need updating.'
-                : ' Note: Analysis stopped after finding '.$this->maxUncachedAssets.' uncached assets to prevent excessive HTTP requests. Additional assets may also be missing headers.')
+            ? ' Note: Analysis stopped after finding '.$this->maxUncachedAssets.' uncached assets to prevent excessive HTTP requests. Additional assets may also be missing headers.'
             : '';
 
-        $message = $isCloud
-            ? 'Compiled assets have short-lived cache headers (Laravel Cloud default: ~2h). Versioned assets should use long-lived caching.'
-            : 'Compiled assets are missing Cache-Control headers or use non-cacheable directives';
-
-        $summary = $isCloud
-            ? sprintf('Found %d asset(s) with short-lived cache headers', $this->uncachedAssets->count())
-            : sprintf('Found %d asset(s) without proper cache headers', $this->uncachedAssets->count());
+        $message = 'Compiled assets are missing Cache-Control headers or use non-cacheable directives';
+        $summary = sprintf('Found %d asset(s) without proper cache headers', $this->uncachedAssets->count());
 
         $issues = [$this->createIssueWithSnippet(
             message: $message,
@@ -479,16 +479,6 @@ class CacheHeaderAnalyzer extends AbstractAnalyzer
     private function buildRecommendation(string $thresholdNote): string
     {
         $assets = $this->formatUncachedAssets();
-
-        if ($this->isLaravelCloud()) {
-            return sprintf(
-                'Compiled assets are missing long-lived cache headers. Uncached assets: %s. '.
-                'Add a middleware that sets "Cache-Control: public, max-age=31536000, immutable" for /build/* '.
-                'requests and register it in bootstrap/app.php.%s',
-                $assets,
-                $thresholdNote
-            );
-        }
 
         return sprintf(
             'Compiled assets are missing long-lived cache headers. Uncached assets: %s. '.

--- a/tests/Unit/Analyzers/Performance/CacheHeaderAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/CacheHeaderAnalyzerTest.php
@@ -1264,56 +1264,18 @@ class CacheHeaderAnalyzerTest extends AnalyzerTestCase
         $this->assertFalse($issues[0]->metadata['hit_threshold']);
     }
 
-    public function test_recommendation_mentions_middleware_on_laravel_cloud(): void
+    public function test_skips_on_laravel_cloud(): void
     {
-        $manifest = json_encode([
-            '/css/app.css' => '/css/app.css?id=abc123',
-        ]);
-
-        $tempDir = $this->createTempDirectory([
-            'public/mix-manifest.json' => $manifest,
-        ]);
+        $manifest = json_encode(['resources/js/app.js' => ['file' => 'assets/app.abc123.js']]);
+        $tempDir = $this->createTempDirectory(['public/build/manifest.json' => $manifest]);
 
         /** @var CacheHeaderAnalyzer $analyzer */
-        $analyzer = $this->createAnalyzer([new Response(200)]);
+        $analyzer = $this->createAnalyzer();
         $analyzer->setPublicPath($tempDir.'/public');
         $analyzer->setDeploymentPlatform('laravel-cloud');
-        $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
-        $recommendation = $result->getIssues()[0]->recommendation;
-
-        $this->assertStringContainsString('middleware', $recommendation);
-        $this->assertStringContainsString('bootstrap/app.php', $recommendation);
-        $this->assertStringContainsString('max-age=31536000, immutable', $recommendation);
-        $this->assertStringNotContainsString('.htaccess', $recommendation);
-    }
-
-    public function test_message_describes_short_lived_headers_on_laravel_cloud(): void
-    {
-        // On Cloud, assets always get Cache-Control headers (default ~2h).
-        // The issue message should say "short-lived", not "missing".
-        $manifest = json_encode([
-            '/css/app.css' => '/css/app.css?id=abc123',
-        ]);
-
-        $tempDir = $this->createTempDirectory([
-            'public/mix-manifest.json' => $manifest,
-        ]);
-
-        /** @var CacheHeaderAnalyzer $analyzer */
-        $analyzer = $this->createAnalyzer([new Response(200)]);
-        $analyzer->setPublicPath($tempDir.'/public');
-        $analyzer->setDeploymentPlatform('laravel-cloud');
-        $result = $analyzer->analyze();
-
-        $this->assertFailed($result);
-        $issue = $result->getIssues()[0];
-
-        $this->assertStringContainsString('short-lived', $issue->message);
-        $this->assertStringNotContainsString('missing', $issue->message);
-        $this->assertStringContainsString('short-lived', $result->getMessage());
-        $this->assertStringNotContainsString('without proper cache headers', $result->getMessage());
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Laravel Cloud manages asset cache headers', $analyzer->getSkipReason());
     }
 
     public function test_recommendation_mentions_web_server_config_on_traditional_servers(): void


### PR DESCRIPTION
## Summary
- `CacheHeaderAnalyzer` now skips entirely on Laravel Cloud — `shouldRun()` returns `false` with the reason: *"Laravel Cloud manages asset cache headers. No configuration is possible."*
- Removed Cloud-specific message, summary, and middleware recommendation branches from `runAnalysis()` and `buildRecommendation()` — these paths were unreachable and based on a wrong assumption that a PHP middleware could override CDN-level headers
- Replaced two Cloud-specific tests (asserting wrong behavior) with a single `test_skips_on_laravel_cloud()` test