### PR TITLE
fix: clear AstParser cache after each analyzer to prevent OOM (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.22
+
+### Fixed
+- `shield:analyze` no longer exhausts the PHP memory limit on large projects — `AstParser` is a singleton whose internal file cache accumulated parsed AST trees across all 73 analyzers without being cleared; `AnalyzerManager` now calls `clearParserCache()` after each `analyze()` invocation, which also eliminates false positives in `SilentFailureAnalyzer` and `MissingDatabaseTransactionsAnalyzer` caused by `resolveNames()` mutating cached `Node` objects in-place between analyzers
+
 ## v1.7.21
 
 ### Changed

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -81,6 +81,7 @@ parameters:
         - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::with\(\)#'
         - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::andThrow\(\)#'
         - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::andReturnSelf\(\)#'
+        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::times\(\)#'
         - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage\|Mockery\\MockInterface::with\(\)#'
 
         # Test files: PHPUnit assertions on already-narrowed types are intentional defensive checks

--- a/src/AnalyzerManager.php
+++ b/src/AnalyzerManager.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Collection;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
+use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Results\AnalysisResult;
 
@@ -65,6 +66,23 @@ class AnalyzerManager
         $this->cachedAnalyzers = null;
         $this->cachedSkippedAnalyzers = null;
         $this->configCacheInitialized = false;
+    }
+
+    /**
+     * Clear the singleton AstParser's file cache to prevent unbounded heap growth
+     * when 73 analyzers each call parseFile() across the same project.
+     * Called after every analyze() invocation in runAll() and run().
+     */
+    public function clearParserCache(): void
+    {
+        try {
+            $parser = $this->container->make(ParserInterface::class);
+            if (method_exists($parser, 'clearCache')) {
+                $parser->clearCache();
+            }
+        } catch (\Throwable) {
+            // Parser not bound or doesn't support clearing — silently skip
+        }
     }
 
     private function initConfigCache(): void
@@ -248,6 +266,7 @@ class AnalyzerManager
         $results = $this->getAnalyzers()
             ->map(function (AnalyzerInterface $analyzer) {
                 $result = $analyzer->analyze();
+                $this->clearParserCache();
                 $metadata = $analyzer->getMetadata();
 
                 // Enrich result with analyzer metadata
@@ -422,6 +441,7 @@ class AnalyzerManager
         }
 
         $result = $analyzer->analyze();
+        $this->clearParserCache();
         $metadata = $analyzer->getMetadata();
 
         // Enrich result with analyzer metadata (same as runAll)

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -273,6 +273,7 @@ class AnalyzeCommand extends Command
 
                 // Run analyzer
                 $result = $analyzer->analyze();
+                $manager->clearParserCache();
                 $metadata = $analyzer->getMetadata();
 
                 // Enrich result with metadata
@@ -409,6 +410,7 @@ class AnalyzeCommand extends Command
 
                 // Run analyzer
                 $result = $analyzer->analyze();
+                $manager->clearParserCache();
                 $metadata = $analyzer->getMetadata();
 
                 // Enrich result with metadata
@@ -648,6 +650,7 @@ class AnalyzeCommand extends Command
                 $progressBar->setMessage($metadata->name);
             }
             $result = $analyzer->analyze();
+            $manager->clearParserCache();
             if ($progressBar !== null) {
                 $progressBar->advance();
             }

--- a/tests/Unit/AnalyzerManagerTest.php
+++ b/tests/Unit/AnalyzerManagerTest.php
@@ -10,6 +10,7 @@ use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use ShieldCI\AnalyzerManager;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
+use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
@@ -672,6 +673,46 @@ class AnalyzerManagerTest extends TestCase
         $this->assertEquals(2, $callCount, 'After invalidateCache(), make() should be called again');
     }
 
