### PR TITLE
fix: correct FrontendVulnerableDependencyAnalyzer npm v7+ title extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.10
+
+### Fixed
+- `FrontendVulnerableDependencyAnalyzer` now correctly reports vulnerability titles when running against projects using npm v7+ — npm audit v2 format stores advisory details (`title`, `url`, `severity`, `range`, `cves`) inside each vulnerability's `via` array as objects rather than at the top level; the analyzer was passing the raw vulnerability object to `createFrontendVulnerabilityIssue()` which found no `title` key and fell back to "Known security vulnerability"; `parseNpmAuditResults()` now iterates `via` entries and merges each advisory object with the parent vulnerability before creating the issue, so titles such as "ip-address has XSS in Address6 HTML-emitting methods" are correctly surfaced; `via` entries that are strings (transitive dependencies — packages affected only because they depend on a vulnerable package) are no longer reported as separate issues, eliminating the duplicate "Known security vulnerability" entries for packages like `express-rate-limit` that carry no direct advisory
+- `Reporter::streamResult()` now shows the individual issue message for single issues at file-only locations (no line number) — previously, issue messages were only rendered below the location line when multiple issues shared the same location; for lock files such as `package-lock.json` and `yarn.lock` the location alone ("At package-lock.json") carries no meaningful context, and the message is the only identifier of which package is affected; the condition is now `count > 1 || location->line === null`, so file:line locations (e.g. `app/Http/Controllers/Foo.php:42`) continue to display without a redundant message indent for single issues, while file-only locations always show the `→ message` line
+
 ## v1.7.9
 
 ### Fixed

