### PR TITLE
fix: MassAssignmentAnalyzer false positive on inherited $fillable/$guarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.20
+
+### Fixed
+- `MassAssignmentAnalyzer` no longer false-positives on models that inherit mass assignment protection from a parent class — subclasses of vendor models (e.g. `PersonalAccessToken extends Laravel\Sanctum\PersonalAccessToken`) were flagged as missing `$fillable`/`$guarded` because only the current class's own properties were checked; the analyzer now walks the parent class file via Composer's classmap before emitting the finding
+
 ## v1.7.19
 
 ### Fixed

--- a/src/Analyzers/Security/MassAssignmentAnalyzer.php
+++ b/src/Analyzers/Security/MassAssignmentAnalyzer.php
@@ -113,6 +113,9 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
         'two_factor_recovery_codes',
     ];
 
+    /** @var array<string, string>|null */
+    private ?array $composerClassMap = null;
+
     public function __construct(
         private ParserInterface $parser
     ) {}
@@ -256,8 +259,8 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
 
         $modelName = $class->name ? $class->name->toString() : 'Unknown';
 
-        // Issue if neither fillable nor guarded is set
-        if (! $hasFillable && ! $hasGuarded) {
+        // Issue if neither fillable nor guarded is set (and no ancestor provides either)
+        if (! $hasFillable && ! $hasGuarded && ! $this->parentClassHasProtection($file, $class)) {
             $issues[] = $this->createIssueWithSnippet(
                 message: "Model '{$modelName}' lacks mass assignment protection (\$fillable or \$guarded)",
                 filePath: $file,
@@ -1310,5 +1313,153 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
         }
 
         return false;
+    }
+
+    /**
+     * Check whether any ancestor class declares $fillable or $guarded, preventing
+     * false positives on models that inherit mass assignment protection from a parent
+     * (e.g. PersonalAccessToken extending Laravel\Sanctum\PersonalAccessToken).
+     */
+    private function parentClassHasProtection(
+        string $file,
+        Node\Stmt\Class_ $class,
+        int $depth = 0
+    ): bool {
+        if ($depth > 3 || $class->extends === null) {
+            return false;
+        }
+
+        $parentName = $class->extends->toString();
+
+        // Direct Eloquent Model base — no ancestor provides inherited protection
+        if ($parentName === 'Model' || str_ends_with($parentName, '\\Model')) {
+            return false;
+        }
+
+        $fqn = $this->resolveParentClassFqn($parentName, $file);
+        $parentFile = $this->findClassFileByFqn($fqn);
+        if ($parentFile === null) {
+            return false;
+        }
+
+        $ast = $this->parser->parseFile($parentFile);
+        if (empty($ast)) {
+            return false;
+        }
+
+        foreach ($this->parser->findClasses($ast) as $parentClass) {
+            foreach ($parentClass->stmts as $stmt) {
+                if (! $stmt instanceof Node\Stmt\Property) {
+                    continue;
+                }
+
+                foreach ($stmt->props as $prop) {
+                    $name = $prop->name->toString();
+                    if ($name === 'fillable' || $name === 'guarded') {
+                        return true;
+                    }
+                }
+            }
+
+            if ($this->parentClassHasProtection($parentFile, $parentClass, $depth + 1)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve a short or aliased parent class name to its fully-qualified name.
+     *
+     * Uses FileParser::extractUseStatements() which returns the raw body of each
+     * `use ...;` statement (e.g. "Laravel\Sanctum\PersonalAccessToken as SanctumPAT"),
+     * then falls back to the file's own namespace for same-namespace parents.
+     */
+    private function resolveParentClassFqn(string $shortName, string $file): string
+    {
+        if (str_starts_with($shortName, '\\')) {
+            return ltrim($shortName, '\\');
+        }
+
+        $q = preg_quote($shortName, '/');
+
+        foreach (FileParser::extractUseStatements($file) as $raw) {
+            $stmt = trim($raw);
+
+            // use Foo\Bar\Baz as ShortName
+            if (preg_match('/^([\w\\\\]+)\s+as\s+'.$q.'$/', $stmt, $m)) {
+                return $m[1];
+            }
+
+            // use Foo\Bar\ShortName  (last segment matches exactly)
+            if (str_ends_with($stmt, '\\'.$shortName)) {
+                return $stmt;
+            }
+        }
+
+        // Same-namespace parent
+        $ns = FileParser::extractNamespace($file);
+        if ($ns !== null && $ns !== '') {
+            return $ns.'\\'.$shortName;
+        }
+
+        return $shortName;
+    }
+
+    /**
+     * Look up a PHP file path for the given fully-qualified class name.
+     *
+     * Checks Composer's autoload_classmap.php first (covers vendor classes),
+     * then falls back to a PSR-4-style App\ path resolution (covers test fixtures
+     * that have no real vendor directory).
+     */
+    private function findClassFileByFqn(string $fqn): ?string
+    {
+        $map = $this->getComposerClassMap();
+        if (isset($map[$fqn])) {
+            return $map[$fqn];
+        }
+
+        if (str_starts_with($fqn, 'App\\')) {
+            $rel = str_replace('\\', DIRECTORY_SEPARATOR, substr($fqn, 4)).'.php';
+            $path = $this->getBasePath().DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.$rel;
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Load and cache Composer's autoload classmap (FQN → absolute file path).
+     *
+     * @return array<string, string>
+     */
+    private function getComposerClassMap(): array
+    {
+        if ($this->composerClassMap !== null) {
+            return $this->composerClassMap;
+        }
+
+        $classMapFile = $this->getBasePath()
+            .DIRECTORY_SEPARATOR.'vendor'
+            .DIRECTORY_SEPARATOR.'composer'
+            .DIRECTORY_SEPARATOR.'autoload_classmap.php';
+
+        if (! file_exists($classMapFile)) {
+            return $this->composerClassMap = [];
+        }
+
+        /** @var mixed $result */
+        $result = @include $classMapFile;
+
+        if (! is_array($result)) {
+            return $this->composerClassMap = [];
+        }
+
+        /** @var array<string, string> $result */
+        return $this->composerClassMap = $result;
     }
 }

--- a/tests/Unit/Analyzers/Security/MassAssignmentAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/MassAssignmentAnalyzerTest.php
@@ -2786,4 +2786,172 @@ PHP;
         $this->assertNotNull($relationshipIssue, 'Expected a relationship mass assignment issue');
         $this->assertStringContainsString('FormRequest', $relationshipIssue->recommendation);
     }
+
+    // -------------------------------------------------------------------------
+    // Inherited protection (parent/vendor class already defines $fillable)
+    // -------------------------------------------------------------------------
+
+    public function test_passes_when_vendor_parent_has_fillable(): void
+    {
+        // Simulates PersonalAccessToken extends SanctumPersonalAccessToken where
+        // the Sanctum class already declares $fillable.
+        $parentCode = <<<'PHP'
+<?php
+
+namespace FakeVendor;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BaseToken extends Model
+{
+    protected $fillable = ['name', 'token', 'abilities'];
+}
+PHP;
+
+        $childCode = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use FakeVendor\BaseToken as SanctumPAT;
+
+class PersonalAccessToken extends SanctumPAT
+{
+    // inherits $fillable from SanctumPAT
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'vendor/fakevendor/BaseToken.php' => $parentCode,
+            'app/Models/PersonalAccessToken.php' => $childCode,
+        ]);
+
+        // Write a classmap that maps the vendor FQN to its file using __DIR__-relative paths.
+        $classMapCode = <<<'PHP'
+<?php
+$vendorDir = dirname(__DIR__);
+return [
+    'FakeVendor\\BaseToken' => $vendorDir . '/fakevendor/BaseToken.php',
+];
+PHP;
+        mkdir($tempDir.'/vendor/composer', 0777, true);
+        file_put_contents($tempDir.'/vendor/composer/autoload_classmap.php', $classMapCode);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // No missing-protection issue — inherited $fillable satisfies the check.
+        $protectionIssues = array_filter(
+            $result->getIssues(),
+            fn ($i) => isset($i->metadata['issue_type']) && $i->metadata['issue_type'] === 'missing_model_protection'
+        );
+        $this->assertEmpty($protectionIssues, 'Should not flag model that inherits $fillable from a vendor parent');
+    }
+
+    public function test_passes_when_app_parent_has_fillable_via_psr4_fallback(): void
+    {
+        // Two-level App\ inheritance — no classmap, uses the PSR-4 App\ path fallback.
+        $baseCode = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BaseModel extends Model
+{
+    protected $fillable = ['id', 'created_at', 'updated_at'];
+}
+PHP;
+
+        $childCode = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+class User extends BaseModel
+{
+    // inherits $fillable from BaseModel
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/BaseModel.php' => $baseCode,
+            'app/Models/User.php' => $childCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $protectionIssues = array_filter(
+            $result->getIssues(),
+            fn ($i) => isset($i->metadata['issue_type']) && $i->metadata['issue_type'] === 'missing_model_protection'
+        );
+        $this->assertEmpty($protectionIssues, 'Should not flag model that inherits $fillable from an App\ parent');
+    }
+
+    public function test_still_flags_when_entire_inheritance_chain_lacks_protection(): void
+    {
+        // Vendor parent also has no $fillable or $guarded — child must still be flagged.
+        $parentCode = <<<'PHP'
+<?php
+
+namespace FakeVendor;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UnprotectedBase extends Model
+{
+    // deliberately no $fillable or $guarded
+}
+PHP;
+
+        $childCode = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use FakeVendor\UnprotectedBase;
+
+class Dangerous extends UnprotectedBase
+{
+    // also no $fillable or $guarded
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'vendor/fakevendor/UnprotectedBase.php' => $parentCode,
+            'app/Models/Dangerous.php' => $childCode,
+        ]);
+
+        $classMapCode = <<<'PHP'
+<?php
+$vendorDir = dirname(__DIR__);
+return [
+    'FakeVendor\\UnprotectedBase' => $vendorDir . '/fakevendor/UnprotectedBase.php',
+];
+PHP;
+        mkdir($tempDir.'/vendor/composer', 0777, true);
+        file_put_contents($tempDir.'/vendor/composer/autoload_classmap.php', $classMapCode);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+
+        $protectionIssues = array_filter(
+            $result->getIssues(),
+            fn ($i) => isset($i->metadata['issue_type']) && $i->metadata['issue_type'] === 'missing_model_protection'
+        );
+        $this->assertNotEmpty($protectionIssues, 'Should still flag model when whole chain lacks protection');
+    }
 }


### PR DESCRIPTION
## Summary
- `MassAssignmentAnalyzer` was flagging models like `PersonalAccessToken extends Laravel\Sanctum\PersonalAccessToken` as missing mass assignment protection, because `checkModelProtection()` only scanned the current class's own `$stmts` — never the parent
- The fix adds `parentClassHasProtection()` which resolves the parent class FQN (via `use` statement parsing), looks up its file via Composer's `autoload_classmap.php` (with a PSR-4 `App\` path fallback), parses the parent AST, and checks for `$fillable`/`$guarded` up to three levels deep
- Models where the entire ancestry chain genuinely lacks protection continue to be flagged