### PR TITLE
fix: honour SHIELDCI_TIMEOUT env var in PHPStanAnalyzer and AnalyzeCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.17
+
+### Fixed
+- `PHPStanAnalyzer` and `AnalyzeCommand` now honour `SHIELDCI_TIMEOUT` when set as an environment variable — `env()` returns strings, so `is_int('600')` was silently falling back to the hardcoded `300`; both callsites now apply the same `is_numeric()` cast already used in `Reporter`
+
 ## v1.7.16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.7.17
 
 ### Fixed
-- `PHPStanAnalyzer` and `AnalyzeCommand` now honour `SHIELDCI_TIMEOUT` when set as an environment variable — `env()` returns strings, so `is_int('600')` was silently falling back to the hardcoded `300`; both callsites now apply the same `is_numeric()` cast already used in `Reporter`
+- `PHPStanAnalyzer` and `AnalyzeCommand` now honour `SHIELDCI_TIMEOUT` when set as an environment variable — `env()` returns strings, so `is_int('600')` was silently falling back to the default; both callsites now apply the same `is_numeric()` cast already used in `Reporter`
 
 ## v1.7.16
 

--- a/src/Analyzers/Reliability/PHPStanAnalyzer.php
+++ b/src/Analyzers/Reliability/PHPStanAnalyzer.php
@@ -306,7 +306,7 @@ class PHPStanAnalyzer extends AbstractFileAnalyzer
         $activeCategories = array_values(array_diff($enabledCategories, $disabledCategories));
 
         $timeoutConfig = $this->config->get('shieldci.timeout', 300);
-        $timeout = is_int($timeoutConfig) ? $timeoutConfig : 300;
+        $timeout = is_int($timeoutConfig) ? $timeoutConfig : (is_numeric($timeoutConfig) ? (int) $timeoutConfig : 300);
 
         try {
             // Run PHPStan once on all paths

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -103,8 +103,8 @@ class AnalyzeCommand extends Command
 
         // Set timeout
         $timeout = config('shieldci.timeout');
-        if ($timeout !== null && is_int($timeout)) {
-            set_time_limit($timeout);
+        if ($timeout !== null && (is_int($timeout) || is_numeric($timeout))) {
+            set_time_limit((int) $timeout);
         }
 
         // Check if enabled

--- a/tests/Unit/Analyzers/Reliability/PHPStanAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/PHPStanAnalyzerTest.php
@@ -550,6 +550,41 @@ PHP;
         $this->assertStringContainsString('static analysis', $metadata->description);
     }
 
+    public function test_honours_string_timeout_from_config(): void
+    {
+        $tempDir = $this->createTempDirectory(['app/Services/ValidService.php' => "<?php\nclass ValidService {}"]);
+
+        @mkdir($tempDir.'/vendor/bin', 0755, true);
+        // Sleeps 2s — exceeds the 1s timeout so the process is killed on time.
+        // If string '1' fell back to the hardcoded 300 (the bug), the mock would
+        // complete before the timeout and the result would be passed, not error.
+        file_put_contents(
+            $tempDir.'/vendor/bin/phpstan',
+            "#!/bin/bash\nsleep 2\necho '{}'"
+        );
+        chmod($tempDir.'/vendor/bin/phpstan', 0755);
+
+        // env() returns strings, so SHIELDCI_TIMEOUT=600 arrives as '1' here.
+        // is_int('1') = false → without the is_numeric fix it falls back to 300.
+        $configRepo = new Repository([
+            'shieldci' => [
+                'timeout' => '1',
+                'analyzers' => ['reliability' => ['enabled' => true, 'phpstan' => [
+                    'level' => 5, 'paths' => ['app'], 'categories' => ['undefined-variable'], 'disabled_categories' => [],
+                ]]],
+            ],
+        ]);
+
+        $analyzer = new PHPStanAnalyzer($configRepo);
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertError($result);
+        $this->assertStringContainsString('exceeded the timeout of 1', $result->getMessage());
+    }
+
     /**
      * Create a mock PHPStan script that returns predefined issues.
      *

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -407,6 +407,18 @@ class AnalyzeCommandTest extends TestCase
     }
 
     #[Test]
+    public function it_applies_string_timeout_from_config(): void
+    {
+        // env() always returns strings, so SHIELDCI_TIMEOUT=600 arrives as '600'.
+        // is_int('600') = false — without the is_numeric fix set_time_limit() is skipped.
+        config(['shieldci.timeout' => '300']);
+        $this->registerTestAnalyzers();
+
+        $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful();
+    }
+
+    #[Test]
     public function it_saves_report_using_config_output_file(): void
     {
         $this->registerTestAnalyzers();


### PR DESCRIPTION
## Summary

- `env()` always returns strings for env-sourced values; `is_int('600')` evaluated to `false`, silently falling back to the default timeout value
- Applies the same `is_numeric()` cast already present in `Reporter.php` to both broken callsites: `PHPStanAnalyzer` and `AnalyzeCommand`
- Adds a regression test that passes `'1'` (string) as the timeout with a 2-second mock PHPStan, confirming the process is killed at 1s rather than falling back to the default