### PR TITLE
fix: stop flagging third-party ::create() calls as missing DB transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.11
+
+### Fixed
+- `CsrfAnalyzer`, `XssAnalyzer`, `FilePermissionsAnalyzer`, and `FillableForeignKeyAnalyzer` no longer embed severity as a text prefix in issue message strings (e.g. `"Critical: All routes excluded..."` → `"All routes excluded..."`) — severity is already expressed via the typed `Severity` enum on each issue and rendered separately by the output layer; embedding it again as a prefix created redundancy and risked the text label drifting out of sync with the enum value; 22 prefixes removed; `FilePermissionsAnalyzer` also renames `"Critical file"` to `"Sensitive file"` where the word described the file sensitivity tier rather than the finding's severity level — that check carries `Severity::Medium`, making `"Critical file"` a misleading mismatch (#190)
+- `MissingDatabaseTransactionsAnalyzer` no longer false-positives on third-party static `::create()` calls — non-Eloquent classes that expose a factory method of the same name were incorrectly counted as database write operations; static write-method calls are now validated against Eloquent model ancestry via PHP reflection (full inheritance chain including vendor parents), an AST parent-chain registry built from project files (up to 3 levels), and namespace heuristics as a fallback (#191)
+
 ## v1.7.10
 
 ### Fixed

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -65,6 +65,24 @@ class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
 
         $phpFiles = $this->getPhpFiles();
 
+        // Phase 0: Build Eloquent model registry from all project PHP files.
+        $modelScanner = new EloquentModelScanner;
+        foreach ($phpFiles as $file) {
+            try {
+                $ast = $this->parser->parseFile($file);
+                if (empty($ast)) {
+                    continue;
+                }
+                $ast = $this->parser->resolveNames($ast, ['replaceNodes' => false]);
+                $registryTraverser = new NodeTraverser;
+                $registryTraverser->addVisitor($modelScanner);
+                $registryTraverser->traverse($ast);
+            } catch (\Throwable) {
+                continue;
+            }
+        }
+        $classParents = $modelScanner->getParents();
+
         foreach ($phpFiles as $file) {
             // Skip test and development files
             if ($this->isTestFile($file) || $this->isDevelopmentFile($file)) {
@@ -77,12 +95,14 @@ class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
                     continue;
                 }
 
+                $ast = $this->parser->resolveNames($ast, ['replaceNodes' => false]);
+
                 $scanner = new TransactionDelegatedMethodScanner;
                 $preScanTraverser = new NodeTraverser;
                 $preScanTraverser->addVisitor($scanner);
                 $preScanTraverser->traverse($ast);
 
-                $visitor = new TransactionVisitor($this->threshold, $scanner->getDelegatedMethods());
+                $visitor = new TransactionVisitor($this->threshold, $scanner->getDelegatedMethods(), $classParents);
                 $traverser = new NodeTraverser;
                 $traverser->addVisitor($visitor);
                 $traverser->traverse($ast);
@@ -189,10 +209,14 @@ class TransactionVisitor extends NodeVisitorAbstract
      */
     private array $ifElseBranchStack = [];
 
-    /** @param array<string, true> $transactionDelegatedMethods */
+    /**
+     * @param  array<string, true>  $transactionDelegatedMethods
+     * @param  array<string, string|null>  $classParents
+     */
     public function __construct(
         private int $threshold,
         private array $transactionDelegatedMethods = [],
+        private array $classParents = [],
     ) {}
 
     public function enterNode(Node $node): ?Node
@@ -591,6 +615,10 @@ class TransactionVisitor extends NodeVisitorAbstract
                     'upsert', 'updateOrInsert', 'updateOrCreate', 'firstOrCreate',
                 ];
                 if (in_array($method, $writeMethods, true)) {
+                    if ($node->class instanceof Node\Name && ! $this->isLikelyDatabaseClass($node->class)) {
+                        return false;
+                    }
+
                     return true;
                 }
             }
@@ -625,6 +653,62 @@ class TransactionVisitor extends NodeVisitorAbstract
         }
 
         return false;
