### PR TITLE
fix: clear per-analyzer AST parser cache to prevent OOM on large runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.7.25
+
+### Fixed
+- `shield:analyze` no longer exhausts PHP memory when pro analyzers are installed — pro analyzers create private `AstParser` instances that bypass the container, making them invisible to the existing `clearParserCache()` singleton call; `runAll()`, `run()`, and `AnalyzeCommand` now call `clearAstParserCache()` via `method_exists()` after each `analyze()` invocation
+
 ## v1.7.24
 
 ### Changed

--- a/src/AnalyzerManager.php
+++ b/src/AnalyzerManager.php
@@ -266,6 +266,9 @@ class AnalyzerManager
         $results = $this->getAnalyzers()
             ->map(function (AnalyzerInterface $analyzer) {
                 $result = $analyzer->analyze();
+                if (method_exists($analyzer, 'clearAstParserCache')) {
+                    $analyzer->clearAstParserCache();
+                }
                 $this->clearParserCache();
                 $metadata = $analyzer->getMetadata();
 
@@ -441,6 +444,9 @@ class AnalyzerManager
         }
 
         $result = $analyzer->analyze();
+        if (method_exists($analyzer, 'clearAstParserCache')) {
+            $analyzer->clearAstParserCache();
+        }
         $this->clearParserCache();
         $metadata = $analyzer->getMetadata();
 

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -273,6 +273,9 @@ class AnalyzeCommand extends Command
 
                 // Run analyzer
                 $result = $analyzer->analyze();
+                if (method_exists($analyzer, 'clearAstParserCache')) {
+                    $analyzer->clearAstParserCache();
+                }
                 $manager->clearParserCache();
                 $metadata = $analyzer->getMetadata();
 
@@ -410,6 +413,9 @@ class AnalyzeCommand extends Command
 
                 // Run analyzer
                 $result = $analyzer->analyze();
+                if (method_exists($analyzer, 'clearAstParserCache')) {
+                    $analyzer->clearAstParserCache();
+                }
                 $manager->clearParserCache();
                 $metadata = $analyzer->getMetadata();
 
@@ -650,6 +656,9 @@ class AnalyzeCommand extends Command
                 $progressBar->setMessage($metadata->name);
             }
             $result = $analyzer->analyze();
