### PR TITLE
fix: show issue message for single issues at file-only locations in Reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.10
+
+### Fixed
+- `FrontendVulnerableDependencyAnalyzer` now correctly reports vulnerability titles when running against projects using npm v7+ — npm audit v2 format stores advisory details (`title`, `url`, `severity`, `range`, `cves`) inside each vulnerability's `via` array as objects rather than at the top level; the analyzer was passing the raw vulnerability object to `createFrontendVulnerabilityIssue()` which found no `title` key and fell back to "Known security vulnerability"; `parseNpmAuditResults()` now iterates `via` entries and merges each advisory object with the parent vulnerability before creating the issue, so titles such as "ip-address has XSS in Address6 HTML-emitting methods" are correctly surfaced; `via` entries that are strings (transitive dependencies — packages affected only because they depend on a vulnerable package) are no longer reported as separate issues, eliminating the duplicate "Known security vulnerability" entries for packages like `express-rate-limit` that carry no direct advisory
+- `Reporter::streamResult()` now shows the individual issue message for single issues at file-only locations (no line number) — previously, issue messages were only rendered below the location line when multiple issues shared the same location; for lock files such as `package-lock.json` and `yarn.lock` the location alone ("At package-lock.json") carries no meaningful context, and the message is the only identifier of which package is affected; the condition is now `count > 1 || location->line === null`, so file:line locations (e.g. `app/Http/Controllers/Foo.php:42`) continue to display without a redundant message indent for single issues, while file-only locations always show the `→ message` line
+
 ## v1.7.9
 
 ### Fixed

--- a/src/Support/Reporter.php
+++ b/src/Support/Reporter.php
@@ -828,8 +828,11 @@ class Reporter implements ReporterInterface
                         $output[] = $this->color($locationText, 'magenta');
                     }
 
-                    // If multiple issues at same location, show their messages indented
-                    if (count($locationIssues) > 1 && $firstIssue->location !== null) {
+                    // Show individual messages when grouped (multiple at same location) or
+                    // when the location has no line number (e.g. package-lock.json) and
+                    // the message carries the only meaningful detail
+                    if ($firstIssue->location !== null &&
+                        (count($locationIssues) > 1 || $firstIssue->location->line === null)) {
                         foreach ($locationIssues as $issue) {
                             $output[] = $this->color("  → {$issue->message}", 'gray');
                         }

--- a/tests/Unit/Support/ReporterTest.php
+++ b/tests/Unit/Support/ReporterTest.php
@@ -538,6 +538,59 @@ class ReporterTest extends TestCase
     }
 
     #[Test]
+    public function stream_result_shows_message_for_single_issue_without_line_number(): void
+    {
+        // File-only locations (e.g. package-lock.json) are not self-descriptive —
+        // the message must be shown so the user knows which package is affected
+        $result = new AnalysisResult(
+            analyzerId: 'test-analyzer',
+            status: Status::Failed,
+            message: 'Found 1 frontend dependency security issue',
+            issues: [
+                new Issue(
+                    message: 'Frontend package "ip-address" has a known vulnerability: ip-address has XSS in Address6 HTML-emitting methods',
+                    location: new Location('package-lock.json'),
+                    severity: Severity::Medium,
+                    recommendation: 'Update package "ip-address" to a patched version',
+                ),
+            ],
+            executionTime: 0.1,
+            metadata: ['name' => 'Frontend Vulnerable Dependencies Analyzer'],
+        );
+
+        $output = $this->reporter->streamResult($result, 1, 1, 'Security');
+
+        $this->assertStringContainsString('ip-address has XSS in Address6 HTML-emitting methods', $output);
+        $this->assertStringContainsString('Update package "ip-address" to a patched version', $output);
+    }
+
+    #[Test]
+    public function stream_result_does_not_show_message_for_single_issue_with_line_number(): void
+    {
+        // File:line locations are already specific — no need to repeat the message for a single issue
+        $result = new AnalysisResult(
+            analyzerId: 'test-analyzer',
+            status: Status::Failed,
+            message: 'Found 1 silent failure',
+            issues: [
+                new Issue(
+                    message: 'Catching Exception is overly broad',
+                    location: new Location('app/Http/Controllers/UserController.php', 42),
+                    severity: Severity::Medium,
+                    recommendation: 'Catch specific exception types',
+                ),
+            ],
+            executionTime: 0.1,
+            metadata: ['name' => 'Silent Failure Analyzer'],
+        );
+
+        $output = $this->reporter->streamResult($result, 1, 1, 'Security');
+
+        $this->assertStringContainsString('app/Http/Controllers/UserController.php', $output);
+        $this->assertStringNotContainsString('→ Catching Exception is overly broad', $output);
+    }
+
+    #[Test]
     public function stream_result_groups_issues_at_same_location(): void
     {
         $result = new AnalysisResult(


### PR DESCRIPTION
## Summary

- `Reporter::streamResult()` was only rendering the indented `→ message` line when multiple issues shared the same location
- For lock files such as `package-lock.json` the location line alone ("At package-lock.json") carries no meaningful context — the message is the only identifier of which package is affected
- The condition is now `count > 1 || location->line === null`: file:line locations (e.g. `app/Http/Controllers/Foo.php:42`) continue to display without a redundant message indent for single issues, while file-only locations always show the arrow message line