### PR TITLE
fix: eliminate ChunkMissingAnalyzer false positives on derived-table and correlated-subquery patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.18
+
+### Fixed
+- `ChunkMissingAnalyzer` no longer false-positives on `DB::query()->fromSub(...)` derived-table queries — `fromSub`, `joinSub`, `leftJoinSub`, and `rightJoinSub` in the method chain now exempt the call; result bounds are encoded in the subquery structure, not a terminal method like `limit()`; plain `DB::table()->get()` continues to be flagged
+- `ChunkMissingAnalyzer` no longer false-positives on queries that pass `DB::raw()` inside `select([...])` — a correlated subquery in the select list signals explicit, bounded SQL that does not need chunking
+
 ## v1.7.17
 
 ### Fixed

--- a/pint.json
+++ b/pint.json
@@ -1,6 +1,7 @@
 {
     "preset": "laravel",
     "notPath": [
-        "tests/Fixtures/inspects-code/syntax_error.php"
+        "tests/Fixtures/inspects-code/syntax_error.php",
+        "tests/Fixtures/inspects-code-config/syntax_error.php"
     ]
 }

--- a/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
+++ b/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
@@ -195,7 +195,71 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
             return false;
         }
 
+        // Subquery composition methods signal explicit, developer-controlled SQL structure
+        // (derived tables, subquery joins). Result bounds are encoded in the subquery design
+        // itself — not expressible via terminal Eloquent methods like limit() or take().
+        $subqueryCompositionMethods = ['fromSub', 'joinSub', 'leftJoinSub', 'rightJoinSub'];
+        if (! empty(array_intersect($methods, $subqueryCompositionMethods))) {
+            return false;
+        }
+
+        // A DB::raw() call inside select() args signals a correlated subquery — explicit,
+        // developer-authored SQL that embeds per-row constraints inline.
+        if ($this->hasDbRawInSelectArgs($expr)) {
+            return false;
+        }
+
         return ! $hasChunking && ! $hasSmallDatasetModifier;
+    }
+
+    /**
+     * Walk the method call chain and check whether any select() call's argument array
+     * contains a DB::raw() expression. This catches correlated-subquery enrichment
+     * patterns like ->select(['id', DB::raw('(SELECT ...)')]) ->get().
+     */
+    private function hasDbRawInSelectArgs(Node\Expr $expr): bool
+    {
+        $current = $expr;
+
+        while ($current instanceof Node\Expr\MethodCall) {
+            if ($current->name instanceof Node\Identifier
+                && $current->name->toString() === 'select') {
+                foreach ($current->args as $arg) {
+                    if ($this->containsDbRaw($arg->value)) {
+                        return true;
+                    }
+                }
+            }
+
+            $current = $current->var;
+        }
+
+        return false;
+    }
+
+    /**
+     * Recursively check whether an expression node is or contains a DB::raw() call.
+     * Descends into array literals so that select([..., DB::raw(...)]) is detected.
+     */
+    private function containsDbRaw(Node\Expr $node): bool
+    {
+        if ($node instanceof Node\Expr\StaticCall
+            && $node->class instanceof Node\Name
+            && $node->class->getLast() === 'DB'
+            && $node->name instanceof Node\Identifier
+            && $node->name->toString() === 'raw') {
+            return true;
+        }
+
+        if ($node instanceof Node\Expr\Array_) {
+            foreach ($node->items as $item) {
+                if ($item !== null && $this->containsDbRaw($item->value)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Analyzers/BestPractices/ChunkMissingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ChunkMissingAnalyzerTest.php
@@ -848,6 +848,147 @@ PHP;
         $this->assertPassed($result);
     }
 
+    public function test_passes_for_db_query_with_from_sub(): void
+    {
+        // Reproduces the false positive from ProjectController::computeProjectScoreDeltas().
+        // DB::query()->fromSub(...)->where('rn', '<=', 2)->get() is bounded by the window-
+        // function subquery and uses a derived table (fromSub) — explicit SQL engineering
+        // where result set size is encoded in the subquery structure, not a terminal method.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\DB;
+use App\Models\Report;
+
+class ProjectController
+{
+    public function computeProjectScoreDeltas(array $projectIds): array
+    {
+        $ranked = Report::query()
+            ->select(['project_id', 'score', DB::raw('ROW_NUMBER() OVER (PARTITION BY project_id ORDER BY analyzed_at DESC) AS rn')])
+            ->whereIn('project_id', $projectIds)
+            ->whereIn('environment', ['production', 'staging']);
+
+        $reports = DB::query()
+            ->fromSub($ranked, 'ranked')
+            ->select(['project_id', 'score', 'rn'])
+            ->where('rn', '<=', 2)
+            ->orderBy('project_id')
+            ->orderByDesc('rn')
+            ->get();
+
+        $deltas = [];
+        $previousScores = [];
+
+        foreach ($reports as $report) {
+            $deltas[$report->project_id] = isset($previousScores[$report->project_id])
+                ? $report->score - $previousScores[$report->project_id]
+                : null;
+            $previousScores[$report->project_id] = $report->score;
+        }
+
+        return $deltas;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Controllers/ProjectController.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_still_flags_db_table_without_limit(): void
+    {
+        // DB::table()->get() without a limit or subquery composition still risks
+        // loading an unbounded result set and must remain flagged.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+
+class ReportService
+{
+    public function processAll(): void
+    {
+        $rows = DB::table('users')->where('active', true)->get();
+        foreach ($rows as $row) {
+            // process
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/ReportService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+    }
+
+    public function test_passes_for_select_with_db_raw_correlated_subquery(): void
+    {
+        // Reproduces the false positive from ActivityController::computeScoreDeltas().
+        // The DB::raw() correlated subquery inside select() signals deliberate, expert-level
+        // SQL — the result set is bounded by the whereIn on page-scoped $reportIds.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Report;
+use Illuminate\Support\Facades\DB;
+
+class ActivityController
+{
+    private function computeScoreDeltas(array $reportIds): array
+    {
+        $rows = Report::query()
+            ->select([
+                'id',
+                'score',
+                DB::raw('(SELECT p.score FROM reports p WHERE p.project_id = reports.project_id AND p.analyzed_at < reports.analyzed_at ORDER BY p.analyzed_at DESC LIMIT 1) AS prev_score'),
+            ])
+            ->whereIn('id', $reportIds)
+            ->get();
+
+        $deltas = [];
+
+        foreach ($rows as $row) {
+            $deltas[$row->id] = $row->prev_score !== null
+                ? $row->score - (int) $row->prev_score
+                : null;
+        }
+
+        return $deltas;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Controllers/ActivityController.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
     public function test_grammar_singular_vs_plural(): void
     {
         // Test singular


### PR DESCRIPTION
## Summary

- `ChunkMissingAnalyzer` no longer false-positives on `DB::query()->fromSub(...)` queries — `fromSub`, `joinSub`, `leftJoinSub`, and `rightJoinSub` in the method chain now exempt the call, as result bounds are encoded in the subquery structure itself
- `ChunkMissingAnalyzer` no longer false-positives on queries with `DB::raw()` inside `select([...])` — a correlated subquery in the select list signals explicit, bounded SQL
- `pint.json` extended to exclude `tests/Fixtures/inspects-code-config/syntax_error.php`
- 3 new test cases; 30 total passing; PHPStan Level 9 clean