### PR TITLE
refactor: extract DetectsLaravelVersion trait

### DIFF
--- a/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
+++ b/src/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzer.php
@@ -9,7 +9,6 @@ use Fruitcake\Cors\HandleCors as FruitcakeHandleCors;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel;
-use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\HandleCors;
 use Illuminate\Http\Middleware\TrustHosts;
 use Illuminate\Http\Middleware\TrustProxies;
@@ -23,6 +22,7 @@ use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\Concerns\AnalyzesMiddleware;
+use ShieldCI\Concerns\DetectsLaravelVersion;
 
 /**
  * Detects unused global HTTP middleware in the application.
@@ -37,6 +37,7 @@ use ShieldCI\Concerns\AnalyzesMiddleware;
 class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
 {
     use AnalyzesMiddleware;
+    use DetectsLaravelVersion;
 
     /**
      * @var array<int, array{name: string, class: string, reason: string, recommendation: string}>
@@ -308,19 +309,6 @@ class UnusedGlobalMiddlewareAnalyzer extends AbstractAnalyzer
         }
 
         return $basePath.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'Http'.DIRECTORY_SEPARATOR.'Kernel.php';
-    }
-
-    /**
-     * Determine if the application uses Laravel 11+.
-     *
-     * Detected via the presence of Illuminate\Foundation\Configuration\Middleware,
-     * which was introduced in Laravel 11 as part of the new bootstrap/app.php API.
-     * This is more reliable than filesystem checks since the laravel/framework
-     * package is always present and its version reflects the actual Laravel version.
-     */
-    private function isLaravel11OrNewer(): bool
-    {
-        return class_exists(Middleware::class);
     }
 
     /**

--- a/src/Analyzers/Security/AuthenticationAnalyzer.php
+++ b/src/Analyzers/Security/AuthenticationAnalyzer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ShieldCI\Analyzers\Security;
 
 use Illuminate\Contracts\Config\Repository as Config;
-use Illuminate\Foundation\Configuration\Middleware;
 use PhpParser\Node;
 use PhpParser\Node\VariadicPlaceholder;
 use PhpParser\NodeTraverser;
@@ -19,6 +18,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
+use ShieldCI\Concerns\DetectsLaravelVersion;
 
 /**
  * Detects missing authentication and authorization protection.
@@ -32,6 +32,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Issue;
  */
 class AuthenticationAnalyzer extends AbstractFileAnalyzer
 {
+    use DetectsLaravelVersion;
+
     /**
      * @var array<string>
      */
@@ -1353,12 +1355,6 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
         $this->resolvedAuthMiddleware[$fqcn] = $isAuth;
 
         return $isAuth;
-    }
-
-    private function isLaravel11OrNewer(): bool
-    {
-        /** @phpstan-ignore-next-line */
-        return class_exists(Middleware::class);
     }
 }
 

--- a/src/Analyzers/Security/LoginThrottlingAnalyzer.php
+++ b/src/Analyzers/Security/LoginThrottlingAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Security;
 
-use Illuminate\Foundation\Configuration\Middleware;
 use PhpParser\Node;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
@@ -13,6 +12,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Concerns\DetectsLaravelVersion;
 use ShieldCI\Support\BootstrapRouteParser;
 
 /**
@@ -26,6 +26,8 @@ use ShieldCI\Support\BootstrapRouteParser;
  */
 class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
 {
+    use DetectsLaravelVersion;
+
     public function __construct(
         private ParserInterface $parser
     ) {}
@@ -1075,11 +1077,5 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
         // For Breeze/Jetstream using default Fortify routes, the Fortify check above
         // already validates throttling configuration, so we don't need additional checks here.
         // This avoids false positives since Fortify's default behavior includes throttling.
-    }
-
-    private function isLaravel11OrNewer(): bool
-    {
-        /** @phpstan-ignore-next-line */
-        return class_exists(Middleware::class);
     }
 }

--- a/src/Concerns/DetectsLaravelVersion.php
+++ b/src/Concerns/DetectsLaravelVersion.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Concerns;
+
+trait DetectsLaravelVersion
+{
+    private function isLaravel11OrNewer(): bool
+    {
+        return version_compare(app()->version(), '11.0.0', '>=');
+    }
+}

--- a/tests/Unit/Concerns/DetectsLaravelVersionTest.php
+++ b/tests/Unit/Concerns/DetectsLaravelVersionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Concerns;
+
+use PHPUnit\Framework\Attributes\Test;
+use ShieldCI\Concerns\DetectsLaravelVersion;
+use ShieldCI\Tests\TestCase;
+
+class DetectsLaravelVersionTest extends TestCase
+{
+    private ConcreteDetectsLaravelVersion $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new ConcreteDetectsLaravelVersion;
+    }
+
+    #[Test]
+    public function it_returns_a_boolean(): void
+    {
+        $this->assertIsBool($this->subject->check());
+    }
+
+    #[Test]
+    public function it_matches_the_running_laravel_version(): void
+    {
+        $expected = version_compare(app()->version(), '11.0.0', '>=');
+
+        $this->assertSame($expected, $this->subject->check());
+    }
+
+    #[Test]
+    public function it_returns_true_on_laravel_11_or_higher(): void
+    {
+        if (version_compare(app()->version(), '11.0.0', '<')) {
+            $this->markTestSkipped('Running on Laravel '.app()->version().' — skipping L11+ assertion.');
+        }
+
+        $this->assertTrue($this->subject->check());
+    }
+
+    #[Test]
+    public function it_returns_false_on_laravel_10_or_lower(): void
+    {
+        if (version_compare(app()->version(), '11.0.0', '>=')) {
+            $this->markTestSkipped('Running on Laravel '.app()->version().' — skipping L10 assertion.');
+        }
+
+        $this->assertFalse($this->subject->check());
+    }
+}
+
+class ConcreteDetectsLaravelVersion
+{
+    use DetectsLaravelVersion;
+
+    public function check(): bool
+    {
+        return $this->isLaravel11OrNewer();
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `src/Concerns/DetectsLaravelVersion` trait with a single `isLaravel11OrNewer()` method using `version_compare(app()->version(), '11.0.0', '>=')` — authoritative, PHPStan Level 9 clean, no suppression annotations
- Removes the duplicated inline `isLaravel11OrNewer()` method from `UnusedGlobalMiddlewareAnalyzer`, `AuthenticationAnalyzer`, and `LoginThrottlingAnalyzer`; two of the three previously used `class_exists(Middleware::class)` which required `@phpstan-ignore-next-line`
- Adds `tests/Unit/Concerns/DetectsLaravelVersionTest.php` with 4 tests covering boolean return, version matching, and version-specific assertions (skipped when running on the wrong Laravel version)