### PR TITLE
chore: improve package metadata and fix README accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ![ShieldCI terminal demo](https://raw.githubusercontent.com/ShieldCI/laravel/master/.github/assets/analyzer-terminal.gif)
 
-Open-source code quality analysis for Laravel applications with 73 comprehensive analyzers covering security, performance, reliability, code quality, and best practices.
+Automated code analysis for Laravel applications — 73 open-source analyzers covering security, performance, reliability, code quality, and best practices.
 
 Built on top of [`shieldci/analyzers-core`](https://github.com/ShieldCI/analyzers-core) (v1.x) - a shared, framework-agnostic foundation for static analysis tools.
 
@@ -285,7 +285,7 @@ class MyAnalyzer extends AbstractFileAnalyzer
 ## Testing
 
 ```bash
-composer test           # 400+ tests
+composer test           # 4,000+ tests
 composer test-coverage  # 98%+ code coverage
 composer analyse        # PHPStan Level 9
 ```

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,10 @@
         "audit": {
             "ignore": {
                 "PKSA-8qx3-n5y5-vvnd": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions",
-                "PKSA-w7xr-vk7n-rstm": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions"
+                "PKSA-w7xr-vk7n-rstm": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions",
+                "PKSA-mdq4-51ck-6kdq": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions",
+                "PKSA-q46n-4fdk-zjr4": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions",
+                "PKSA-qzrn-rnz3-85w1": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,17 @@
 {
     "name": "shieldci/laravel",
-    "description": "ShieldCI Laravel Package - Security and code quality analysis for Laravel applications",
+    "description": "Automated code analysis for Laravel applications covering security, performance, reliability, code quality and best practices.",
     "keywords": [
         "laravel",
         "security",
-        "static-analysis",
+        "performance",
+        "reliability",
         "code-quality",
+        "best-practices",
+        "static-analysis",
         "vulnerability-scanner",
+        "enlightn",
+        "enlightn-alternative",
         "shieldci"
     ],
     "type": "library",


### PR DESCRIPTION
## Summary

Polishes the package's public-facing metadata, corrects a README inaccuracy, and unblocks CI dependency resolution under Composer 2.9+.

### composer.json — metadata
- **Description** broadened to cover all five analyzer categories (was only "security and code quality").
- **Keywords** expanded: added `performance`, `reliability`, `best-practices`, `enlightn`, and `enlightn-alternative`.

### composer.json — CI advisory fix
Composer 2.9+ blocks installing packages affected by security advisories during dependency resolution. The CI matrix tests Laravel 9/10/11, whose entire release lines carry framework advisories, so `composer update` could not resolve an installable version. Added the three additional advisory IDs (`PKSA-mdq4-51ck-6kdq`, `PKSA-q46n-4fdk-zjr4`, `PKSA-qzrn-rnz3-85w1`) to the existing dev-only `config.audit.ignore` list — these reach the project only via `orchestra/testbench` when testing older Laravel versions and are not shipped to consumers. Verified locally that Laravel 9, 10, and 11 all resolve cleanly with the updated list.

### README.md
- Fixed test count: `400+` → `4,000+` (the suite has 4,097 registered tests).
- Reworded the lead sentence to match the new package description.