+    #[Test]
+    public function it_calls_clear_cache_on_parser_when_method_exists(): void
+    {
+        $parser = new ParserWithClearCache;
+
+        $config = Mockery::mock(Config::class);
+        $config->shouldReceive('get')->andReturn([]);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('make')
+            ->with(ParserInterface::class)
+            ->once()
+            ->andReturn($parser);
+
+        $manager = new AnalyzerManager($config, [], $container);
+        $manager->clearParserCache();
+
+        $this->assertTrue($parser->clearCacheCalled);
+    }
+
+    #[Test]
+    public function it_does_not_throw_when_parser_has_no_clear_cache_method(): void
+    {
+        $parser = new ParserWithoutClearCache;
+
+        $config = Mockery::mock(Config::class);
+        $config->shouldReceive('get')->andReturn([]);
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('make')
+            ->with(ParserInterface::class)
+            ->once()
+            ->andReturn($parser);
+
+        $manager = new AnalyzerManager($config, [], $container);
+        $manager->clearParserCache();
+
+        $this->addToAssertionCount(1);
+    }
+
     protected function createManager(array $analyzerClasses): AnalyzerManager
     {
         $config = Mockery::mock(Config::class);
@@ -921,5 +962,88 @@ class FileTestAnalyzer implements AnalyzerInterface
     public function getId(): string
     {
         return 'file-test-analyzer';
+    }
+}
+
+class ParserWithClearCache implements ParserInterface
+{
+    public bool $clearCacheCalled = false;
+
+    public function parseFile(string $filePath): array
+    {
+        return [];
+    }
+
+    public function parseCode(string $code): array
+    {
+        return [];
+    }
+
+    public function findNodes(array $ast, string $nodeType): array
+    {
+        return [];
+    }
+
+    public function findMethodCalls(array $ast, string $methodName): array
+    {
+        return [];
+    }
+
+    public function findStaticCalls(array $ast, string $className, string $methodName): array
+    {
+        return [];
+    }
+
+    public function resolveNames(array $ast, array $options = []): array
+    {
+        return [];
+    }
+
+    public function collectStringLines(array $ast): array
+    {
+        return [];
+    }
+
+    public function clearCache(): void
+    {
+        $this->clearCacheCalled = true;
+    }
+}
+
+class ParserWithoutClearCache implements ParserInterface
+{
+    public function parseFile(string $filePath): array
+    {
+        return [];
+    }
+
+    public function parseCode(string $code): array
+    {
+        return [];
+    }
+
+    public function findNodes(array $ast, string $nodeType): array
+    {
+        return [];
+    }
+
+    public function findMethodCalls(array $ast, string $methodName): array
+    {
+        return [];
+    }
+
+    public function findStaticCalls(array $ast, string $className, string $methodName): array
+    {
+        return [];
+    }
+
+    public function resolveNames(array $ast, array $options = []): array
+    {
+        return [];
+    }
+
+    public function collectStringLines(array $ast): array
+    {
+        return [];
     }
 }

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -1535,6 +1535,10 @@ class AnalyzeCommandTest extends TestCase
             $manager->shouldReceive('runAll')
                 ->andReturn(collect());
 
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
+
             return $manager;
         });
 
@@ -2387,6 +2391,10 @@ PHP);
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$failedAnalyzer->analyze()]));
 
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
+
             return $manager;
         });
     }
@@ -2451,6 +2459,10 @@ PHP);
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$failedAnalyzer->analyze()]));
 
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
+
             return $manager;
         });
     }
@@ -2509,6 +2521,10 @@ PHP);
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$warningAnalyzer->analyze()]));
 
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
+
             return $manager;
         });
     }
@@ -2566,6 +2582,10 @@ PHP);
             /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$failedAnalyzer->analyze()]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
 
             return $manager;
         });
@@ -2666,6 +2686,10 @@ PHP);
                     $performanceAnalyzer->analyze(),
                 ]));
 
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
+
             return $manager;
         });
     }
@@ -2723,6 +2747,10 @@ PHP);
             /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$warningAnalyzer->analyze()]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
 
             return $manager;
         });
@@ -2802,6 +2830,10 @@ PHP);
             /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$passedAnalyzer->analyze()]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
 
             return $manager;
         });
@@ -2916,6 +2948,10 @@ PHP);
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$skipped]));
 
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
+
             return $manager;
         });
     }
@@ -2978,6 +3014,10 @@ PHP);
             /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$passedAnalyzer->analyze()]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
 
             return $manager;
         });
@@ -3052,6 +3092,10 @@ PHP);
             /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with(Mockery::any())
+                ->andReturn(null);
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
             return $manager;
@@ -3194,6 +3238,8 @@ PHP);
             $manager->shouldReceive('getSkippedAnalyzers')->andReturn(collect());
             /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')->andReturn(collect());
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')->andReturn(null);
 
             return $manager;
         });
@@ -3245,6 +3291,8 @@ PHP);
             $manager->shouldReceive('getByCategory')->with(Mockery::any())->andReturn(collect());
             /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')->andReturn(collect());
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')->andReturn(null);
 
             return $manager;
         });
@@ -4110,6 +4158,8 @@ PHP);
         $manager->shouldReceive('run')->with('test-performance-analyzer')->andReturn($performanceAnalyzer->analyze());
         /** @phpstan-ignore-next-line */
         $manager->shouldReceive('resolveAnalyzerDisplayName')->andReturn('Test Security Analyzer');
+        /** @phpstan-ignore-next-line */
+        $manager->shouldReceive('clearParserCache')->andReturn(null);
 
         return $manager;
     }


### PR DESCRIPTION
## Summary

- `AstParser` is a singleton whose internal file cache accumulated parsed AST trees across all 73 analyzers without being cleared, exhausting the 512 MB heap by analyzer ~40 and killing the process mid-run
- `AnalyzerManager::clearParserCache()` now calls `AstParser::clearCache()` after every `analyze()` invocation in `runAll()`, `run()`, and all three execution paths in `AnalyzeCommand`
- As a secondary effect, this eliminates false positives in `SilentFailureAnalyzer` and `MissingDatabaseTransactionsAnalyzer` caused by `resolveNames()` mutating cached `Node` objects in-place between analyzers