### PR TITLE
fix: exclude shieldci/* packages from LicenseAnalyzer checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.19
+
+### Fixed
+- `LicenseAnalyzer` no longer flags `shieldci/*` packages — the tool's own packages ship without a public SPDX license declaration, causing the analyzer to emit missing-license or non-standard-license findings against itself
+
 ## v1.7.18
 
 ### Fixed

--- a/src/Analyzers/Security/LicenseAnalyzer.php
+++ b/src/Analyzers/Security/LicenseAnalyzer.php
@@ -23,6 +23,10 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class LicenseAnalyzer extends AbstractFileAnalyzer
 {
+    private array $excludedPackages = [
+        'shieldci/*',
+    ];
+
     /**
      * Default whitelisted licenses for commercial/proprietary use.
      */
@@ -169,6 +173,10 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
                 ? $package['name']
                 : 'Unknown';
 
+            if ($this->isPackageExcluded($packageName)) {
+                continue;
+            }
+
             // Normalize license to array and detect if it's conjunctive (AND) or disjunctive (OR)
             $licenseData = $this->parseLicenseField($package);
             $licenses = $licenseData['licenses'];
@@ -290,6 +298,17 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
                 }
             }
         }
+    }
+
+    private function isPackageExcluded(string $packageName): bool
+    {
+        foreach ($this->excludedPackages as $pattern) {
+            if (fnmatch($pattern, $packageName)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/LicenseAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/LicenseAnalyzerTest.php
@@ -799,4 +799,42 @@ class LicenseAnalyzerTest extends AnalyzerTestCase
         // Should pass because MIT is available (disjunctive)
         $this->assertPassed($result);
     }
+
+    public function test_shieldci_packages_are_excluded_from_license_checks(): void
+    {
+        $composerLock = json_encode([
+            'packages' => [
+                [
+                    'name' => 'shieldci/laravel',
+                    'version' => '1.0.0',
+                    'license' => ['GPL-3.0'],  // Would be Critical if not excluded
+                ],
+                [
+                    'name' => 'shieldci/analyzers-core',
+                    'version' => '1.0.0',
+                    // No license field — would be Medium if not excluded
+                ],
+                [
+                    'name' => 'vendor/gpl-package',
+                    'version' => '1.0.0',
+                    'license' => ['GPL-3.0'],  // Non-shieldci: must still fail
+                ],
+            ],
+        ]);
+
+        $tempDir = $this->createTempDirectory([
+            'composer.lock' => $composerLock,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // Only vendor/gpl-package should produce an issue
+        $this->assertFailed($result);
+        $this->assertIssueCount(1, $result);
+        $this->assertHasIssueContaining('vendor/gpl-package', $result);
+    }
 }


### PR DESCRIPTION
## Summary
- `LicenseAnalyzer` no longer flags `shieldci/*` packages for missing or non-standard licenses
- Exclusion uses `fnmatch()` glob matching against a private `$excludedPackages = ['shieldci/*']` property
- Non-shieldci packages with restrictive licenses continue to be flagged as before