### PR TITLE
docs: restore platform integration config and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Publish the configuration file:
 php artisan vendor:publish --tag=shieldci-config
 ```
 
+Add your ShieldCI credentials to `.env` (your API token is displayed when you create a project in the [ShieldCI dashboard](https://shieldci.com/dashboard)):
+
+```env
+SHIELDCI_TOKEN=your-api-token
+SHIELDCI_PROJECT_ID=your-project-id
+```
+
 ## Usage
 
 Run the analysis:
@@ -71,6 +78,25 @@ php artisan shield:analyze --format=json
 Save report to file:
 ```bash
 php artisan shield:analyze --output=report.json
+```
+
+Send results to ShieldCI platform:
+```bash
+php artisan shield:analyze --report
+```
+
+Schedule analysis with trigger tracking:
+```php
+// Laravel 11+ (routes/console.php)
+Schedule::command('shield:analyze --triggered-by=scheduled --report')->daily();
+
+// Laravel 11+ (bootstrap/app.php)
+->withSchedule(function (Schedule $schedule) {
+    $schedule->command('shield:analyze --triggered-by=scheduled --report')->daily();
+})
+
+// Laravel 9-10 (app/Console/Kernel.php)
+$schedule->command('shield:analyze --triggered-by=scheduled --report')->daily();
 ```
 
 ### Advanced Features
@@ -164,6 +190,25 @@ ShieldCI includes **73 comprehensive analyzers** across five categories:
 | Best Practices | 15 | Laravel-specific patterns |
 
 → [Full Analyzer Reference](https://docs.shieldci.com/analyzers/) — all 73 analyzers with examples and fix guidance
+
+### ShieldCI Pro
+
+[ShieldCI Pro](https://shieldci.com) adds **82 advanced analyzers** on top of the free package:
+
+| Category | Count | Coverage |
+|---|---|---|
+| Security | 45 | Enterprise-grade vulnerability detection |
+| Performance | 15 | Advanced performance optimization |
+| Reliability | 15 | Production-grade resilience checks |
+| Best Practices | 4 | Laravel architecture and conventions |
+| Code Quality | 3 | Test coverage and quality analysis |
+
+Highlights:
+- **Security** — command injection, SSRF, XXE, object injection, GDPR compliance, hard-coded credentials, cryptographic weaknesses; framework-specific checks for Sanctum, Horizon, Telescope, Nova, Livewire, Inertia, and FilamentPHP
+- **Performance** — Redis rate limiting, CDN/HTTP2/compression header analysis, lazy collection opportunities, FilamentPHP table optimization
+- **Reliability** — health check and alerting config, job queue config, Horizon status and provisioning, Redis eviction policy, Laravel Vapor config
+
+→ [Upgrade to Pro](https://shieldci.com)
 
 ## Configuration Options
 

--- a/config/shieldci.php
+++ b/config/shieldci.php
@@ -19,6 +19,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | ShieldCI Platform Integration
+    |--------------------------------------------------------------------------
+    |
+    | Connect to the ShieldCI platform for centralized dashboards, historical
+    | trends, and team-wide visibility. Sign up at https://shieldci.com
+    |
+    | These settings are optional. The package works fully offline without
+    | any platform credentials configured.
+    |
+    */
+
+    'token' => env('SHIELDCI_TOKEN'),
+
+    'project_id' => env('SHIELDCI_PROJECT_ID'),
+
+    'api_url' => env('SHIELDCI_API_URL', 'https://shieldci.com'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Documentation Base URL
     |--------------------------------------------------------------------------
     |
@@ -256,6 +275,8 @@ return [
         'snippet_syntax_highlighting' => env('SHIELDCI_SNIPPET_SYNTAX_HIGHLIGHTING', true), // Enable PHP syntax highlighting
 
         'max_issues_per_check' => env('SHIELDCI_MAX_ISSUES', 5), // Limit displayed issues per check
+
+        'send_to_api' => env('SHIELDCI_SEND_TO_API', false),
     ],
 
     /*


### PR DESCRIPTION
## Summary

- Restores `token`, `project_id`, `api_url`, and `report.send_to_api` keys to `config/shieldci.php` — these are actively referenced by `ShieldCIClient` and `AnalyzeCommand` but were missing from the published config
- Adds platform credentials setup to README with a direct link to the ShieldCI dashboard
- Restores `--report` usage and scheduling examples to README
- Adds a ShieldCI Pro section to the Available Analyzers area with correct counts sourced from `ANALYZER_CATALOG.md` (82 analyzers: Security 45, Performance 15, Reliability 15, Best Practices 4, Code Quality 3)