### PR TITLE
fix: suppress false-positive unclosed @php block for single-statement @php(expr) directives

### DIFF
--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -160,6 +160,11 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
 
             // Check for @php block start
             if (preg_match('/@php\b/', $trimmed)) {
+                // Single-statement @php(expr) — self-closing, no @endphp needed
+                if (preg_match('/@php\s*\(/', $trimmed)) {
+                    continue;
+                }
+
                 $inPhpBlock = true;
                 $phpBlockStart = $lineNumber + 1;
                 $phpBlockLines = 0;

--- a/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
@@ -409,6 +409,27 @@ BLADE;
         $this->assertHasIssueContaining('Unclosed', $result);
     }
 
+    public function test_single_statement_php_directive_does_not_trigger_unclosed_block(): void
+    {
+        $blade = <<<'BLADE'
+<div>
+    @php($total = $days['total'])
+    @php($count = $items['count'])
+    <p>{{ $total }}</p>
+</div>
+BLADE;
+
+        $tempDir = $this->createTempDirectory(['views/single-php.blade.php' => $blade]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['views']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
     public function test_detects_inline_php(): void
     {
         $blade = <<<'BLADE'


### PR DESCRIPTION
## Summary

- `LogicInBladeAnalyzer` was matching `@php\b` for both the block form (`@php ... @endphp`) and the single-statement form (`@php($expr)`), entering block-tracking mode for both
- When a Blade file contained `@php($var = value)` lines (which are self-closing and never need `@endphp`), the analyzer incorrectly emitted an "Unclosed @php block detected" issue
- Added a guard in `analyzeBladeStructure` that detects `@php\s*\(` and skips block tracking for those lines
- Added a regression test covering multiple `@php($expr)` directives in a single template