### PR TITLE
fix: correct two false-negative detection gaps in HSTSHeaderAnalyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.9
+
+### Fixed
+- `HSTSHeaderAnalyzer` no longer false-negatives when a middleware file contains a comment referencing HSTS (e.g. `// HSTS configuration`) without actually setting the header — only the presence of `Strict-Transport-Security` in file content is treated as evidence the header is set; previously any mention of the string `HSTS` suppressed the missing-header finding
+- `HSTSHeaderAnalyzer` no longer false-negatives when a security package such as `bepsvpt/secure-headers` appears only in `require-dev` — `composer.json` is now decoded and only the `require` section is checked; a dev-only package provides no HSTS protection in production
+
 ## v1.7.8
 
 ### Fixed

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -51,14 +51,7 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
-        // Check if app is configured for HTTPS
-        $isHttpsOnly = $this->isHttpsOnlyApp();
-
-        if (! $isHttpsOnly) {
-            return false;
-        }
-
-        return true;
+        return $this->isHttpsOnlyApp();
     }
 
     public function getSkipReason(): string
@@ -230,8 +223,7 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
                 }
 
                 // Check for HSTS header configuration
-                if (str_contains($content, 'Strict-Transport-Security') ||
-                    str_contains($content, 'HSTS')) {
+                if (str_contains($content, 'Strict-Transport-Security')) {
                     $hasHSTSMiddleware = true;
 
                     // Validate HSTS configuration
@@ -390,7 +382,13 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
             return false;
         }
 
-        // Check for packages that handle security headers
+        $composerData = json_decode($content, true);
+
+        if (! is_array($composerData) || ! isset($composerData['require']) || ! is_array($composerData['require'])) {
+            return false;
+        }
+
+        // Check for packages that handle security headers (production dependencies only)
         $securityPackages = [
             'bepsvpt/secure-headers',
             'spatie/laravel-csp',
@@ -398,7 +396,7 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
         ];
 
         foreach ($securityPackages as $package) {
-            if (str_contains($content, $package)) {
+            if (array_key_exists($package, $composerData['require'])) {
                 return true;
             }
         }

--- a/tests/Unit/Analyzers/Security/HSTSHeaderAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/HSTSHeaderAnalyzerTest.php
@@ -336,7 +336,7 @@ PHP;
         $this->assertPassed($result);
     }
 
-    public function test_detects_hsts_from_hsts_keyword(): void
+    public function test_hsts_comment_does_not_suppress_missing_hsts_issue(): void
     {
         $sessionConfig = <<<'PHP'
 <?php
@@ -372,9 +372,10 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // Should pass because HSTS keyword is found (even though not properly configured)
-        // The validation tests below check for proper configuration
-        $this->assertPassed($result);
+        // A comment mentioning HSTS does not mean the header is actually set —
+        // the analyzer must still report missing HSTS.
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('missing HSTS', $result);
     }
 
     public function test_fails_when_https_app_missing_hsts(): void
@@ -952,6 +953,40 @@ JSON;
         $result = $analyzer->analyze();
 
         $this->assertPassed($result);
+    }
+
+    public function test_security_package_in_require_dev_does_not_suppress_missing_hsts(): void
+    {
+        $sessionConfig = <<<'PHP'
+<?php
+
+return [
+    'secure' => true,
+];
+PHP;
+
+        $composerJson = <<<'JSON'
+{
+    "require": {},
+    "require-dev": {
+        "bepsvpt/secure-headers": "^7.0"
+    }
+}
+JSON;
+
+        $tempDir = $this->createTempDirectory([
+            'config/session.php' => $sessionConfig,
+            'composer.json' => $composerJson,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        // A dev-only security package provides no HSTS in production.
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('missing HSTS', $result);
     }
 
     public function test_fails_with_security_package_but_has_issues(): void


### PR DESCRIPTION
## Summary

- `HSTSHeaderAnalyzer` no longer false-negatives when a middleware file contains a comment referencing HSTS (e.g. `// HSTS configuration`) without actually setting the header — only `Strict-Transport-Security` is treated as evidence the header is set
- `HSTSHeaderAnalyzer` no longer false-negatives when a security package such as `bepsvpt/secure-headers` appears only in `require-dev` — `composer.json` is now decoded and only the `require` section is checked; a dev-only package provides no HSTS protection in production
- `shouldRun()` simplified to `return $this->isHttpsOnlyApp()`
- Two new tests added covering both scenarios; `test_detects_hsts_from_hsts_keyword` updated to assert the correct (failure) behaviour