### PR TITLE
chore: add v1.8.0 changelog entry and test coverage for Reporter version methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.8.0
+
+### Added
+- Platform integration config keys added to `config/shieldci.php`: `token` (`SHIELDCI_TOKEN`), `project_id` (`SHIELDCI_PROJECT_ID`), `api_url` (`SHIELDCI_API_URL`, default `https://shieldci.com`), and `report.send_to_api` (`SHIELDCI_SEND_TO_API`, default `false`) — connect to the ShieldCI dashboard for centralised results, historical trends, and team visibility; the package continues to work fully offline without credentials configured (#202)
+- `AnalysisReport` now carries `proPackageVersion` — included as `pro_package_version` in API payloads and JSON output when `shieldci/laravel-pro` is installed, allowing the platform to correlate results with the correct pro analyzer version (#202)
+- README: platform credentials setup with link to ShieldCI dashboard, `--report` flag usage examples, scheduling examples for Laravel 9/10/11+, and ShieldCI Pro analyzer counts by category (#202)
+
 ## v1.7.26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,8 @@
 ## v1.8.0
 
 ### Added
-- Platform integration config keys added to `config/shieldci.php`: `token` (`SHIELDCI_TOKEN`), `project_id` (`SHIELDCI_PROJECT_ID`), `api_url` (`SHIELDCI_API_URL`, default `https://shieldci.com`), and `report.send_to_api` (`SHIELDCI_SEND_TO_API`, default `false`) — connect to the ShieldCI dashboard for centralised results, historical trends, and team visibility; the package continues to work fully offline without credentials configured (#202)
-- `AnalysisReport` now carries `proPackageVersion` — included as `pro_package_version` in API payloads and JSON output when `shieldci/laravel-pro` is installed, allowing the platform to correlate results with the correct pro analyzer version (#202)
-- README: platform credentials setup with link to ShieldCI dashboard, `--report` flag usage examples, scheduling examples for Laravel 9/10/11+, and ShieldCI Pro analyzer counts by category (#202)
+- Platform integration config keys in `config/shieldci.php`: `token` (`SHIELDCI_TOKEN`), `project_id` (`SHIELDCI_PROJECT_ID`), `api_url` (`SHIELDCI_API_URL`), and `report.send_to_api` (`SHIELDCI_SEND_TO_API`) — send results to the ShieldCI dashboard via `shield:analyze --report`; the package works fully offline without credentials (#202)
+- `pro_package_version` included in API payloads and JSON output when `shieldci/laravel-pro` is installed (#202)
 
 ## v1.7.26
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Publish the configuration file:
 php artisan vendor:publish --tag=shieldci-config
 ```
 
+Add your ShieldCI credentials to `.env` (your API token is displayed when you create a project in the [ShieldCI dashboard](https://shieldci.com/dashboard)):
+
+```env
+SHIELDCI_TOKEN=your-api-token
+SHIELDCI_PROJECT_ID=your-project-id
+```
+
 ## Usage
 
 Run the analysis:
@@ -71,6 +78,25 @@ php artisan shield:analyze --format=json
 Save report to file:
 ```bash
 php artisan shield:analyze --output=report.json
+```
+
+Send results to ShieldCI platform:
+```bash
+php artisan shield:analyze --report
+```
+
+Schedule analysis with trigger tracking:
+```php
+// Laravel 11+ (routes/console.php)
+Schedule::command('shield:analyze --triggered-by=scheduled --report')->daily();
+
+// Laravel 11+ (bootstrap/app.php)
+->withSchedule(function (Schedule $schedule) {
+    $schedule->command('shield:analyze --triggered-by=scheduled --report')->daily();
+})
+
+// Laravel 9-10 (app/Console/Kernel.php)
+$schedule->command('shield:analyze --triggered-by=scheduled --report')->daily();
 ```
 
 ### Advanced Features
@@ -164,6 +190,25 @@ ShieldCI includes **73 comprehensive analyzers** across five categories:
 | Best Practices | 15 | Laravel-specific patterns |
 
 → [Full Analyzer Reference](https://docs.shieldci.com/analyzers/) — all 73 analyzers with examples and fix guidance
+
+### ShieldCI Pro
+
+[ShieldCI Pro](https://shieldci.com) adds **82 advanced analyzers** on top of the free package:
+
+| Category | Count | Coverage |
+|---|---|---|
+| Security | 45 | Enterprise-grade vulnerability detection |
+| Performance | 15 | Advanced performance optimization |
+| Reliability | 15 | Production-grade resilience checks |
+| Best Practices | 4 | Laravel architecture and conventions |
+| Code Quality | 3 | Test coverage and quality analysis |
+
+Highlights:
+- **Security** — command injection, SSRF, XXE, object injection, GDPR compliance, hard-coded credentials, cryptographic weaknesses; framework-specific checks for Sanctum, Horizon, Telescope, Nova, Livewire, Inertia, and FilamentPHP
+- **Performance** — Redis rate limiting, CDN/HTTP2/compression header analysis, lazy collection opportunities, FilamentPHP table optimization
+- **Reliability** — health check and alerting config, job queue config, Horizon status and provisioning, Redis eviction policy, Laravel Vapor config
+
+→ [Upgrade to Pro](https://shieldci.com)
 
 ## Configuration Options
 

--- a/config/shieldci.php
+++ b/config/shieldci.php
@@ -19,6 +19,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | ShieldCI Platform Integration
+    |--------------------------------------------------------------------------
+    |
+    | Connect to the ShieldCI platform for centralized dashboards, historical
+    | trends, and team-wide visibility. Sign up at https://shieldci.com
+    |
+    | These settings are optional. The package works fully offline without
+    | any platform credentials configured.
+    |
+    */
+
+    'token' => env('SHIELDCI_TOKEN'),
+
+    'project_id' => env('SHIELDCI_PROJECT_ID'),
+
+    'api_url' => env('SHIELDCI_API_URL', 'https://shieldci.com'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Documentation Base URL
     |--------------------------------------------------------------------------
     |
@@ -256,6 +275,8 @@ return [
         'snippet_syntax_highlighting' => env('SHIELDCI_SNIPPET_SYNTAX_HIGHLIGHTING', true), // Enable PHP syntax highlighting
 
         'max_issues_per_check' => env('SHIELDCI_MAX_ISSUES', 5), // Limit displayed issues per check
+
+        'send_to_api' => env('SHIELDCI_SEND_TO_API', false),
     ],
 
     /*

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -186,6 +186,7 @@ class AnalyzeCommand extends Command
             metadata: $report->metadata,
             suppressedIssues: $this->suppressedIssues,
             configuration: $report->configuration,
+            proPackageVersion: $report->proPackageVersion,
         );
 
         // Save to file if requested (CLI option or config default)
@@ -1406,6 +1407,7 @@ class AnalyzeCommand extends Command
             triggeredBy: $report->triggeredBy,
             metadata: $report->metadata,
             configuration: $report->configuration,
+            proPackageVersion: $report->proPackageVersion,
         );
     }
 
@@ -1493,6 +1495,7 @@ class AnalyzeCommand extends Command
             triggeredBy: $report->triggeredBy,
             metadata: $report->metadata,
             configuration: $report->configuration,
+            proPackageVersion: $report->proPackageVersion,
         );
     }
 
@@ -1628,6 +1631,7 @@ class AnalyzeCommand extends Command
             triggeredBy: $report->triggeredBy,
             metadata: $report->metadata,
             configuration: $report->configuration,
+            proPackageVersion: $report->proPackageVersion,
         );
     }
 

--- a/src/Support/Reporter.php
+++ b/src/Support/Reporter.php
@@ -38,6 +38,7 @@ class Reporter implements ReporterInterface
             triggeredBy: $triggeredBy,
             metadata: $this->buildMetadata($gitContext),
             configuration: $this->buildConfiguration(),
+            proPackageVersion: $this->getProPackageVersion(),
         );
     }
 
@@ -571,6 +572,15 @@ class Reporter implements ReporterInterface
         }
 
         return 'dev';
+    }
+
+    protected function getProPackageVersion(): ?string
+    {
+        if (class_exists(InstalledVersions::class) && InstalledVersions::isInstalled('shieldci/laravel-pro')) {
+            return InstalledVersions::getPrettyVersion('shieldci/laravel-pro');
+        }
+
+        return null;
     }
 
     /**

--- a/src/ValueObjects/AnalysisReport.php
+++ b/src/ValueObjects/AnalysisReport.php
@@ -33,6 +33,7 @@ final class AnalysisReport
         public readonly array $metadata = [],
         public readonly array $suppressedIssues = [],
         public readonly array $configuration = [],
+        public readonly ?string $proPackageVersion = null,
     ) {}
 
     public function score(): int
@@ -165,6 +166,7 @@ final class AnalysisReport
             'project_id' => $this->projectId,
             'laravel_version' => $this->laravelVersion,
             'package_version' => $this->packageVersion,
+            'pro_package_version' => $this->proPackageVersion,
             'triggered_by' => $this->triggeredBy->value,
             'analyzed_at' => $this->analyzedAt->format('c'),
             'total_execution_time' => $this->totalExecutionTime,

--- a/tests/Unit/Support/ReporterTest.php
+++ b/tests/Unit/Support/ReporterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Tests\Unit\Support;
 
+use Composer\InstalledVersions;
 use PHPUnit\Framework\Attributes\Test;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
@@ -1289,6 +1290,113 @@ class ReporterTest extends TestCase
         $this->assertEquals('15', $payload['metadata']['pr_number']);
         $this->assertEquals('acme/app', $payload['metadata']['repository']);
         $this->assertEquals('main', $payload['metadata']['base_branch']);
+    }
+
+    #[Test]
+    public function get_package_version_returns_actual_version_when_found_in_installed_versions(): void
+    {
+        [$installedProp, $byVendorProp, $isLocalDirProp] = $this->reflectInstalledVersionsProps();
+        $savedInstalled = $installedProp->getValue(null);
+        $savedIsLocalDir = $isLocalDirProp->getValue(null);
+
+        $this->injectInstalledVersions($installedProp, $byVendorProp, $isLocalDirProp, [
+            'versions' => [
+                'shieldci/laravel' => [
+                    'pretty_version' => '1.5.0',
+                    'version' => '1.5.0.0',
+                    'reference' => null,
+                    'type' => 'library',
+                    'install_path' => '/vendor/shieldci/laravel/',
+                    'aliases' => [],
+                    'dev_requirement' => false,
+                ],
+            ],
+        ]);
+
+        try {
+            $reflection = new \ReflectionMethod($this->reporter, 'getPackageVersion');
+            $reflection->setAccessible(true);
+            $this->assertEquals('1.5.0', $reflection->invoke($this->reporter));
+        } finally {
+            $installedProp->setValue(null, $savedInstalled);
+            $isLocalDirProp->setValue(null, $savedIsLocalDir);
+            $byVendorProp->setValue(null, []);
+        }
+    }
+
+    #[Test]
+    public function get_pro_package_version_returns_version_when_pro_is_installed(): void
+    {
+        [$installedProp, $byVendorProp, $isLocalDirProp] = $this->reflectInstalledVersionsProps();
+        $savedInstalled = $installedProp->getValue(null);
+        $savedIsLocalDir = $isLocalDirProp->getValue(null);
+
+        $this->injectInstalledVersions($installedProp, $byVendorProp, $isLocalDirProp, [
+            'versions' => [
+                'shieldci/laravel-pro' => [
+                    'pretty_version' => '2.0.0',
+                    'version' => '2.0.0.0',
+                    'reference' => null,
+                    'type' => 'library',
+                    'install_path' => '/vendor/shieldci/laravel-pro/',
+                    'aliases' => [],
+                    'dev_requirement' => false,
+                ],
+            ],
+        ]);
+
+        try {
+            $reflection = new \ReflectionMethod($this->reporter, 'getProPackageVersion');
+            $reflection->setAccessible(true);
+            $this->assertEquals('2.0.0', $reflection->invoke($this->reporter));
+        } finally {
+            $installedProp->setValue(null, $savedInstalled);
+            $isLocalDirProp->setValue(null, $savedIsLocalDir);
+            $byVendorProp->setValue(null, []);
+        }
+    }
+
+    /**
+     * @return array{\ReflectionProperty, \ReflectionProperty, \ReflectionProperty}
+     */
+    private function reflectInstalledVersionsProps(): array
+    {
+        $make = static function (string $name): \ReflectionProperty {
+            $prop = new \ReflectionProperty(InstalledVersions::class, $name);
+            $prop->setAccessible(true);
+
+            return $prop;
+        };
+
+        return [$make('installed'), $make('installedByVendor'), $make('installedIsLocalDir')];
+    }
+
+    /**
+     * @param  array{versions: array<string, mixed>}  $testVersions
+     */
+    private function injectInstalledVersions(
+        \ReflectionProperty $installedProp,
+        \ReflectionProperty $byVendorProp,
+        \ReflectionProperty $isLocalDirProp,
+        array $testVersions
+    ): void {
+        // Set test data as the primary installed dataset
+        $installedProp->setValue(null, array_merge([
+            'root' => ['name' => 'test/project', 'pretty_version' => '1.0.0', 'version' => '1.0.0.0', 'reference' => null, 'type' => 'project', 'install_path' => '/', 'aliases' => [], 'dev' => true],
+        ], $testVersions));
+
+        // Mark $installed as NOT from the local vendor dir so getInstalled() appends it
+        // at the end of the dataset list (after the vendor cache entries)
+        $isLocalDirProp->setValue(null, false);
+
+        // Pre-fill $installedByVendor with an empty entry for the local vendor dir,
+        // preventing the real installed.php from being re-read and shadowing our test data
+        $installedFile = (new \ReflectionClass(InstalledVersions::class))->getFileName();
+        $vendorDir = is_string($installedFile) ? strtr(dirname(dirname($installedFile)), '\\', '/') : '';
+        $byVendorProp->setValue(null, [$vendorDir => [
+            'root' => ['name' => 'empty', 'pretty_version' => '1.0.0', 'version' => '1.0.0.0', 'reference' => null, 'type' => 'project', 'install_path' => '/', 'aliases' => [], 'dev' => false],
+            'versions' => [],
+        ]]);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Adds the v1.8.0 changelog entry for PR #202 (platform integration config keys and `pro_package_version` in API payloads)
- Adds test coverage for the two previously unreachable branches in `Reporter`: `getPackageVersion()` returning an actual version string (line 573) and `getProPackageVersion()` returning a version when `laravel-pro` is installed (line 580)