### PR TITLE
fix: suppress MissingDatabaseTransactionsAnalyzer false positive for transaction-delegated private methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.8
+
+### Fixed
+- `MissingDatabaseTransactionsAnalyzer` no longer false-positives on private methods exclusively called from within a `DB::transaction()` closure — the analyzer now runs a pre-scan pass over each file to identify which `$this->method()` calls occur inside transaction closures versus outside them; methods called only from within a transaction closure are treated as already protected when their writes are counted, so the "delegate pattern" (an orchestrating method that wraps all work in `DB::transaction()` by calling private helpers) no longer produces spurious findings; methods called from both inside and outside a transaction continue to be flagged as before (#186)
+
 ## v1.7.7
 
 ### Fixed

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -77,7 +77,12 @@ class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
                     continue;
                 }
 
-                $visitor = new TransactionVisitor($this->threshold);
+                $scanner = new TransactionDelegatedMethodScanner;
+                $preScanTraverser = new NodeTraverser;
+                $preScanTraverser->addVisitor($scanner);
+                $preScanTraverser->traverse($ast);
+
+                $visitor = new TransactionVisitor($this->threshold, $scanner->getDelegatedMethods());
                 $traverser = new NodeTraverser;
                 $traverser->addVisitor($visitor);
                 $traverser->traverse($ast);
@@ -184,8 +189,10 @@ class TransactionVisitor extends NodeVisitorAbstract
      */
     private array $ifElseBranchStack = [];
 
+    /** @param array<string, true> $transactionDelegatedMethods */
     public function __construct(
-        private int $threshold
+        private int $threshold,
+        private array $transactionDelegatedMethods = [],
     ) {}
 
     public function enterNode(Node $node): ?Node
@@ -202,7 +209,9 @@ class TransactionVisitor extends NodeVisitorAbstract
             $this->writeOperations = 0;
             $this->writeOperationsInTransaction = 0;
             $this->unprotectedWriteLines = [];
-            $this->transactionDepth = 0;
+            // Start inside a virtual transaction if this method is exclusively called
+            // from within DB::transaction() closures (determined by the pre-scan).
+            $this->transactionDepth = isset($this->transactionDelegatedMethods[$this->currentMethodName]) ? 1 : 0;
             $this->manualTransactionDepth = 0;
             $this->isolatedWrites = 0;
             $this->earlyExitIfDepth = 0;
@@ -640,5 +649,88 @@ class TransactionVisitor extends NodeVisitorAbstract
         }
 
         return $last instanceof Node\Stmt\Return_ || $last instanceof Node\Expr\Throw_;
