### PR TITLE
fix: skip UpToDateDependencyAnalyzer on live serverless runtimes (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.16
+
+### Fixed
+- `UpToDateDependencyAnalyzer` no longer false-positives on live Vapor Lambda deployments — Composer is not installed in Lambda containers; `shouldRun()` now returns `false` on serverless runtimes so the check is skipped entirely
+- `UpToDateDependencyAnalyzer` metadata `composer_version_check` now reflects `--ignore-platform-reqs` when it is passed to the dry-run
+
 ## v1.7.15
 
 ### Fixed

--- a/src/Analyzers/Security/UpToDateDependencyAnalyzer.php
+++ b/src/Analyzers/Security/UpToDateDependencyAnalyzer.php
@@ -8,6 +8,7 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\PlatformDetector;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Concerns\DetectsDeploymentPlatform;
@@ -77,6 +78,14 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
 
     public function shouldRun(): bool
     {
+        // On live serverless runtimes (Lambda, Cloud Functions, Azure Functions) Composer is
+        // not installed and the deployed package is frozen. Running install --dry-run fails
+        // immediately and produces a false positive via the conservative fallback in isUpToDate().
+        // This check only makes sense at development/CI time, not at runtime.
+        if ($this->isServerlessRuntime()) {
+            return false;
+        }
+
         // Run if composer.json exists (even if composer.lock is missing)
         // We want to warn about missing composer.lock
         return $this->composer->getJsonFile() !== null;
@@ -84,7 +93,23 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
 
     public function getSkipReason(): string
     {
+        if ($this->isServerlessRuntime()) {
+            return 'Dependency update checks are not applicable on serverless runtimes';
+        }
+
         return 'No composer.json file found';
+    }
+
+    // Distinct from isVaporOrServerless(): that also triggers on local Vapor projects via
+    // vapor.yml so they still get the --ignore-platform-reqs run. This method gates only
+    // on the actual Lambda runtime where Composer is absent and the check is meaningless.
+    private function isServerlessRuntime(): bool
+    {
+        if ($this->deploymentPlatformOverride !== null) {
+            return $this->deploymentPlatformOverride === 'serverless';
+        }
+
+        return PlatformDetector::isServerless();
     }
 
     protected function runAnalysis(): ResultInterface
@@ -139,7 +164,10 @@ class UpToDateDependencyAnalyzer extends AbstractAnalyzer
             // Extract which packages are being updated from Composer output
             $updatedPackages = $this->extractUpdatedPackages($allDepsOutput);
 
-            $dryRunFlag = $devPackagesInstalled ? 'install --dry-run' : 'install --dry-run --no-dev';
+            // Reflect the actual options used so the reported command is not misleading
+            // (previously this was computed independently and never included --ignore-platform-reqs).
+            $optionsString = implode(' ', $dryRunOptions);
+            $dryRunFlag = 'install --dry-run'.($optionsString !== '' ? ' '.$optionsString : '');
 
             // If we can't extract packages (unexpected output format), report general update needed
             if (empty($updatedPackages)) {

--- a/tests/Unit/Analyzers/Security/UpToDateDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/UpToDateDependencyAnalyzerTest.php
@@ -779,19 +779,21 @@ OUTPUT;
         $this->assertStringContainsString('up-to-date', $result->getMessage());
     }
 
-    public function test_passes_on_serverless_with_up_to_date_dependencies(): void
+    public function test_skips_on_serverless_runtime_via_analyze(): void
     {
+        // On a live Lambda container the analyzer must not run at all — shouldRun() returns
+        // false for 'serverless' so analyze() returns a Skipped result immediately.
+        // No allDepsOutput passed so no installDryRun expectation is registered (it won't be called).
         /** @var UpToDateDependencyAnalyzer $analyzer */
         $analyzer = $this->createAnalyzer(
             composerLockPath: '/path/to/composer.lock',
-            allDepsOutput: "Nothing to install or update\n",
         );
         $analyzer->setDeploymentPlatform('serverless');
 
         $result = $analyzer->analyze();
 
-        $this->assertPassed($result);
-        $this->assertStringContainsString('up-to-date', $result->getMessage());
+        $this->assertSkipped($result);
+        $this->assertStringContainsString('serverless', $result->getMessage());
     }
 
     public function test_passes_on_laravel_cloud_with_up_to_date_dependencies(): void
@@ -901,6 +903,52 @@ OUTPUT;
         // Real version updates must still be reported even in Vapor environments
         $this->assertWarning($result);
         $this->assertHasIssueContaining('dependencies are not up-to-date', $result);
+    }
+
+    public function test_skips_on_serverless_runtime(): void
+    {
+        // On a live Lambda container Composer is not installed, so installDryRun() exits
+        // immediately with an error. That empty/unrecognised output falls through to the
+        // conservative fallback in isUpToDate() and produces a false positive. shouldRun()
+        // must return false for serverless runtimes to prevent the analyzer from running at all.
+        /** @var UpToDateDependencyAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('serverless');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('serverless', $analyzer->getSkipReason());
+    }
+
+    public function test_dry_run_flag_in_metadata_reflects_ignore_platform_reqs(): void
+    {
+        // composer_version_check in issue metadata must match the actual options passed to
+        // installDryRun() — previously the string was built independently of $dryRunOptions
+        // and never included --ignore-platform-reqs even when it was used.
+        /** @var Composer&MockInterface $composer */
+        $composer = Mockery::mock(Composer::class);
+
+        $composer->shouldReceive('getLockFile')->andReturn('/path/to/composer.lock');
+        $composer->shouldReceive('getJsonFile')->andReturn('/path/to/composer.json');
+        $composer->shouldReceive('areDevPackagesInstalled')->andReturn(true);
+
+        // Output with a Lock file operations line but no parseable "- Verb Package" lines
+        // so we reach the scope='unknown' branch where $dryRunFlag is recorded.
+        /** @phpstan-ignore-next-line Mockery expectation chaining */
+        $composer->shouldReceive('installDryRun')
+            ->with(['--ignore-platform-reqs'])
+            ->once()
+            ->andReturn('Lock file operations: 0 installs, 1 update, 0 removals');
+
+        $analyzer = new UpToDateDependencyAnalyzer($composer);
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $result = $analyzer->analyze();
+        $issues = $result->getIssues();
+
+        $this->assertNotEmpty($issues);
+        $versionCheck = $issues[0]->metadata['composer_version_check'] ?? '';
+        $this->assertIsString($versionCheck);
+        $this->assertStringContainsString('--ignore-platform-reqs', $versionCheck);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## Summary

- `UpToDateDependencyAnalyzer` now returns `false` from `shouldRun()` on live serverless runtimes (`PlatformDetector::isServerless()`) — Composer is not installed in deployed Lambda containers, so `install --dry-run` was failing immediately and the conservative fallback always returned "not up-to-date"
- Fixes `composer_version_check` metadata to reflect `--ignore-platform-reqs` when passed to the dry-run — the flag string was previously built independently of `$dryRunOptions`
- Adds `isServerlessRuntime()` private method that respects `$deploymentPlatformOverride` for test isolation, distinct from `isVaporOrServerless()` which also triggers on local Vapor projects via `vapor.yml`