### PR TITLE
fix: restrict EnvHttpAccessibilityAnalyzer HTTP checks to production/staging

### DIFF
--- a/src/Analyzers/Security/EnvHttpAccessibilityAnalyzer.php
+++ b/src/Analyzers/Security/EnvHttpAccessibilityAnalyzer.php
@@ -83,6 +83,11 @@ class EnvHttpAccessibilityAnalyzer extends AbstractAnalyzer
 
     public function shouldRun(): bool
     {
+        // HTTP accessibility checks only apply in deployed environments
+        if (! $this->isHttpCheckEnvironment()) {
+            return false;
+        }
+
         // Only run if we can find a guest route to test from
         $url = $this->findLoginRoute();
 
@@ -100,14 +105,25 @@ class EnvHttpAccessibilityAnalyzer extends AbstractAnalyzer
 
     public function getSkipReason(): string
     {
+        if (! $this->isHttpCheckEnvironment()) {
+            return sprintf('HTTP accessibility checks only run in production/staging (current: %s)', $this->getEnvironment());
+        }
+
         $url = $this->findLoginRoute();
 
         if ($url === null) {
             return 'No guest URL found for HTTP accessibility check';
         }
 
-        // Otherwise, provide specific reason about localhost URLs
         return 'Skipped for localhost URLs (local development environment)';
+    }
+
+    private function isHttpCheckEnvironment(): bool
+    {
+        $current = $this->getEnvironment();
+
+        return strcasecmp($current, 'production') === 0
+            || strcasecmp($current, 'staging') === 0;
     }
 
     protected function runAnalysis(): ResultInterface

--- a/tests/Unit/Analyzers/Security/EnvHttpAccessibilityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/EnvHttpAccessibilityAnalyzerTest.php
@@ -25,6 +25,12 @@ class EnvHttpAccessibilityAnalyzerTest extends AnalyzerTestCase
      */
     protected function createAnalyzer(array $responses = []): EnvHttpAccessibilityAnalyzer
     {
+        // HTTP checks only run in production/staging — default to production for these tests.
+        // Individual tests can override app.env after calling this helper if needed.
+        if (config('app.env') === 'testing') {
+            config(['app.env' => 'production']);
+        }
+
         // Force URL root to respect app.url config in tests
         // This is needed because Orchestra Testbench doesn't automatically
         // configure the URL generator from app.url
@@ -836,7 +842,7 @@ ENV;
 
         $this->assertFalse($analyzer->shouldRun());
         $reason = $analyzer->getSkipReason();
-        // When no URL is configured, findLoginRoute() falls back to url('/') which is localhost
+        // With production env set, the env gate passes; findLoginRoute() falls back to url('/') which is localhost
         $this->assertStringContainsString('localhost', $reason);
     }
 
@@ -849,5 +855,34 @@ ENV;
         $reason = $analyzer->getSkipReason();
         $this->assertStringContainsString('localhost', $reason);
         $this->assertStringContainsString('local development', $reason);
+    }
+
+    public function test_skips_when_environment_is_local(): void
+    {
+        config(['app.url' => 'https://example.com']);
+        $analyzer = $this->createAnalyzer();
+        config(['app.env' => 'local']); // Override after helper sets 'production'
+
+        $this->assertFalse($analyzer->shouldRun());
+    }
+
+    public function test_skips_when_environment_is_testing(): void
+    {
+        config(['app.url' => 'https://example.com']);
+        $analyzer = $this->createAnalyzer();
+        config(['app.env' => 'testing']); // Override after helper sets 'production'
+
+        $this->assertFalse($analyzer->shouldRun());
+    }
+
+    public function test_get_skip_reason_for_non_production_environment(): void
+    {
+        config(['app.url' => 'https://example.com']);
+        $analyzer = $this->createAnalyzer();
+        config(['app.env' => 'local']); // Override after helper sets 'production'
+
+        $reason = $analyzer->getSkipReason();
+        $this->assertStringContainsString('production/staging', $reason);
+        $this->assertStringContainsString('local', $reason);
     }
 }


### PR DESCRIPTION
## Summary

- Same false-positive pattern identified in #193 (XssAnalyzer): the `.env` HTTP accessibility check was running in all non-CI environments, firing Critical alerts for developers whose local web server (Docker, Valet `.test`) serves `.env` files at their dev URL
- Adds `isHttpCheckEnvironment()` using the inherited `getEnvironment()`, consistent with the pattern from #193 and transparent to `shieldci.environment_mapping`
- Gates via `shouldRun()` (correct for this analyzer — prevents it appearing in output entirely) with a matching `getSkipReason()` message
- Adds 3 new tests: local and testing environments skip; skip reason message is accurate for non-production environments