### PR TITLE
fix: inspect $force argument in URL::forceHttps() to prevent false positives

### DIFF
--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Security;
 
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Scalar\String_;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
@@ -166,10 +167,26 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
             }
         }
 
-        // Check for URL::forceHttps()
+        // Check for URL::forceHttps() — inspect the $force argument to avoid false positives
+        // when forceHttps(false) is used to explicitly disable HTTPS enforcement.
         $forceHttpsCallNodes = $astParser->findStaticCalls($ast, 'URL', 'forceHttps');
 
-        if ($forceHttpsCallNodes !== []) {
+        foreach ($forceHttpsCallNodes as $call) {
+            /** @var StaticCall $call */
+
+            // No argument → default $force = true → HTTPS is forced
+            if (empty($call->args)) {
+                return true;
+            }
+
+            $firstArg = $call->args[0]->value;
+
+            // Explicit false → HTTPS is NOT forced; skip this call
+            if ($firstArg instanceof ConstFetch && strtolower((string) $firstArg->name) === 'false') {
+                continue;
+            }
+
+            // Explicit true, variable, or expression → HTTPS is (conditionally) forced
             return true;
         }
 

--- a/tests/Unit/Analyzers/Security/HSTSHeaderAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/HSTSHeaderAnalyzerTest.php
@@ -293,6 +293,99 @@ PHP;
         $this->assertHasIssueContaining('HSTS', $result);
     }
 
+    public function test_force_https_with_false_argument_is_not_detected_as_https_only(): void
+    {
+        $provider = <<<'PHP'
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\URL;
+
+class AppServiceProvider
+{
+    public function boot(): void
+    {
+        URL::forceHttps(false);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Providers/AppServiceProvider.php' => $provider,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertSkipped($result);
+    }
+
+    public function test_force_https_with_true_argument_is_detected_as_https_only(): void
+    {
+        $provider = <<<'PHP'
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\URL;
+
+class AppServiceProvider
+{
+    public function boot(): void
+    {
+        URL::forceHttps(true);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Providers/AppServiceProvider.php' => $provider,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('HSTS', $result);
+    }
+
+    public function test_force_https_with_variable_argument_is_detected_as_https_only(): void
+    {
+        $provider = <<<'PHP'
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\URL;
+
+class AppServiceProvider
+{
+    public function boot(): void
+    {
+        $shouldForce = app()->isProduction() || app()->environment('staging');
+        URL::forceHttps($shouldForce);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Providers/AppServiceProvider.php' => $provider,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('HSTS', $result);
+    }
+
     // ============================================
     // HSTS Middleware Detection Tests
     // ============================================


### PR DESCRIPTION
## Summary

- `URL::forceHttps(false)` explicitly disables HTTPS enforcement, but `hasForceHttpsInServiceProvider()` was treating any call to `forceHttps()` as HTTPS-only — regardless of the `$force` argument
- This caused false positives: apps that call `URL::forceHttps(false)` (e.g. to disable HTTPS in development) would incorrectly trigger HSTS checks
- The fix iterates over call nodes and skips those where the first argument is a literal `false` `ConstFetch`, mirroring the existing `URL::forceScheme()` check which already inspects its argument
- No-arg calls (default `$force = true`), `forceHttps(true)`, and variable/expression args (e.g. `forceHttps($shouldForce)`) continue to be treated as HTTPS-only

## Changes

- `src/Analyzers/Security/HSTSHeaderAnalyzer.php` — replace early-return forceHttps block with argument-aware loop; add `ConstFetch` import
- `tests/Unit/Analyzers/Security/HSTSHeaderAnalyzerTest.php` — add three new tests covering `forceHttps(false)`, `forceHttps(true)`, and `forceHttps($variable)`