### PR TITLE
fix: restrict XssAnalyzer HTTP header checks to production/staging environments

### DIFF
--- a/src/Analyzers/Security/XssAnalyzer.php
+++ b/src/Analyzers/Security/XssAnalyzer.php
@@ -138,17 +138,19 @@ class XssAnalyzer extends AbstractFileAnalyzer
         $staticIssues = $this->analyzeCodePatterns();
         $issues = array_merge($issues, $staticIssues);
 
-        // PART 2: HTTP Header Analysis (production only)
-        if (! $this->skipHttpChecks) {
+        // PART 2: HTTP Header Analysis (production/staging only, non-CI)
+        $headersVerified = false;
+        if (! $this->skipHttpChecks && $this->isHttpCheckEnvironment() && ! $this->isApiOnlyApp()) {
             $headerIssues = $this->analyzeHttpHeaders();
             $issues = array_merge($issues, $headerIssues);
+            $headersVerified = true;
         }
 
         if (empty($issues)) {
             return $this->passed(
-                $this->skipHttpChecks
-                    ? 'No XSS vulnerabilities detected in code'
-                    : 'No XSS vulnerabilities detected (code and headers verified)'
+                $headersVerified
+                    ? 'No XSS vulnerabilities detected (code and headers verified)'
+                    : 'No XSS vulnerabilities detected in code'
             );
         }
 
@@ -803,6 +805,10 @@ class XssAnalyzer extends AbstractFileAnalyzer
             return [];
         }
 
+        if (! $this->isHttpCheckEnvironment()) {
+            return [];
+        }
+
         $issues = [];
 
         // Try to find a guest URL to check
@@ -887,6 +893,21 @@ class XssAnalyzer extends AbstractFileAnalyzer
         } catch (Throwable) {
             return false; // Can't inspect → assume web app to avoid missing real issues
         }
+    }
+
+    /**
+     * Check if the current environment warrants live HTTP header checks.
+     *
+     * HTTP header checks (CSP validation) are only meaningful in environments
+     * where the full infrastructure stack is deployed. Uses the inherited
+     * getEnvironment() so shieldci.environment_mapping is applied transparently.
+     */
+    private function isHttpCheckEnvironment(): bool
+    {
+        $current = $this->getEnvironment();
+
+        return strcasecmp($current, 'production') === 0
+            || strcasecmp($current, 'staging') === 0;
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
@@ -42,6 +42,12 @@ class XssAnalyzerTest extends AnalyzerTestCase
      */
     protected function createAnalyzerWithHttpMock(array $responses): XssAnalyzer
     {
+        // HTTP checks only run in production/staging — default to production for HTTP header tests.
+        // Individual tests can override app.env after calling this helper if needed.
+        if (config('app.env') === 'testing') {
+            config(['app.env' => 'production']);
+        }
+
         $appUrl = config('app.url');
         if ($appUrl && is_string($appUrl)) {
             /** @phpstan-ignore-next-line */
@@ -520,6 +526,7 @@ BLADE;
     public function test_skips_csp_check_for_api_only_app(): void
     {
         config(['app.url' => 'https://api.example.com']);
+        config(['app.env' => 'production']); // Ensure env gate is not the reason for skipping
         config(['shieldci.ci_mode' => false]);
 
         $tempDir = $this->createTempDirectory(['test.blade.php' => '<div>{{ $safe }}</div>']);
@@ -572,6 +579,7 @@ BLADE;
     {
         config(['app.url' => 'http://localhost']);
         config(['shieldci.guest_url' => '/']);
+        config(['app.env' => 'production']); // Ensure env gate is not the reason for skipping
         config(['shieldci.ci_mode' => false]);
 
         $tempDir = $this->createTempDirectory(['test.blade.php' => '<div>{{ $safe }}</div>']);
@@ -606,6 +614,91 @@ BLADE;
 
         // Should not fail due to network error
         $this->assertPassed($result);
+    }
+
+    // ==========================================
+    // Environment Gate Tests
+    // ==========================================
+
+    public function test_skips_http_check_in_local_environment(): void
+    {
+        config(['app.url' => 'https://example.com']);
+        config(['shieldci.guest_url' => '/']);
+        config(['app.env' => 'local']);
+        config(['shieldci.ci_mode' => false]);
+
+        $tempDir = $this->createTempDirectory(['test.blade.php' => '<div>{{ $safe }}</div>']);
+
+        /** @var XssAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false); // Web app, but env gate should still skip
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertStringContainsString('in code', $result->getMessage());
+    }
+
+    public function test_skips_http_check_in_testing_environment(): void
+    {
+        config(['app.url' => 'https://example.com']);
+        config(['shieldci.guest_url' => '/']);
+        config(['app.env' => 'testing']);
+        config(['shieldci.ci_mode' => false]);
+
+        $tempDir = $this->createTempDirectory(['test.blade.php' => '<div>{{ $safe }}</div>']);
+
+        /** @var XssAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setStatelessOverride(false);
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertStringContainsString('in code', $result->getMessage());
+    }
+
+    public function test_runs_http_check_in_staging_environment(): void
+    {
+        config(['app.url' => 'https://staging.example.com']);
+        config(['shieldci.guest_url' => '/']);
+        config(['shieldci.ci_mode' => false]);
+
+        $responses = [
+            new Response(200, [], '<html></html>'), // No CSP header
+        ];
+
+        $analyzer = $this->createAnalyzerWithHttpMock($responses);
+        config(['app.env' => 'staging']); // Override after helper sets 'production'
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('Content-Security-Policy header not set', $result);
+    }
+
+    public function test_runs_http_check_for_custom_environment_mapped_to_production(): void
+    {
+        config(['app.url' => 'https://example.com']);
+        config(['shieldci.guest_url' => '/']);
+        config(['shieldci.ci_mode' => false]);
+        config(['shieldci.environment_mapping' => ['production-us' => 'production']]);
+
+        $responses = [
+            new Response(200, [], '<html></html>'), // No CSP header
+        ];
+
+        $analyzer = $this->createAnalyzerWithHttpMock($responses);
+        config(['app.env' => 'production-us']); // Maps to 'production' via environment_mapping
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('Content-Security-Policy header not set', $result);
     }
 
     // ==========================================


### PR DESCRIPTION
## Summary

- Adds `isHttpCheckEnvironment()` to `XssAnalyzer` that gates live HTTP CSP checks to `production` and `staging` environments, eliminating false-positive "CSP header not set" reports for developers using non-localhost URLs (Docker, Valet `.test`, ngrok)
- Uses the inherited `getEnvironment()` from `AbstractAnalyzer` — consistent with `$relevantEnvironments` across other analyzers and transparent to `shieldci.environment_mapping` (e.g. `production-us` → `production`)
- Fixes the pass message to accurately reflect whether HTTP headers were actually verified, rather than relying solely on the `ci_mode` flag
- Adds 4 new tests: local and testing environments skip the HTTP check; staging runs it; custom environment names resolved via `environment_mapping` run it