+    }
+
+    /**
+     * Returns true if the class Name likely descends from Illuminate\Database\Eloquent\Model.
+     *
+     * Three-tier strategy:
+     * 1. Reflection (class_exists + is_a) — accurate when the Laravel autoloader is active.
+     * 2. AST parent registry — follows up to 3 levels for project-file classes.
+     * 3. Namespace heuristics — fallback for test contexts where model files are not
+     *    present in the scanned directory and the autoloader cannot resolve them.
+     */
+    private function isLikelyDatabaseClass(Node\Name $name): bool
+    {
+        $resolvedName = $name->getAttribute('resolvedName');
+
+        if (! ($resolvedName instanceof Node\Name\FullyQualified)) {
+            return true; // Cannot resolve FQN — assume may be a model (conservative)
+        }
+
+        $fqn = ltrim($resolvedName->toString(), '\\');
+
+        if (! str_contains($fqn, '\\')) {
+            return true; // Unnamespaced class — conservative
+        }
+
+        $eloquentBase = 'Illuminate\\Database\\Eloquent\\Model';
+
+        // Tier 1: reflection covers the full hierarchy in one call (project + vendor)
+        if (class_exists($fqn, false) || class_exists($fqn)) {
+            return is_a($fqn, $eloquentBase, true);
+        }
+
+        // Tier 2: AST registry — follow parent chain up to 3 levels
+        $current = $fqn;
+        for ($depth = 0; $depth < 3; $depth++) {
+            if ($current === $eloquentBase) {
+                return true;
+            }
+
+            if (! array_key_exists($current, $this->classParents)) {
+                break; // Not in registry — fall through to heuristics
+            }
+
+            $parent = $this->classParents[$current];
+            if ($parent === null) {
+                break;
+            }
+
+            $current = $parent;
+        }
+
+        // Tier 3: namespace heuristics — catches App\Models\* and *\Models\* patterns
+        // (handles test contexts where models are not in the scanned temp directory)
+        return str_starts_with($fqn, 'App\\Models\\')
+            || str_starts_with($fqn, 'App\\Model\\')
+            || str_contains($fqn, '\\Models\\');
     }
 
     /**
@@ -732,5 +816,52 @@ class TransactionDelegatedMethodScanner extends NodeVisitorAbstract
     public function getDelegatedMethods(): array
     {
         return array_diff_key($this->calledInsideTransaction, $this->calledOutsideTransaction);
+    }
+}
+
+/**
+ * Pre-scan that records every class's direct parent FQN from AST.
+ *
+ * Requires NameResolver to have run first so that resolvedName attributes
+ * and namespacedName are populated on class and name nodes.
+ */
+class EloquentModelScanner extends NodeVisitorAbstract
+{
+    /** @var array<string, string|null> class FQN → parent FQN (null if no parent) */
+    private array $parents = [];
+
+    public function enterNode(Node $node): ?Node
+    {
+        if (! ($node instanceof Node\Stmt\Class_)) {
+            return null;
+        }
+
+        // NameResolver sets namespacedName on class definitions
+        $namespacedName = $node->getAttribute('namespacedName');
+        $className = $namespacedName instanceof Node\Name
+            ? $namespacedName->toString()
+            : $node->name?->toString();
+
+        if ($className === null) {
+            return null;
+        }
+
+        $parentFqn = null;
+        if ($node->extends !== null) {
+            $resolved = $node->extends->getAttribute('resolvedName');
+            $parentFqn = $resolved instanceof Node\Name\FullyQualified
+                ? ltrim($resolved->toString(), '\\')
+                : ltrim($node->extends->toString(), '\\');
+        }
+
+        $this->parents[$className] = $parentFqn;
+
+        return null;
+    }
+
+    /** @return array<string, string|null> */
+    public function getParents(): array
+    {
+        return $this->parents;
     }
 }

--- a/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
@@ -2053,4 +2053,44 @@ PHP;
 
         $this->assertPassed($result);
     }
+
+    public function test_passes_with_third_party_static_create_calls(): void
+    {
+        // Spatie\Sitemap\Tags\Url and Spatie\Sitemap\Sitemap are not Eloquent models.
+        // Multiple ::create() calls on them must not trigger the missing-transaction warning.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers\Marketing;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Response;
+use Spatie\Sitemap\Sitemap;
+use Spatie\Sitemap\Tags\Url;
+
+class SitemapController extends Controller
+{
+    public function __invoke(): Response
+    {
+        $sitemap = Sitemap::create()
+            ->add(Url::create('/')->setPriority(1.0)->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY))
+            ->add(Url::create('/features')->setPriority(0.9)->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY))
+            ->add(Url::create('/pricing')->setPriority(0.9)->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY))
+            ->add(Url::create('/changelog')->setPriority(0.7)->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY));
+
+        return response($sitemap->render(), 200, ['Content-Type' => 'application/xml']);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Http/Controllers/Marketing/SitemapController.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
 }


### PR DESCRIPTION
## Summary

- `MissingDatabaseTransactionsAnalyzer` was treating any static call whose method name appeared in the write-methods list (e.g. `create`, `update`) as a database write, regardless of the calling class — causing false positives on third-party classes like `Spatie\Sitemap\Tags\Url::create()`
- Added `EloquentModelScanner` pre-scan (Phase 0) that builds a parent-chain registry from all project PHP files using PHP-Parser's `NameResolver` with `replaceNodes => false`
- Added `isLikelyDatabaseClass()` to `TransactionVisitor` using a three-tier strategy: reflection → AST registry (up to 3 levels) → namespace heuristics (`App\Models\*`, `*\Models\*`)
- Added regression test reproducing the exact `SitemapController` false positive