+            if (method_exists($analyzer, 'clearAstParserCache')) {
+                $analyzer->clearAstParserCache();
+            }
             $manager->clearParserCache();
             if ($progressBar !== null) {
                 $progressBar->advance();

--- a/tests/Unit/AnalyzerManagerTest.php
+++ b/tests/Unit/AnalyzerManagerTest.php
@@ -713,6 +713,90 @@ class AnalyzerManagerTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    #[Test]
+    public function it_calls_clear_ast_parser_cache_on_analyzer_after_run_all(): void
+    {
+        $analyzerInstance = null;
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('make')
+            ->andReturnUsing(function (string $class) use (&$analyzerInstance) {
+                if ($class === ParserInterface::class) {
+                    throw new \RuntimeException('Not bound');
+                }
+                $instance = new $class;
+                if ($instance instanceof AnalyzerWithAstParserCache) {
+                    $analyzerInstance = $instance;
+                }
+
+                return $instance;
+            });
+
+        $config = Mockery::mock(Config::class);
+        $config->shouldReceive('get')
+            ->andReturnUsing(function (string $key, $default = null) {
+                $values = [
+                    'disabled_analyzers' => [],
+                    'analyzers' => [],
+                    'ci_mode' => false,
+                    'ci_mode_analyzers' => [],
+                    'ci_mode_exclude_analyzers' => [],
+                    'paths.analyze' => [],
+                    'excluded_paths' => [],
+                ];
+
+                return $values[str_replace('shieldci.', '', $key)] ?? $default;
+            });
+
+        $manager = new AnalyzerManager($config, [AnalyzerWithAstParserCache::class], $container);
+        $manager->runAll();
+
+        $this->assertNotNull($analyzerInstance);
+        $this->assertTrue($analyzerInstance->clearAstParserCacheCalled);
+    }
+
+    #[Test]
+    public function it_calls_clear_ast_parser_cache_on_analyzer_after_run(): void
+    {
+        $analyzerInstance = null;
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('make')
+            ->andReturnUsing(function (string $class) use (&$analyzerInstance) {
+                if ($class === ParserInterface::class) {
+                    throw new \RuntimeException('Not bound');
+                }
+                $instance = new $class;
+                if ($instance instanceof AnalyzerWithAstParserCache) {
+                    $analyzerInstance = $instance;
+                }
+
+                return $instance;
+            });
+
+        $config = Mockery::mock(Config::class);
+        $config->shouldReceive('get')
+            ->andReturnUsing(function (string $key, $default = null) {
+                $values = [
+                    'disabled_analyzers' => [],
+                    'analyzers' => [],
+                    'ci_mode' => false,
+                    'ci_mode_exclude_analyzers' => [],
+                    'ci_mode_analyzers' => [],
+                    'paths.analyze' => [],
+                    'excluded_paths' => [],
+                ];
+
+                return $values[str_replace('shieldci.', '', $key)] ?? $default;
+            });
+
+        $manager = new AnalyzerManager($config, [AnalyzerWithAstParserCache::class], $container);
+        $manager->run('ast-cache-analyzer');
+
+        $this->assertNotNull($analyzerInstance);
+        $this->assertTrue($analyzerInstance->clearAstParserCacheCalled);
+    }
+
     protected function createManager(array $analyzerClasses): AnalyzerManager
     {
         $config = Mockery::mock(Config::class);
@@ -1045,5 +1129,46 @@ class ParserWithoutClearCache implements ParserInterface
     public function collectStringLines(array $ast): array
     {
         return [];
+    }
+}
+
+class AnalyzerWithAstParserCache implements AnalyzerInterface
+{
+    public bool $clearAstParserCacheCalled = false;
+
+    public function clearAstParserCache(): void
+    {
+        $this->clearAstParserCacheCalled = true;
+    }
+
+    public function analyze(): ResultInterface
+    {
+        return AnalysisResult::passed('ast-cache-analyzer', 'Test passed');
+    }
+
+    public function getMetadata(): AnalyzerMetadata
+    {
+        return new AnalyzerMetadata(
+            id: 'ast-cache-analyzer',
+            name: 'AST Cache Analyzer',
+            description: 'Test analyzer with clearAstParserCache()',
+            category: Category::Security,
+            severity: Severity::High,
+        );
+    }
+
+    public function shouldRun(): bool
+    {
+        return true;
+    }
+
+    public function getSkipReason(): string
+    {
+        return '';
+    }
+
+    public function getId(): string
+    {
+        return 'ast-cache-analyzer';
     }
 }

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -4352,4 +4352,156 @@ PHP);
             ->assertSuccessful()
             ->doesntExpectOutputToContain('is not a recognized standard environment');
     }
