### PR TITLE
fix: remove redundant severity labels from analyzer message strings

### DIFF
--- a/src/Analyzers/Security/CsrfAnalyzer.php
+++ b/src/Analyzers/Security/CsrfAnalyzer.php
@@ -389,7 +389,7 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
                 foreach ($exceptions as $exception) {
                     if ($exception === '*' || $exception === '/*') {
                         $issues[] = $this->createIssueWithSnippet(
-                            message: 'Critical: All routes excluded from CSRF protection with wildcard',
+                            message: 'All routes excluded from CSRF protection with wildcard',
                             filePath: $middlewarePath,
                             lineNumber: $lineNumber + 1,
                             severity: Severity::Critical,
@@ -595,7 +595,7 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
                 // If use() method was found but ValidateCsrfToken wasn't in it
                 if (! $hasValidateCsrfTokenInUse) {
                     $issues[] = $this->createIssueWithSnippet(
-                        message: 'Critical: ValidateCsrfToken missing from global middleware stack',
+                        message: 'ValidateCsrfToken missing from global middleware stack',
                         filePath: $file,
                         lineNumber: $useMethodStartLine + 1,
                         severity: Severity::Critical,
@@ -622,7 +622,7 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
 
                     if (preg_match('/ValidateCsrfToken/', $lines[$i])) {
                         $issues[] = $this->createIssueWithSnippet(
-                            message: 'Critical: ValidateCsrfToken removed from web middleware group',
+                            message: 'ValidateCsrfToken removed from web middleware group',
                             filePath: $file,
                             lineNumber: $lineNumber + 1,
                             severity: Severity::Critical,
@@ -648,7 +648,7 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
             // - validateCsrfTokens(except: ['*'])
             if (preg_match('/validateCsrfTokens\s*\(\s*except\s*:\s*\[\s*[\'\"]\*[\'\"]\s*\]/', $line)) {
                 $issues[] = $this->createIssueWithSnippet(
-                    message: 'Critical: All routes excluded from CSRF protection in bootstrap/app.php',
+                    message: 'All routes excluded from CSRF protection in bootstrap/app.php',
                     filePath: $file,
                     lineNumber: $lineNumber + 1,
                     severity: Severity::Critical,
@@ -665,7 +665,7 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
             // Check for $middleware->remove(ValidateCsrfToken::class) - older approach
             if (preg_match('/\$middleware\s*->\s*remove\s*\(\s*.*ValidateCsrfToken/', $line)) {
                 $issues[] = $this->createIssueWithSnippet(
-                    message: 'Critical: ValidateCsrfToken middleware has been removed',
+                    message: 'ValidateCsrfToken middleware has been removed',
                     filePath: $file,
                     lineNumber: $lineNumber + 1,
                     severity: Severity::Critical,

--- a/src/Analyzers/Security/FilePermissionsAnalyzer.php
+++ b/src/Analyzers/Security/FilePermissionsAnalyzer.php
@@ -210,7 +210,7 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
         // Check 2: World-readable on critical files (CRITICAL - for sensitive files)
         if ($isCritical && $this->isWorldReadable($permissions['raw'])) {
             $issues[] = $this->createIssue(
-                message: sprintf('Critical file "%s" is world-readable (permissions: %s)', $relativePath, $permissions['octal']),
+                message: sprintf('Sensitive file "%s" is world-readable (permissions: %s)', $relativePath, $permissions['octal']),
                 location: new Location($relativePath),
                 severity: Severity::Critical,
                 recommendation: sprintf(
@@ -272,7 +272,7 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
         // Check 4: Group-writable on critical files (Medium severity)
         if ($isCritical && $this->isGroupWritable($permissions['raw'])) {
             $issues[] = $this->createIssue(
-                message: sprintf('Critical file "%s" is group-writable (permissions: %s)', $relativePath, $permissions['octal']),
+                message: sprintf('Sensitive file "%s" is group-writable (permissions: %s)', $relativePath, $permissions['octal']),
                 location: new Location($relativePath),
                 severity: Severity::Medium,
                 recommendation: sprintf(

--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -260,7 +260,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                 // guarded = []
                 $issues[] = $this->createIssueWithSnippet(
                     message: sprintf(
-                        'Critical: Model "%s" uses $guarded = [] which allows unrestricted mass assignment',
+                        'Model "%s" uses $guarded = [] which allows unrestricted mass assignment',
                         $modelName
                     ),
                     filePath: $file,
@@ -289,7 +289,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 
             $issues[] = $this->createIssueWithSnippet(
                 message: sprintf(
-                    'Critical: "%s" (%s) is fillable in model "%s" - this allows users to impersonate others',
+                    '"%s" (%s) is fillable in model "%s" - this allows users to impersonate others',
                     $fieldName,
                     $relationship,
                     $modelName

--- a/src/Analyzers/Security/XssAnalyzer.php
+++ b/src/Analyzers/Security/XssAnalyzer.php
@@ -228,7 +228,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
                     $rawBladeMatched = true;
 
                     $issues[] = $this->createIssueWithSnippet(
-                        message: 'Critical XSS: Unescaped blade output with possible user input',
+                        message: 'Unescaped blade output with possible user input',
                         filePath: $file,
                         lineNumber: $lineNumber + 1,
                         severity: Severity::Critical,
@@ -239,7 +239,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
                 // Check for echo with superglobals
                 if (preg_match('/echo\s+\$_(GET|POST|REQUEST|COOKIE)/', $line)) {
                     $issues[] = $this->createIssueWithSnippet(
-                        message: 'Critical XSS: Direct echo of superglobal without escaping',
+                        message: 'Direct echo of superglobal without escaping',
                         filePath: $file,
                         lineNumber: $lineNumber + 1,
                         severity: Severity::Critical,
@@ -299,7 +299,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
                         : Severity::High;
 
                     $issues[] = $this->createIssueWithSnippet(
-                        message: $isJsString ? 'Critical XSS: User input injected into JavaScript string context' : 'Potential XSS: User data injected into JavaScript without proper encoding',
+                        message: $isJsString ? 'User input injected into JavaScript string context' : 'Potential XSS: User data injected into JavaScript without proper encoding',
                         filePath: $file,
                         lineNumber: $lineNumber + 1,
                         severity: $severity,
@@ -352,7 +352,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
 
                 if ($this->containsSuperglobalAst($expr, $nodeFinder)) {
                     $issues[] = $this->createIssueWithSnippet(
-                        message: 'Critical XSS: Direct echo of superglobal without escaping',
+                        message: 'Direct echo of superglobal without escaping',
                         filePath: $file,
                         lineNumber: $echoNode->getStartLine(),
                         severity: Severity::Critical,
@@ -691,8 +691,8 @@ class XssAnalyzer extends AbstractFileAnalyzer
                 $hasUserInput = $this->mightContainUserInput($line);
                 $issues[] = $this->createIssueWithSnippet(
                     message: $hasUserInput
-                        ? 'Critical XSS: javascript: protocol with user input in HTML attribute'
-                        : 'High: javascript: protocol with executable code in HTML attribute',
+                        ? 'javascript: protocol with user input in HTML attribute'
+                        : 'javascript: protocol with executable code in HTML attribute',
                     filePath: $file,
                     lineNumber: $lineNumber + 1,
                     severity: $hasUserInput ? Severity::Critical : Severity::High,
@@ -704,7 +704,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
         // Check for data: protocol with user input (Critical - can execute JavaScript)
         if (preg_match('/(?:href|src)\s*=\s*["\']?\s*data:/i', $line) && $this->mightContainUserInput($line)) {
             $issues[] = $this->createIssueWithSnippet(
-                message: 'Critical XSS: data: protocol with user input in HTML attribute',
+                message: 'data: protocol with user input in HTML attribute',
                 filePath: $file,
                 lineNumber: $lineNumber + 1,
                 severity: Severity::Critical,
@@ -723,7 +723,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
             // Check for event handlers with Blade output or user input
             if (preg_match('/'.$handler.'\s*=\s*["\'][^"\']*(\{\{|\{!!|\$_|request\()/i', $line)) {
                 $issues[] = $this->createIssueWithSnippet(
-                    message: "Critical XSS: User input in {$handler} event handler attribute",
+                    message: "User input in {$handler} event handler attribute",
                     filePath: $file,
                     lineNumber: $lineNumber + 1,
                     severity: Severity::Critical,
@@ -742,7 +742,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
                 // Skip if user input is properly URL-encoded
                 if (! $this->isUrlSafeContext($hrefValue)) {
                     $issues[] = $this->createIssueWithSnippet(
-                        message: 'High: User input in href attribute without URL validation',
+                        message: 'User input in href attribute without URL validation',
                         filePath: $file,
                         lineNumber: $lineNumber + 1,
                         severity: Severity::High,
@@ -761,7 +761,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
                 // Skip if user input is properly URL-encoded
                 if (! $this->isUrlSafeContext($srcValue)) {
                     $issues[] = $this->createIssueWithSnippet(
-                        message: 'High: User input in src attribute without validation',
+                        message: 'User input in src attribute without validation',
                         filePath: $file,
                         lineNumber: $lineNumber + 1,
                         severity: Severity::High,
@@ -774,7 +774,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
         // Check for user input in data-* attributes (Medium - can be exploited in some contexts)
         if (preg_match('/data-[a-z0-9_-]+\s*=\s*["\'][^"\']*(\{!!)/i', $line)) {
             $issues[] = $this->createIssueWithSnippet(
-                message: 'Medium: Unescaped user input in data-* attribute',
+                message: 'Unescaped user input in data-* attribute',
                 filePath: $file,
                 lineNumber: $lineNumber + 1,
                 severity: Severity::Medium,

--- a/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
@@ -816,7 +816,6 @@ PHP;
         $result = $analyzer->analyze();
 
         $issue = $result->getIssues()[0];
-        $this->assertStringContainsString('Critical', $issue->message);
         $this->assertStringContainsString('user_id', $issue->message);
         $this->assertStringContainsString('impersonate', $issue->message);
     }


### PR DESCRIPTION
## Summary

- Removes 22 severity label prefixes (`Critical:`, `High:`, `Medium:`, `Critical XSS:`) embedded in `createIssue`/`createIssueWithSnippet` message strings across four analyzers — severity is already expressed via the typed `Severity` enum and embedding it again in prose risks the two drifting out of sync
- Renames `"Critical file"` → `"Sensitive file"` in `FilePermissionsAnalyzer` where the word described the file type (not the issue severity), causing a misleading mismatch (`severity: Severity::Medium` on that path)
- Removes one test assertion that was checking for the word `"Critical"` in a message string rather than inspecting the structured `severity` field

**Files changed:** `CsrfAnalyzer`, `XssAnalyzer`, `FilePermissionsAnalyzer`, `FillableForeignKeyAnalyzer` + one test file