--- a/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
@@ -345,8 +345,33 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
         // Check for vulnerabilities in the result (npm v7+)
         if (isset($results['vulnerabilities']) && is_array($results['vulnerabilities'])) {
             foreach ($results['vulnerabilities'] as $package => $vulnerability) {
-                if (is_string($package) && is_array($vulnerability)) {
+                if (! is_string($package) || ! is_array($vulnerability)) {
+                    continue;
+                }
+
+                $via = isset($vulnerability['via']) && is_array($vulnerability['via'])
+                    ? $vulnerability['via']
+                    : [];
+
+                $createdAny = false;
+
+                foreach ($via as $viaItem) {
+                    if (is_array($viaItem)) {
+                        // npm v7+: advisory details (title, url, severity, range, cves) live inside via entries
+                        $merged = array_merge($vulnerability, $viaItem);
+                        $this->createFrontendVulnerabilityIssue($package, $merged, $issues, $packageLock);
+                        $createdAny = true;
+                    }
+                    // string entries mean a transitive dependency — skip, the root package is reported separately
+                }
+
+                // Fallback for old / non-standard format with no via key at all
+                if (! $createdAny && $via === []) {
                     $this->createFrontendVulnerabilityIssue($package, $vulnerability, $issues, $packageLock);
+                    $createdAny = true;
+                }
+
+                if ($createdAny) {
                     $detailedIssuesCreated = true;
                 }
             }

--- a/tests/Unit/Analyzers/Security/FrontendVulnerableDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FrontendVulnerableDependencyAnalyzerTest.php
@@ -753,6 +753,178 @@ TEXT;
         $this->assertNotEmpty($result->getMessage());
     }
 
+    // ==================== npm v7+ Parsing Tests ====================
+
+    public function test_npm_v7_extracts_title_from_via_advisory_object(): void
+    {
+        $analyzer = $this->createAnalyzer();
+
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('parseNpmAuditResults');
+        $method->setAccessible(true);
+
+        $issues = [];
+
+        $results = [
+            'vulnerabilities' => [
+                'ip-address' => [
+                    'name' => 'ip-address',
+                    'severity' => 'moderate',
+                    'isDirect' => false,
+                    'via' => [
+                        [
+                            'source' => 1117683,
+                            'name' => 'ip-address',
+                            'dependency' => 'ip-address',
+                            'title' => 'ip-address has XSS in Address6 HTML-emitting methods',
+                            'url' => 'https://github.com/advisories/GHSA-v2v4-37r5-5v8g',
+                            'severity' => 'moderate',
+                            'range' => '<=10.1.0',
+                        ],
+                    ],
+                    'range' => '<=10.1.0',
+                    'fixAvailable' => true,
+                ],
+            ],
+        ];
+
+        $method->invokeArgs($analyzer, [$results, &$issues, 'package-lock.json']);
+
+        $this->assertCount(1, $issues);
+        $issue = reset($issues);
+        $this->assertNotFalse($issue);
+        $this->assertStringContainsString('ip-address has XSS in Address6 HTML-emitting methods', $issue->message);
+    }
+
+    public function test_npm_v7_skips_transitive_only_vulnerabilities(): void
+    {
+        $analyzer = $this->createAnalyzer();
+
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('parseNpmAuditResults');
+        $method->setAccessible(true);
+
+        $issues = [];
+
+        $results = [
+            'vulnerabilities' => [
+                'express-rate-limit' => [
+                    'name' => 'express-rate-limit',
+                    'severity' => 'moderate',
+                    'isDirect' => false,
+                    'via' => ['ip-address'], // strings only — transitive effect
+                    'range' => '8.0.1 - 8.5.0',
+                    'fixAvailable' => true,
+                ],
+            ],
+        ];
+
+        $method->invokeArgs($analyzer, [$results, &$issues, 'package-lock.json']);
+
+        $this->assertCount(0, $issues);
+    }
+
+    public function test_npm_v7_multiple_via_advisories_create_multiple_issues(): void
+    {
+        $analyzer = $this->createAnalyzer();
+
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('parseNpmAuditResults');
+        $method->setAccessible(true);
+
+        $issues = [];
+
+        $results = [
+            'vulnerabilities' => [
+                'some-package' => [
+                    'name' => 'some-package',
+                    'severity' => 'high',
+                    'via' => [
+                        [
+                            'source' => 1001,
+                            'title' => 'First vulnerability',
+                            'severity' => 'high',
+                        ],
+                        [
+                            'source' => 1002,
+                            'title' => 'Second vulnerability',
+                            'severity' => 'moderate',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $method->invokeArgs($analyzer, [$results, &$issues, 'package-lock.json']);
+
+        $this->assertCount(2, $issues);
+    }
+
+    public function test_npm_v7_falls_back_when_no_via(): void
+    {
+        $analyzer = $this->createAnalyzer();
+
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('parseNpmAuditResults');
+        $method->setAccessible(true);
+
+        $issues = [];
+
+        $results = [
+            'vulnerabilities' => [
+                'old-package' => [
+                    'name' => 'old-package',
+                    'severity' => 'high',
+                    'title' => 'Old format title',
+                    // no 'via' key
+                ],
+            ],
+        ];
+
+        $method->invokeArgs($analyzer, [$results, &$issues, 'package-lock.json']);
+
+        $this->assertCount(1, $issues);
+        $issue = reset($issues);
+        $this->assertNotFalse($issue);
+        $this->assertStringContainsString('Old format title', $issue->message);
+    }
+
+    public function test_npm_v7_advisory_url_included_in_metadata(): void
+    {
+        $analyzer = $this->createAnalyzer();
+
+        $reflection = new \ReflectionClass($analyzer);
+        $method = $reflection->getMethod('parseNpmAuditResults');
+        $method->setAccessible(true);
+
+        $issues = [];
+
+        $results = [
+            'vulnerabilities' => [
+                'ip-address' => [
+                    'name' => 'ip-address',
+                    'severity' => 'moderate',
+                    'via' => [
+                        [
+                            'source' => 1117683,
+                            'title' => 'ip-address has XSS in Address6 HTML-emitting methods',
+                            'url' => 'https://github.com/advisories/GHSA-v2v4-37r5-5v8g',
+                            'severity' => 'moderate',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $method->invokeArgs($analyzer, [$results, &$issues, 'package-lock.json']);
+
+        $this->assertCount(1, $issues);
+        $issue = reset($issues);
+        $this->assertNotFalse($issue);
+        $this->assertArrayHasKey('advisory_url', $issue->metadata);
+        $this->assertStringContainsString('GHSA-v2v4-37r5-5v8g', $issue->metadata['advisory_url']);
+    }
+
     // ==================== Helper Methods ====================
 
     /**


### PR DESCRIPTION
## Summary

- npm audit v2 format (npm v7+) stores advisory details inside each vulnerability's `via` array as objects rather than at the top level — `parseNpmAuditResults()` was passing the raw vulnerability object to `createFrontendVulnerabilityIssue()`, which found no `title` key and fell back to "Known security vulnerability"
- `parseNpmAuditResults()` now iterates `via` entries and merges each advisory object with the parent vulnerability before creating the issue, so titles such as "ip-address has XSS in Address6 HTML-emitting methods" are correctly surfaced
- `via` entries that are plain strings (transitive dependencies — packages affected only because they depend on a vulnerable package) are skipped, eliminating duplicate "Known security vulnerability" entries