### PR TITLE
fix: SilentFailureAnalyzer no longer flags empty catch blocks with explanatory comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.12
+
+### Fixed
+- `SilentFailureAnalyzer` no longer false-positives on empty catch blocks that contain an explanatory comment — previously the comment text had to match a hardcoded keyword list; `isIntentionalIgnoreComment()` is removed and `hasExplanatoryComment()` now passes on any comment with non-empty content, treating its presence as sufficient evidence of a deliberate choice; bare `//` markers with no text continue to be flagged
+
 ## v1.7.11
 
 ### Fixed

--- a/src/Analyzers/BestPractices/SilentFailureAnalyzer.php
+++ b/src/Analyzers/BestPractices/SilentFailureAnalyzer.php
@@ -406,31 +406,24 @@ class SilentFailureVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * Check if the catch block has an explanatory comment indicating intentional empty catch.
-     * Only considers comments that appear to explicitly justify the empty catch block.
+     * Check if the catch block has a non-empty comment — evidence the developer made a deliberate choice.
      */
     private function hasExplanatoryComment(Node\Stmt\Catch_ $catch): bool
     {
-        $allComments = [];
+        $allComments = $catch->getComments();
 
-        // Collect comments attached to the catch node
-        $allComments = array_merge($allComments, $catch->getComments());
-
-        // Collect comments inside the catch block (attached to Nop statements)
         foreach ($catch->stmts as $stmt) {
             if ($stmt instanceof Node\Stmt\Nop) {
                 $allComments = array_merge($allComments, $stmt->getComments());
             }
         }
 
-        // Collect comments from attributes
         /** @var array<Comment> $attributes */
         $attributes = $catch->getAttribute('comments', []);
         $allComments = array_merge($allComments, $attributes);
 
-        // Check if any comment indicates intentional ignoring
         foreach ($allComments as $comment) {
-            if ($this->isIntentionalIgnoreComment($comment->getText())) {
+            if ($this->commentHasContent($comment->getText())) {
                 return true;
             }
         }
@@ -438,56 +431,20 @@ class SilentFailureVisitor extends NodeVisitorAbstract
         return false;
     }
 
-    /**
-     * Check if a comment text indicates intentional exception ignoring.
-     */
-    private function isIntentionalIgnoreComment(string $commentText): bool
+    private function commentHasContent(string $text): bool
     {
-        $lowerText = strtolower($commentText);
-
-        // Bug 4: Tightened patterns - removed vague 'expected' and 'acceptable'
-        // Added more specific patterns instead
-        $intentionalPatterns = [
-            'intentional',
-            'intentionally',
-            'deliberately',
-            'on purpose',
-            'expected to fail',      // More specific than 'expected'
-            'expected exception',    // More specific than 'expected'
-            'safe to ignore',
-            'safely ignore',
-            'safely ignored',
-            'can be ignored',
-            'may be ignored',
-            'optional',
-            'not critical',
-            'non-critical',
-            'best effort',
-            'best-effort',
-            'fire and forget',
-            'fire-and-forget',
-            'no action needed',
-            'no action required',
-            'nothing to do',
-            'noop',
-            'no-op',
-            '@suppress',
-            '@ignore',
-            'phpstan-ignore',
-            'psalm-suppress',
-            'swallow',
-            'don\'t care',
-            'doesn\'t matter',
-            'not important',
-        ];
-
-        foreach ($intentionalPatterns as $pattern) {
-            if (str_contains($lowerText, $pattern)) {
-                return true;
-            }
+        if (str_starts_with($text, '//')) {
+            return trim(substr($text, 2)) !== '';
         }
 
-        return false;
+        if (str_starts_with($text, '#')) {
+            return trim(substr($text, 1)) !== '';
+        }
+
+        // Block comments: strip /* ... */ markers
+        $inner = preg_replace('/^\/\*+|\*+\/$/', '', $text);
+
+        return trim($inner ?? '') !== '';
     }
 
     /**

--- a/tests/Unit/Analyzers/BestPractices/SilentFailureAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/SilentFailureAnalyzerTest.php
@@ -534,7 +534,6 @@ class MultiService
         try {
             // Do something
         } catch (\Exception $e) {
-            // Silent failure 1
         }
     }
 
@@ -543,7 +542,6 @@ class MultiService
         try {
             // Do something else
         } catch (\Exception $e) {
-            // Silent failure 2
         }
     }
 }
@@ -609,7 +607,6 @@ class ImportService
         try {
             // Import data
         } catch (\Exception $e) {
-            // Do nothing
         }
     }
 }
@@ -1142,7 +1139,6 @@ class RegularService
         try {
             // Regular code
         } catch (\Exception $e) {
-            // This should be flagged as silent failure
         }
     }
 }
@@ -1812,7 +1808,6 @@ class DataService
         try {
             $this->parse($data);
         } catch (\RuntimeException|\InvalidArgumentException $e) {
-            // Neither type is whitelisted, should be flagged
         }
     }
 }
@@ -1919,8 +1914,6 @@ class WarningService
         try {
             $this->doWork();
         } catch (ModelNotFoundException|\RuntimeException $e) {
-            // Partial whitelist warning should be issued
-            // But empty catch body should ALSO be flagged
         }
     }
 }
@@ -3192,6 +3185,37 @@ PHP;
     // BUG 4: COMMENT PATTERN TESTS
     // ========================================================================
 
+    public function test_fails_when_empty_catch_has_bare_comment_marker(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class ChangelogSyncService
+{
+    public function fetchTag(): void
+    {
+        try {
+            $this->fetchCommit();
+        } catch (\RuntimeException $e) {
+            //
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/ChangelogSyncService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+    }
+
     public function test_fails_with_vague_acceptable_comment(): void
     {
         $code = <<<'PHP'
@@ -3220,8 +3244,8 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // 'acceptable' alone is too vague - should be flagged
-        $this->assertFailed($result);
+        // any comment signals deliberate intent
+        $this->assertPassed($result);
     }
 
     public function test_fails_with_vague_expected_comment(): void
@@ -3252,8 +3276,39 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // 'expected' alone is too vague - should be flagged
-        $this->assertFailed($result);
+        // any comment signals deliberate intent
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_when_empty_catch_has_skip_comment(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class ChangelogSyncService
+{
+    public function fetchTag(): void
+    {
+        try {
+            $this->fetchCommit();
+        } catch (\RuntimeException $e) {
+            // Skip tags whose commit cannot be fetched; date falls back to now() in parser.
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/ChangelogSyncService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
     }
 
     public function test_passes_with_expected_exception_comment(): void
@@ -3550,7 +3605,6 @@ class SilentService
         try {
             $this->doWork();
         } catch (\Exception $e) {
-            // Completely empty — no logging, no fallback, nothing
         }
     }
 }


### PR DESCRIPTION
## Summary

- Removes the hardcoded keyword list (`intentional`, `safe to ignore`, `swallow`, etc.) from `hasExplanatoryComment()` — the list was inherently incomplete and kept producing false positives on valid natural-language phrasings
- Any comment with non-empty content now suppresses the empty-catch warning; bare `//` markers with no text are still flagged
- `isIntentionalIgnoreComment()` deleted entirely; replaced by `commentHasContent()` which strips comment delimiters (`//`, `#`, `/* */`) and checks for non-whitespace content