### PR TITLE
fix: prevent PHPStanAnalyzer timeout on Vapor/Lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.14
+
+### Fixed
+- `PHPStanAnalyzer` no longer times out on Laravel Vapor / AWS Lambda — `PHPStanRunner` now emits `parallel.maximumNumberOfProcesses: 1` in the generated NEON config when `PlatformDetector::isServerless()` is true; PHPStan 2.x spawns up to 32 worker processes by default and each one cold-loads PHPStan + Larastan from Lambda's read-only filesystem, exhausting memory and I/O before analysis completes; `tmpDir` is now always written to `sys_get_temp_dir() . '/phpstan'` so PHPStan's result cache does not attempt writes to the read-only `/var/task` tree; the PHPStan subprocess timeout now reads from `shieldci.timeout` (default 300 s) so it can be set below Vapor's `cli-timeout`, giving the catch block time to return a clean error result before Lambda terminates the container
+
 ## v1.7.13
 
 ### Fixed

--- a/src/Analyzers/Reliability/PHPStanAnalyzer.php
+++ b/src/Analyzers/Reliability/PHPStanAnalyzer.php
@@ -305,9 +305,12 @@ class PHPStanAnalyzer extends AbstractFileAnalyzer
         // Filter categories
         $activeCategories = array_values(array_diff($enabledCategories, $disabledCategories));
 
