### PR TITLE
fix: prevent UpToDateDependencyAnalyzer false positive on Vapor and Laravel Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.15
+
+### Fixed
+- `UpToDateDependencyAnalyzer` no longer false-positives on Laravel Vapor, serverless, and Laravel Cloud — `composer.lock` is generated on the developer's machine but the dry-run executes on a different OS with different PHP extensions, causing Composer to report platform-specific packages as needing updates; `--ignore-platform-reqs` is now passed to the dry-run on these platforms so only version-constraint differences are evaluated; real outdated dependencies continue to be detected correctly
+
 ## v1.7.14
 
 ### Fixed

--- a/src/Analyzers/Security/UpToDateDependencyAnalyzer.php
+++ b/src/Analyzers/Security/UpToDateDependencyAnalyzer.php
@@ -10,6 +10,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\DetectsDeploymentPlatform;
 use ShieldCI\Support\Composer;
 
 /**
@@ -26,6 +27,8 @@ use ShieldCI\Support\Composer;
  */
 class UpToDateDependencyAnalyzer extends AbstractAnalyzer
 {
+    use DetectsDeploymentPlatform;
+
     /**
      * Patterns indicating Composer is performing operations (updates available).
      * These are more reliable than looking for "nothing to" messages because:
@@ -114,6 +117,17 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
             // OPTIMIZATION: Run composer install --dry-run only ONCE.
             // Scope matches whatever was installed: full deps or production-only.
             $dryRunOptions = $devPackagesInstalled ? [] : ['--no-dev'];
+
+            // On managed cloud platforms (Vapor, Laravel Cloud), the composer.lock is generated
+            // on the developer's machine (e.g., macOS) but the dry-run executes on a different
+            // OS (Amazon Linux, managed Linux containers) with different PHP extensions and
+            // platform requirements. Without this flag, Composer reports platform-specific
+            // packages as needing updates even when version constraints are fully satisfied —
+            // a false positive unique to cross-platform deployments.
+            if ($this->isVaporOrServerless() || $this->isLaravelCloud()) {
+                $dryRunOptions[] = '--ignore-platform-reqs';
+            }
+
             $allDepsOutput = $this->composer->installDryRun($dryRunOptions);
 
             // EARLY EXIT: If everything is up-to-date, no need for further parsing

--- a/tests/Unit/Analyzers/Security/UpToDateDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/UpToDateDependencyAnalyzerTest.php
@@ -764,6 +764,145 @@ OUTPUT;
         $this->assertStringNotContainsString('development', strtolower($issues[0]->message));
     }
 
+    public function test_passes_on_vapor_with_up_to_date_dependencies(): void
+    {
+        /** @var UpToDateDependencyAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer(
+            composerLockPath: '/path/to/composer.lock',
+            allDepsOutput: "Nothing to install or update\n",
+        );
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertStringContainsString('up-to-date', $result->getMessage());
+    }
+
+    public function test_passes_on_serverless_with_up_to_date_dependencies(): void
+    {
+        /** @var UpToDateDependencyAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer(
+            composerLockPath: '/path/to/composer.lock',
+            allDepsOutput: "Nothing to install or update\n",
+        );
+        $analyzer->setDeploymentPlatform('serverless');
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertStringContainsString('up-to-date', $result->getMessage());
+    }
+
+    public function test_passes_on_laravel_cloud_with_up_to_date_dependencies(): void
+    {
+        /** @var UpToDateDependencyAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer(
+            composerLockPath: '/path/to/composer.lock',
+            allDepsOutput: "Nothing to install or update\n",
+        );
+        $analyzer->setDeploymentPlatform('laravel-cloud');
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertStringContainsString('up-to-date', $result->getMessage());
+    }
+
+    public function test_passes_ignore_platform_reqs_to_dry_run_on_laravel_cloud(): void
+    {
+        /** @var Composer&MockInterface $composer */
+        $composer = Mockery::mock(Composer::class);
+
+        $composer->shouldReceive('getLockFile')->andReturn('/path/to/composer.lock');
+        $composer->shouldReceive('getJsonFile')->andReturn('/path/to/composer.json');
+        $composer->shouldReceive('areDevPackagesInstalled')->andReturn(true);
+
+        /** @phpstan-ignore-next-line Mockery expectation chaining */
+        $composer->shouldReceive('installDryRun')
+            ->with(['--ignore-platform-reqs'])
+            ->once()
+            ->andReturn("Nothing to install or update\n");
+
+        $analyzer = new UpToDateDependencyAnalyzer($composer);
+        $analyzer->setDeploymentPlatform('laravel-cloud');
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_ignore_platform_reqs_to_dry_run_on_vapor(): void
+    {
+        /** @var Composer&MockInterface $composer */
+        $composer = Mockery::mock(Composer::class);
+
+        $composer->shouldReceive('getLockFile')->andReturn('/path/to/composer.lock');
+        $composer->shouldReceive('getJsonFile')->andReturn('/path/to/composer.json');
+        $composer->shouldReceive('areDevPackagesInstalled')->andReturn(true);
+
+        // Verify that --ignore-platform-reqs is passed when running in Vapor
+        /** @phpstan-ignore-next-line Mockery expectation chaining */
+        $composer->shouldReceive('installDryRun')
+            ->with(['--ignore-platform-reqs'])
+            ->once()
+            ->andReturn("Nothing to install or update\n");
+
+        $analyzer = new UpToDateDependencyAnalyzer($composer);
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_ignore_platform_reqs_alongside_no_dev_on_vapor(): void
+    {
+        /** @var Composer&MockInterface $composer */
+        $composer = Mockery::mock(Composer::class);
+
+        $composer->shouldReceive('getLockFile')->andReturn('/path/to/composer.lock');
+        $composer->shouldReceive('getJsonFile')->andReturn('/path/to/composer.json');
+        $composer->shouldReceive('areDevPackagesInstalled')->andReturn(false);
+
+        // When --no-dev mode is active, --ignore-platform-reqs is appended after it
+        /** @phpstan-ignore-next-line Mockery expectation chaining */
+        $composer->shouldReceive('installDryRun')
+            ->with(['--no-dev', '--ignore-platform-reqs'])
+            ->once()
+            ->andReturn("Nothing to install or update\n");
+
+        $analyzer = new UpToDateDependencyAnalyzer($composer);
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_still_detects_real_outdated_deps_on_vapor(): void
+    {
+        $allDepsOutput = <<<'OUTPUT'
+Loading composer repositories with package information
+Installing dependencies from lock file
+Package operations: 0 installs, 1 update, 0 removals
+  - Updating vendor/prod-package (v1.0.0 => v1.0.1)
+OUTPUT;
+
+        /** @var UpToDateDependencyAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer(
+            composerLockPath: '/path/to/composer.lock',
+            allDepsOutput: $allDepsOutput,
+        );
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $result = $analyzer->analyze();
+
+        // Real version updates must still be reported even in Vapor environments
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('dependencies are not up-to-date', $result);
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();


### PR DESCRIPTION
## Summary

- `UpToDateDependencyAnalyzer` false-positives on Vapor/Lambda and Laravel Cloud because `composer install --dry-run` runs on Amazon Linux while `composer.lock` was generated on the developer's macOS machine — Composer detects PHP extension/platform differences and reports packages as needing updates even when version constraints are fully satisfied
- Fix: append `--ignore-platform-reqs` to the dry-run command when `PlatformDetector` identifies a Vapor/serverless or Laravel Cloud environment, limiting evaluation to version-constraint differences only
- Real outdated dependencies continue to be detected and reported on all platforms; Docker is intentionally excluded since lock files are typically generated inside the container (same platform)