+
+    // ─── clearAstParserCache() call site tests ────────────────────────
+
+    #[Test]
+    public function it_calls_clear_ast_parser_cache_in_streaming_single_analyzer_path(): void
+    {
+        $astCacheAnalyzer = new AnalyzeCommandAstCacheAnalyzer;
+
+        /** @phpstan-ignore-next-line */
+        $this->app->singleton(AnalyzerManager::class, function ($app) use ($astCacheAnalyzer) {
+            /** @var MockInterface&AnalyzerManager $manager */
+            $manager = Mockery::mock(AnalyzerManager::class);
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getAnalyzers')
+                ->andReturn(collect([$astCacheAnalyzer]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getSkippedAnalyzers')
+                ->andReturn(collect());
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
+
+            return $manager;
+        });
+
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'ast-cache-analyzer',
+            '--format' => 'console',
+        ])->assertSuccessful();
+
+        $this->assertTrue($astCacheAnalyzer->clearAstParserCacheCalled);
+    }
+
+    #[Test]
+    public function it_calls_clear_ast_parser_cache_in_streaming_category_path(): void
+    {
+        $astCacheAnalyzer = new AnalyzeCommandAstCacheAnalyzer;
+
+        /** @phpstan-ignore-next-line */
+        $this->app->singleton(AnalyzerManager::class, function ($app) use ($astCacheAnalyzer) {
+            /** @var MockInterface&AnalyzerManager $manager */
+            $manager = Mockery::mock(AnalyzerManager::class);
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getAnalyzers')
+                ->andReturn(collect([$astCacheAnalyzer]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getSkippedAnalyzers')
+                ->andReturn(collect());
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
+
+            return $manager;
+        });
+
+        $this->artisan('shield:analyze', ['--format' => 'console'])
+            ->assertSuccessful();
+
+        $this->assertTrue($astCacheAnalyzer->clearAstParserCacheCalled);
+    }
+
+    #[Test]
+    public function it_calls_clear_ast_parser_cache_in_non_streaming_path(): void
+    {
+        $astCacheAnalyzer = new AnalyzeCommandAstCacheAnalyzer;
+
+        /** @phpstan-ignore-next-line */
+        $this->app->singleton(AnalyzerManager::class, function ($app) use ($astCacheAnalyzer) {
+            /** @var MockInterface&AnalyzerManager $manager */
+            $manager = Mockery::mock(AnalyzerManager::class);
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getAnalyzers')
+                ->andReturn(collect([$astCacheAnalyzer]));
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('getSkippedAnalyzers')
+                ->andReturn(collect());
+
+            /** @phpstan-ignore-next-line */
+            $manager->shouldReceive('clearParserCache')
+                ->andReturn(null);
+
+            return $manager;
+        });
+
+        $this->artisan('shield:analyze', ['--format' => 'json'])
+            ->assertSuccessful();
+
+        $this->assertTrue($astCacheAnalyzer->clearAstParserCacheCalled);
+    }
+}
+
+class AnalyzeCommandAstCacheAnalyzer implements AnalyzerInterface
+{
+    public bool $clearAstParserCacheCalled = false;
+
+    public function clearAstParserCache(): void
+    {
+        $this->clearAstParserCacheCalled = true;
+    }
+
+    public function analyze(): ResultInterface
+    {
+        return new AnalysisResult(
+            analyzerId: 'ast-cache-analyzer',
+            status: Status::Passed,
+            message: 'No issues',
+            issues: [],
+            executionTime: 0.0,
+            metadata: [
+                'id' => 'ast-cache-analyzer',
+                'name' => 'AST Cache Analyzer',
+                'description' => 'Test analyzer',
+                'category' => Category::Security,
+                'severity' => Severity::High,
+                'docsUrl' => null,
+            ],
+        );
+    }
+
+    public function getMetadata(): AnalyzerMetadata
+    {
+        return new AnalyzerMetadata(
+            id: 'ast-cache-analyzer',
+            name: 'AST Cache Analyzer',
+            description: 'Test analyzer with clearAstParserCache',
+            category: Category::Security,
+            severity: Severity::High,
+        );
+    }
+
+    public function shouldRun(): bool
+    {
+        return true;
+    }
+
+    public function getSkipReason(): string
+    {
+        return '';
+    }
+
+    public function getId(): string
+    {
+        return 'ast-cache-analyzer';
+    }
 }


### PR DESCRIPTION
## Summary

- `AnalyzerManager::getAllInstances()` holds all analyzer instances alive for the full run via `$cachedAllInstances`
- Pro analyzers using `UsesAstParser` create `new AstParser` directly (bypassing the container), so the existing `clearParserCache()` singleton call never reached them
- After ~46 security analyzers each accumulated a full `$astCache` of parsed AST nodes, the 512 MB heap was exhausted mid-run
- Fix: call `clearAstParserCache()` via `method_exists()` guard after each `analyze()` in `runAll()`, `run()`, and all three loop sites in `AnalyzeCommand` — no interface changes required