### PR TITLE
fix: suppress false-positive plain-text password warnings for Filament dehydrateStateUsing

### DIFF
--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -266,6 +266,21 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
 
             $this->detectWeakHashing($file, $ast, $config, $issues);
             $this->detectWeakPasswordHashAlgorithm($file, $ast, $config, $issues);
+
+            // Same-file dehydrateStateUsing() + Hash::make is conclusive on its own:
+            // the hash runs before $data reaches any handler, whether the host is a
+            // Filament resource page or a standalone Livewire component with InteractsWithForms.
+            if ($this->astHasPasswordDehydration($ast)) {
+                continue;
+            }
+
+            // For Filament resource pages, also check sibling files in the same Pages/
+            // directory — CreateRecord pages typically delegate their form definition to
+            // the co-located EditRecord page, so the dehydrateStateUsing lives next door.
+            if ($this->isFilamentResourcePage($ast) && $this->hasSiblingWithPasswordDehydration($file)) {
+                continue;
+            }
+
             $this->detectPlainTextPasswordStorage($file, $ast, $issues);
             $this->detectPlainTextPasswordInMethodCalls($file, $ast, $issues);
         }
@@ -1659,6 +1674,121 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
         }
 
         return $paths;
+    }
+
+    /**
+     * Returns true if the AST contains a class that extends a Filament resource-page base.
+     *
+     * @param  array<Node>  $ast
+     */
+    private function isFilamentResourcePage(array $ast): bool
+    {
+        $filamentPageBases = ['CreateRecord', 'EditRecord', 'UpdateRecord', 'ViewRecord', 'ListRecords'];
+
+        /** @var array<Node\Stmt\Class_> $classes */
+        $classes = $this->parser->findNodes($ast, Node\Stmt\Class_::class);
+
+        foreach ($classes as $class) {
+            if (! $class instanceof Node\Stmt\Class_ || $class->extends === null) {
+                continue;
+            }
+
+            $parts = explode('\\', $class->extends->toString());
+            $shortName = (string) end($parts);
+
+            if (in_array($shortName, $filamentPageBases, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if any sibling file in the same directory contains a
+     * dehydrateStateUsing() call whose closure hashes the password argument.
+     *
+     * Used for Filament resource pages where CreateX.php has no form() definition
+     * but the co-located EditX.php defines the dehydrateStateUsing hashing.
+     */
+    private function hasSiblingWithPasswordDehydration(string $file): bool
+    {
+        $siblings = glob(dirname($file).'/*.php') ?: [];
+
+        foreach ($siblings as $sibling) {
+            if ($sibling === $file) {
+                continue;
+            }
+
+            $siblingAst = $this->parser->parseFile($sibling);
+            if (empty($siblingAst)) {
+                continue;
+            }
+
+            if ($this->astHasPasswordDehydration($siblingAst)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the AST contains a dehydrateStateUsing() call whose closure
+     * body applies Hash::make(), bcrypt(), or password_hash() to its argument.
+     *
+     * @param  array<Node>  $ast
+     */
+    private function astHasPasswordDehydration(array $ast): bool
+    {
+        /** @var array<Node\Expr\MethodCall> $methodCalls */
+        $methodCalls = $this->parser->findNodes($ast, Node\Expr\MethodCall::class);
+
+        foreach ($methodCalls as $call) {
+            if (! $call instanceof Node\Expr\MethodCall) {
+                continue;
+            }
+
+            if (! $call->name instanceof Node\Identifier || $call->name->name !== 'dehydrateStateUsing') {
+                continue;
+            }
+
+            if (empty($call->args) || ! isset($call->args[0]) || ! $call->args[0] instanceof Node\Arg) {
+                continue;
+            }
+
+            $closure = $call->args[0]->value;
+
+            if (! $closure instanceof Node\Expr\Closure && ! $closure instanceof Node\Expr\ArrowFunction) {
+                continue;
+            }
+
+            /** @var array<Node\Expr\StaticCall> $staticCalls */
+            $staticCalls = $this->parser->findNodes([$closure], Node\Expr\StaticCall::class);
+
+            foreach ($staticCalls as $inner) {
+                if ($inner instanceof Node\Expr\StaticCall
+                    && $inner->class instanceof Node\Name
+                    && $inner->class->toString() === 'Hash'
+                    && $inner->name instanceof Node\Identifier
+                    && $inner->name->name === 'make') {
+                    return true;
+                }
+            }
+
+            /** @var array<Node\Expr\FuncCall> $funcCalls */
+            $funcCalls = $this->parser->findNodes([$closure], Node\Expr\FuncCall::class);
+
+            foreach ($funcCalls as $func) {
+                if ($func instanceof Node\Expr\FuncCall
+                    && $func->name instanceof Node\Name
+                    && in_array($func->name->toString(), ['bcrypt', 'password_hash'], true)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/PasswordSecurityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/PasswordSecurityAnalyzerTest.php
@@ -5413,4 +5413,278 @@ PHP;
 
         $this->assertHasIssueContaining('No Password::defaults()', $result);
     }
+
+    // ==================== Filament dehydrateStateUsing False-Positive Tests ====================
+
+    public function test_does_not_flag_filament_edit_record_when_dehydrate_state_hashes_password(): void
+    {
+        // EditRecord page that defines its own form() with dehydrateStateUsing(Hash::make).
+        // By the time handleRecordUpdate() receives $data, the password is already hashed.
+        $editPage = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources\System\Admins\Pages;
+
+use App\Filament\Resources\System\Admins\AdminResource;
+use App\Models\User;
+use Filament\Forms;
+use Filament\Resources\Pages\EditRecord;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Hash;
+
+class EditAdmin extends EditRecord
+{
+    protected static string $resource = AdminResource::class;
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Forms\Components\TextInput::make('user.password')
+                ->label('Password')
+                ->password()
+                ->dehydrateStateUsing(fn (string $state): string => Hash::make($state))
+                ->required(fn (string $operation): bool => $operation === 'create'),
+        ]);
+    }
+
+    protected function handleRecordUpdate(\Illuminate\Database\Eloquent\Model $record, array $data): \Illuminate\Database\Eloquent\Model
+    {
+        $userData = [
+            'name' => $data['user']['name'],
+            'email' => $data['user']['email'],
+        ];
+
+        if (! empty($data['user']['password'])) {
+            $userData['password'] = $data['user']['password'];
+        }
+
+        $record->user()->update($userData);
+
+        return $record;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/System/Admins/Pages/EditAdmin.php' => $editPage,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $hasPlainTextIssue = false;
+        foreach ($result->getIssues() as $issue) {
+            if (isset($issue->metadata['issue_type']) && $issue->metadata['issue_type'] === 'plain_text_password') {
+                $hasPlainTextIssue = true;
+                break;
+            }
+        }
+
+        $this->assertFalse($hasPlainTextIssue, 'Should not flag $data[...][password] in EditRecord when dehydrateStateUsing hashes it');
+    }
+
+    public function test_does_not_flag_filament_create_record_when_sibling_page_dehydrates_password(): void
+    {
+        // CreateRecord page with no form() definition — the form is defined in the
+        // sibling EditRecord page which applies dehydrateStateUsing(Hash::make).
+        // The analyzer should detect the sibling-file dehydration and suppress the false positive.
+        $createPage = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources\System\Admins\Pages;
+
+use App\Filament\Resources\System\Admins\AdminResource;
+use App\Models\Admin;
+use App\Models\User;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+
+class CreateAdmin extends CreateRecord
+{
+    protected static string $resource = AdminResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $admin = Admin::create([
+            'is_active' => $data['is_active'] ?? true,
+        ]);
+
+        $user = new User;
+        $user->name = $data['user']['name'];
+        $user->email = $data['user']['email'];
+        $user->password = $data['user']['password'];
+
+        $admin->user()->save($user);
+
+        return $admin;
+    }
+}
+PHP;
+
+        $editPage = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources\System\Admins\Pages;
+
+use Filament\Forms;
+use Filament\Resources\Pages\EditRecord;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Hash;
+
+class EditAdmin extends EditRecord
+{
+    public function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Forms\Components\TextInput::make('user.password')
+                ->dehydrateStateUsing(fn (string $state): string => Hash::make($state)),
+        ]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/System/Admins/Pages/CreateAdmin.php' => $createPage,
+            'app/Filament/Resources/System/Admins/Pages/EditAdmin.php' => $editPage,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $hasPlainTextIssue = false;
+        foreach ($result->getIssues() as $issue) {
+            if (isset($issue->metadata['issue_type']) && $issue->metadata['issue_type'] === 'plain_text_password') {
+                $hasPlainTextIssue = true;
+                break;
+            }
+        }
+
+        $this->assertFalse($hasPlainTextIssue, 'Should not flag CreateRecord handler when sibling EditRecord page dehydrates password via Hash::make');
+    }
+
+    public function test_does_not_flag_tall_stack_livewire_component_with_filament_form_dehydration(): void
+    {
+        // Standalone Livewire component using Filament's InteractsWithForms — no resource
+        // page base class, but dehydrateStateUsing(Hash::make) is in the same file.
+        // $data returned by $this->form->getState() already contains the hashed password.
+        $component = <<<'PHP'
+<?php
+
+namespace App\Livewire\Auth;
+
+use App\Models\User;
+use Filament\Forms;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Component;
+
+class RegisterForm extends Component implements HasForms
+{
+    use InteractsWithForms;
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('password')
+                    ->password()
+                    ->dehydrateStateUsing(fn (string $state): string => Hash::make($state))
+                    ->required(),
+            ])
+            ->statePath('data');
+    }
+
+    public function register(): void
+    {
+        $data = $this->form->getState();
+
+        $user = new User;
+        $user->password = $data['password'];
+        $user->save();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Livewire/Auth/RegisterForm.php' => $component,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $hasPlainTextIssue = false;
+        foreach ($result->getIssues() as $issue) {
+            if (isset($issue->metadata['issue_type']) && $issue->metadata['issue_type'] === 'plain_text_password') {
+                $hasPlainTextIssue = true;
+                break;
+            }
+        }
+
+        $this->assertFalse($hasPlainTextIssue, 'Should not flag $data[password] in a TALL stack Livewire component when dehydrateStateUsing hashes it in the same file');
+    }
+
+    public function test_still_flags_filament_create_record_without_password_dehydration(): void
+    {
+        // A Filament CreateRecord page that genuinely stores the password as plain text —
+        // no dehydrateStateUsing with hashing anywhere in the Pages directory.
+        $createPage = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources\Users\Pages;
+
+use App\Models\User;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+
+class CreateUser extends CreateRecord
+{
+    protected function handleRecordCreation(array $data): Model
+    {
+        $user = new User;
+        $user->password = $data['password'];
+        $user->save();
+
+        return $user;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/Users/Pages/CreateUser.php' => $createPage,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $hasPlainTextIssue = false;
+        foreach ($result->getIssues() as $issue) {
+            if (isset($issue->metadata['issue_type']) && $issue->metadata['issue_type'] === 'plain_text_password') {
+                $hasPlainTextIssue = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($hasPlainTextIssue, 'Should still flag CreateRecord handler when no dehydrateStateUsing hashing is present');
+    }
 }


### PR DESCRIPTION
## Summary

- `PasswordSecurityAnalyzer` was flagging `$data['password']` assignments in Filament handler methods as plain-text password storage, even when `dehydrateStateUsing(fn ($state) => Hash::make($state))` was applied on the form component — meaning the value in `$data` was already a bcrypt hash by the time it reached `handleRecordCreation`/`handleRecordUpdate`
- Fix introduces two suppression signals checked before plain-text detection runs on each file:
  1. **Same-file** `dehydrateStateUsing` + `Hash::make`/`bcrypt` — covers `EditRecord` pages with inline `form()` **and** standalone TALL stack Livewire components using `InteractsWithForms`
  2. **Filament resource page** (extends `CreateRecord`/`EditRecord`/…) + **sibling file** in the same `Pages/` directory has the dehydration — covers `CreateRecord` pages that delegate their form to the co-located `EditRecord` page
- Adds four regression tests: `EditRecord` inline form, `CreateRecord` with sibling dehydration, standalone Livewire component, and the true-positive case where no hashing dehydration exists

## Root Cause

Filament's `dehydrateStateUsing()` fires during `Form::getState()`, which is called during form submission **before** data is handed to record lifecycle hooks. The analyzer's flat taint model had no model of this pipeline boundary and treated all `$data['password']` array accesses as raw user input.