+        $timeoutConfig = $this->config->get('shieldci.timeout', 300);
+        $timeout = is_int($timeoutConfig) ? $timeoutConfig : 300;
+
         try {
             // Run PHPStan once on all paths
-            $runner->analyze($paths, $level);
+            $runner->analyze($paths, $level, $timeout);
 
             // Categorize all issues
             $categorizedIssues = $this->categorizeIssues($runner, $activeCategories);

--- a/src/Support/PHPStanRunner.php
+++ b/src/Support/PHPStanRunner.php
@@ -6,6 +6,7 @@ namespace ShieldCI\Support;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use ShieldCI\AnalyzersCore\Support\PlatformDetector;
 use Symfony\Component\Process\Process;
 
 /**
@@ -59,7 +60,7 @@ class PHPStanRunner
      * @param  string|array<string>  $paths
      * @return $this
      */
-    public function analyze(string|array $paths, int $level = 5): self
+    public function analyze(string|array $paths, int $level = 5, int $timeout = 300): self
     {
         $paths = is_array($paths) ? $paths : [$paths];
 
@@ -85,7 +86,7 @@ class PHPStanRunner
 
             // Run PHPStan
             $process = new Process($command, $this->basePath);
-            $process->setTimeout(300); // 5 minutes timeout
+            $process->setTimeout($timeout);
             $process->run();
 
             // Parse JSON output
@@ -161,6 +162,11 @@ class PHPStanRunner
     /**
      * Build NEON config string from includes and parameters.
      *
+     * In serverless environments (Lambda, Cloud Functions), PHPStan's parallel
+     * worker processes are constrained to 1 to avoid memory exhaustion and
+     * cold-start I/O bottlenecks from spawning multiple PHP processes on
+     * ephemeral container filesystems.
+     *
      * @param  array<string>  $includes
      */
     private function buildNeonConfig(array $includes, int $level): string
@@ -177,6 +183,12 @@ class PHPStanRunner
 
         $lines[] = 'parameters:';
         $lines[] = '    level: '.$level;
+        $lines[] = '    tmpDir: '.sys_get_temp_dir().'/phpstan';
+
+        if (PlatformDetector::isServerless()) {
+            $lines[] = '    parallel:';
+            $lines[] = '        maximumNumberOfProcesses: 1';
+        }
 
         return implode("\n", $lines);
     }

--- a/tests/Unit/Support/PHPStanRunnerTest.php
+++ b/tests/Unit/Support/PHPStanRunnerTest.php
@@ -7,6 +7,7 @@ namespace ShieldCI\Tests\Unit\Support;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ShieldCI\Support\PHPStanRunner;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 
 class PHPStanRunnerTest extends TestCase
 {
@@ -600,6 +601,71 @@ BASH;
         $firstIssue = $issues->first();
         $this->assertNotNull($firstIssue);
         $this->assertEquals('Real issue', $firstIssue['message']);
+    }
+
+    public function test_config_always_includes_tmpdir(): void
+    {
+        $this->createMockPHPStanWithConfigCapture();
+
+        $runner = new PHPStanRunner($this->tempDir);
+        $runner->analyze(['app']);
+
+        $capturedConfig = $this->getCapturedConfig();
+
+        $this->assertStringContainsString('tmpDir:', $capturedConfig);
+    }
+
+    public function test_config_includes_parallel_limit_when_running_in_serverless(): void
+    {
+        $this->createMockPHPStanWithConfigCapture();
+
+        putenv('AWS_LAMBDA_FUNCTION_NAME=test-function');
+        try {
+            $runner = new PHPStanRunner($this->tempDir);
+            $runner->analyze(['app']);
+        } finally {
+            putenv('AWS_LAMBDA_FUNCTION_NAME');
+        }
+
+        $capturedConfig = $this->getCapturedConfig();
+
+        $this->assertStringContainsString('maximumNumberOfProcesses: 1', $capturedConfig);
+    }
+
+    public function test_config_does_not_include_parallel_limit_outside_serverless(): void
+    {
+        $saved = getenv('AWS_LAMBDA_FUNCTION_NAME');
+        putenv('AWS_LAMBDA_FUNCTION_NAME');
+
+        $this->createMockPHPStanWithConfigCapture();
+
+        try {
+            $runner = new PHPStanRunner($this->tempDir);
+            $runner->analyze(['app']);
+        } finally {
+            if ($saved !== false) {
+                putenv("AWS_LAMBDA_FUNCTION_NAME={$saved}");
+            }
+        }
+
+        $capturedConfig = $this->getCapturedConfig();
+
+        $this->assertStringNotContainsString('maximumNumberOfProcesses', $capturedConfig);
+    }
+
+    public function test_analyze_respects_custom_timeout(): void
+    {
+        $vendorBinDir = $this->tempDir.'/vendor/bin';
+        mkdir($vendorBinDir, 0755, true);
+
+        // Mock that sleeps 3 seconds — longer than our 1s timeout
+        file_put_contents($vendorBinDir.'/phpstan', "#!/bin/bash\nsleep 3\n");
+        chmod($vendorBinDir.'/phpstan', 0755);
+
+        $this->expectException(ProcessTimedOutException::class);
+
+        $runner = new PHPStanRunner($this->tempDir);
+        $runner->analyze(['app'], 5, 1); // 1-second timeout
     }
 
     /**


### PR DESCRIPTION
## Summary

- `PHPStanRunner` now emits `parallel.maximumNumberOfProcesses: 1` in the generated NEON config when `PlatformDetector::isServerless()` is true — PHPStan 2.x spawns up to 32 worker processes by default; on Lambda each worker cold-loads PHPStan + Larastan from the SquashFS filesystem, exhausting memory and I/O before analysis completes within the 15-minute ceiling
- `PHPStanRunner` now always sets `tmpDir` to `sys_get_temp_dir() . '/phpstan'` — prevents PHPStan's result cache from attempting writes to the read-only `/var/task` tree
- `PHPStanRunner::analyze()` gains a `$timeout` parameter; `PHPStanAnalyzer` reads it from `shieldci.timeout` so it can be set below Vapor's `cli-timeout`, giving the catch block time to return a clean error before Lambda hard-kills the container
- Uses `PlatformDetector::isServerless()` from `analyzers-core` (not `isLaravelVapor()`) so the parallel constraint applies only during actual Lambda execution, not when the project is analyzed locally or in CI