+    }
+}
+
+/**
+ * Pre-scan visitor that identifies private/protected methods exclusively called
+ * from within DB::transaction() closures in the same class.
+ *
+ * These "transaction-delegated" methods should not be flagged for missing
+ * transaction protection because every execution path runs inside a transaction.
+ */
+class TransactionDelegatedMethodScanner extends NodeVisitorAbstract
+{
+    /** @var array<int, true> File positions of closures passed directly to DB::transaction(). */
+    private array $transactionClosurePositions = [];
+
+    private int $transactionDepth = 0;
+
+    /** @var array<string, true> Method names called from within a transaction closure. */
+    private array $calledInsideTransaction = [];
+
+    /** @var array<string, true> Method names called outside any transaction closure. */
+    private array $calledOutsideTransaction = [];
+
+    public function enterNode(Node $node): ?Node
+    {
+        // Record closures passed directly to DB::transaction().
+        if ($node instanceof Node\Expr\StaticCall
+            && $node->class instanceof Node\Name
+            && $node->class->toString() === 'DB'
+            && $node->name instanceof Node\Identifier
+            && $node->name->toString() === 'transaction'
+            && ! empty($node->args)
+        ) {
+            $firstArg = $node->args[0]->value;
+            if ($firstArg instanceof Node\Expr\Closure || $firstArg instanceof Node\Expr\ArrowFunction) {
+                $this->transactionClosurePositions[$firstArg->getStartFilePos()] = true;
+            }
+        }
+
+        // Track entering a recorded transaction closure.
+        if ($node instanceof Node\Expr\Closure || $node instanceof Node\Expr\ArrowFunction) {
+            if (isset($this->transactionClosurePositions[$node->getStartFilePos()])) {
+                $this->transactionDepth++;
+            }
+        }
+
+        // Collect $this->method() calls and partition by transaction context.
+        if (
+            $node instanceof Node\Expr\MethodCall
+            && $node->var instanceof Node\Expr\Variable
+            && $node->var->name === 'this'
+            && $node->name instanceof Node\Identifier
+        ) {
+            $methodName = $node->name->toString();
+            if ($this->transactionDepth > 0) {
+                $this->calledInsideTransaction[$methodName] = true;
+            } else {
+                $this->calledOutsideTransaction[$methodName] = true;
+            }
+        }
+
+        return null;
+    }
+
+    public function leaveNode(Node $node): ?Node
+    {
+        if ($node instanceof Node\Expr\Closure || $node instanceof Node\Expr\ArrowFunction) {
+            if (isset($this->transactionClosurePositions[$node->getStartFilePos()]) && $this->transactionDepth > 0) {
+                $this->transactionDepth--;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns method names that are called exclusively from within DB::transaction() closures.
+     *
+     * @return array<string, true>
+     */
+    public function getDelegatedMethods(): array
+    {
+        return array_diff_key($this->calledInsideTransaction, $this->calledOutsideTransaction);
     }
 }

--- a/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
@@ -1908,4 +1908,149 @@ PHP;
 
         $this->assertPassed($result);
     }
+
+    public function test_passes_when_writes_in_private_method_called_from_transaction_closure(): void
+    {
+        // Mirrors the UserDeletionService pattern: the orchestrator wraps all
+        // writes in DB::transaction() by delegating to private helper methods.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class UserDeletionService
+{
+    public function delete(User $user): void
+    {
+        DB::transaction(function () use ($user): void {
+            $this->revokeTokens($user);
+            $this->dissolveOwnedTeams($user);
+            $user->delete();
+        });
+    }
+
+    private function revokeTokens(User $user): void
+    {
+        $user->tokens()->delete();
+    }
+
+    private function dissolveOwnedTeams(User $user): void
+    {
+        DB::table('team_members')->whereIn('team_id', [1])->delete();
+        $user->ownedTeams()->delete();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/UserDeletionService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_flags_private_method_with_writes_called_outside_transaction(): void
+    {
+        // When the same helper is called both inside AND outside a transaction,
+        // the analyzer must still flag it — the outside call path is unprotected.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class UserService
+{
+    public function withTransaction(User $user): void
+    {
+        DB::transaction(function () use ($user): void {
+            $this->doWrites($user);
+        });
+    }
+
+    public function withoutTransaction(User $user): void
+    {
+        $this->doWrites($user);
+    }
+
+    private function doWrites(User $user): void
+    {
+        $user->save();
+        $user->tokens()->delete();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/UserService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('database write operation(s) outside transaction protection', $result);
+    }
+
+    public function test_passes_when_multiple_private_helpers_all_delegated(): void
+    {
+        // All private helpers are exclusively called from within the transaction closure.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class UserDeletionService
+{
+    public function delete(User $user): void
+    {
+        DB::transaction(function () use ($user): void {
+            $this->revokeTokens($user);
+            $this->dissolveOwnedTeams($user);
+            $this->anonymizePii($user);
+            $user->delete();
+        });
+    }
+
+    private function revokeTokens(User $user): void
+    {
+        $user->tokens()->delete();
+    }
+
+    private function dissolveOwnedTeams(User $user): void
+    {
+        DB::table('team_members')->whereIn('team_id', [1])->delete();
+        $user->ownedTeams()->delete();
+    }
+
+    private function anonymizePii(User $user): void
+    {
+        $user->update(['name' => 'Deleted', 'email' => 'deleted@invalid']);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/UserDeletionService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
 }


### PR DESCRIPTION
## Summary

- `MissingDatabaseTransactionsAnalyzer` was false-positiving on private methods that contain multiple writes but are exclusively called from within a `DB::transaction()` closure (the "delegate pattern")
- Adds a lightweight `TransactionDelegatedMethodScanner` pre-scan visitor that partitions `$this->method()` call sites into "inside a transaction closure" vs. "outside" — methods in the former set only are treated as already protected during the main analysis pass
- Methods called from both inside and outside a transaction continue to be flagged; the suppression is strictly scoped to call sites that are always transactional
- 3 new tests covering: the exact delegate pattern, the mixed call-site case (must still flag), and multiple helpers all delegated from one closure