### PR TITLE
fix: resolve analyzer false positives on Filament 4 projects

### DIFF
--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -170,6 +170,41 @@ class TransactionVisitor extends NodeVisitorAbstract
     private int $earlyExitIfDepth = 0;
 
     /**
+     * Heaviest sibling-closure contribution for the current scope. Independent
+     * callback closures (e.g. Filament ->action(fn...)) are mutually-exclusive
+     * dispatch paths that never co-execute, so — like if/else branches — only the
+     * heaviest one counts toward the enclosing scope, not the sum of all of them.
+     */
+    private int $maxClosureWrites = 0;
+
+    private int $maxClosureUnprotected = 0;
+
+    /** @var list<int> Unprotected write lines of the heaviest sibling closure. */
+    private array $maxClosureLines = [];
+
+    /**
+     * Stack of saved parent-scope counters while traversing a callback closure.
+     * Each callback closure is its own write-counting unit; on entry we snapshot
+     * and reset the counters, on exit we restore them and fold the closure in as a
+     * sibling (max), never summing across siblings.
+     *
+     * @var list<array{
+     *   writeOperations: int,
+     *   writeOperationsInTransaction: int,
+     *   unprotectedWriteLines: list<int>,
+     *   isolatedWrites: int,
+     *   earlyExitIfDepth: int,
+     *   earlyExitIfPositions: array<int, true>,
+     *   guardClauseElsePositions: array<int, true>,
+     *   ifElseBranchStack: list<array{pos: int, elsePos: int, inElse: bool, ifWrites: int, elseWrites: int, ifLines: list<int>, elseLines: list<int>}>,
+     *   maxClosureWrites: int,
+     *   maxClosureUnprotected: int,
+     *   maxClosureLines: list<int>
+     * }>
+     */
+    private array $closureScopeStack = [];
+
+    /**
      * Track file positions of closures passed directly to DB::transaction().
      *
      * @var array<int, true>
@@ -243,6 +278,10 @@ class TransactionVisitor extends NodeVisitorAbstract
             $this->earlyExitIfPositions = [];
             $this->guardClauseElsePositions = [];
             $this->ifElseBranchStack = [];
+            $this->maxClosureWrites = 0;
+            $this->maxClosureUnprotected = 0;
+            $this->maxClosureLines = [];
+            $this->closureScopeStack = [];
         }
 
         // Check for DB::transaction or DB::beginTransaction
@@ -272,11 +311,16 @@ class TransactionVisitor extends NodeVisitorAbstract
             }
         }
 
-        // Track entering transaction closure (only closures actually passed to DB::transaction)
+        // Track entering a closure. A closure passed directly to DB::transaction()
+        // marks protection (transactionDepth). Any other callback closure is an
+        // independent execution unit (e.g. a Filament ->action(fn...) handler that
+        // fires on a separate request) and gets its own write-counting scope.
         if ($node instanceof Node\Expr\Closure || $node instanceof Node\Expr\ArrowFunction) {
             $pos = $node->getStartFilePos();
             if (isset($this->transactionClosurePositions[$pos])) {
                 $this->transactionDepth++;
+            } else {
+                $this->pushClosureScope();
             }
         }
 
@@ -374,11 +418,17 @@ class TransactionVisitor extends NodeVisitorAbstract
 
     public function leaveNode(Node $node): ?Node
     {
-        // Track leaving transaction closure (only decrement for closures actually in transaction)
+        // Track leaving a closure: decrement transaction depth for a DB::transaction()
+        // closure, otherwise fold the independent callback closure back into its
+        // parent scope as a sibling (max, not sum).
         if ($node instanceof Node\Expr\Closure || $node instanceof Node\Expr\ArrowFunction) {
             $pos = $node->getStartFilePos();
-            if (isset($this->transactionClosurePositions[$pos]) && $this->transactionDepth > 0) {
-                $this->transactionDepth--;
+            if (isset($this->transactionClosurePositions[$pos])) {
+                if ($this->transactionDepth > 0) {
+                    $this->transactionDepth--;
+                }
+            } else {
+                $this->popClosureScope();
             }
         }
 
@@ -449,26 +499,33 @@ class TransactionVisitor extends NodeVisitorAbstract
             $mainFlowWrites = $this->writeOperations - $this->isolatedWrites;
             $mainFlowUnprotected = $mainFlowWrites - $this->writeOperationsInTransaction;
 
-            // If all main-flow writes are protected, no issue
-            if ($mainFlowUnprotected <= 0) {
+            // Fold in the heaviest sibling callback closure. Main-flow writes co-execute
+            // with whichever single callback fires, so we add the heaviest closure's
+            // counts; sibling closures never co-execute with each other, so they are
+            // not summed (only the max is kept).
+            $effectiveWrites = $mainFlowWrites + $this->maxClosureWrites;
+            $effectiveUnprotected = $mainFlowUnprotected + $this->maxClosureUnprotected;
+
+            // If all effective writes are protected, no issue
+            if ($effectiveUnprotected <= 0) {
                 return null;
             }
 
-            // If main-flow writes >= threshold, they should be protected
-            if ($mainFlowWrites >= $this->threshold) {
+            // If effective writes >= threshold, they should be protected
+            if ($effectiveWrites >= $this->threshold) {
                 $this->issues[] = [
                     'message' => sprintf(
                         'Method "%s::%s()" has %d database write operation(s) outside transaction protection',
                         $this->currentClassName ?? 'Unknown',
                         $this->currentMethodName ?? 'unknown',
-                        $mainFlowUnprotected
+                        $effectiveUnprotected
                     ),
                     'line' => $this->methodStartLine,
                     'severity' => Severity::High,
                     'recommendation' => sprintf(
                         'Wrap all related write operations in a database transaction to ensure atomicity. '.
                         'Unprotected write operations at lines: %s',
-                        implode(', ', $this->unprotectedWriteLines)
+                        implode(', ', array_merge($this->unprotectedWriteLines, $this->maxClosureLines))
                     ),
                     'code' => null,
                 ];
@@ -476,6 +533,83 @@ class TransactionVisitor extends NodeVisitorAbstract
         }
 
         return null;
+    }
+
+    /**
+     * Snapshot the current scope's write counters and reset them so the callback
+     * closure body is counted as its own independent unit. Transaction depth is
+     * intentionally inherited, so a synchronous closure inside DB::transaction()
+     * remains protected.
+     */
+    private function pushClosureScope(): void
+    {
+        $this->closureScopeStack[] = [
+            'writeOperations' => $this->writeOperations,
+            'writeOperationsInTransaction' => $this->writeOperationsInTransaction,
+            'unprotectedWriteLines' => $this->unprotectedWriteLines,
+            'isolatedWrites' => $this->isolatedWrites,
+            'earlyExitIfDepth' => $this->earlyExitIfDepth,
+            'earlyExitIfPositions' => $this->earlyExitIfPositions,
+            'guardClauseElsePositions' => $this->guardClauseElsePositions,
+            'ifElseBranchStack' => $this->ifElseBranchStack,
+            'maxClosureWrites' => $this->maxClosureWrites,
+            'maxClosureUnprotected' => $this->maxClosureUnprotected,
+            'maxClosureLines' => $this->maxClosureLines,
+        ];
+
+        $this->writeOperations = 0;
+        $this->writeOperationsInTransaction = 0;
+        $this->unprotectedWriteLines = [];
+        $this->isolatedWrites = 0;
+        $this->earlyExitIfDepth = 0;
+        $this->earlyExitIfPositions = [];
+        $this->guardClauseElsePositions = [];
+        $this->ifElseBranchStack = [];
+        $this->maxClosureWrites = 0;
+        $this->maxClosureUnprotected = 0;
+        $this->maxClosureLines = [];
+    }
+
+    /**
+     * Restore the parent scope's counters and fold this closure in as a sibling:
+     * its effective writes (own main flow + its own heaviest child closure)
+     * contribute to the parent via max(), never summed across siblings.
+     */
+    private function popClosureScope(): void
+    {
+        if ($this->closureScopeStack === []) {
+            return;
+        }
+
+        // Effective metrics for the closure we are leaving (mirror the method check).
+        $closureMainWrites = $this->writeOperations - $this->isolatedWrites;
+        $closureMainUnprotected = $closureMainWrites - $this->writeOperationsInTransaction;
+        $effClosureWrites = $closureMainWrites + $this->maxClosureWrites;
+        $effClosureUnprotected = $closureMainUnprotected + $this->maxClosureUnprotected;
+        $effClosureLines = array_merge($this->unprotectedWriteLines, $this->maxClosureLines);
+
+        $frame = array_pop($this->closureScopeStack);
+
+        $this->writeOperations = $frame['writeOperations'];
+        $this->writeOperationsInTransaction = $frame['writeOperationsInTransaction'];
+        $this->unprotectedWriteLines = $frame['unprotectedWriteLines'];
+        $this->isolatedWrites = $frame['isolatedWrites'];
+        $this->earlyExitIfDepth = $frame['earlyExitIfDepth'];
+        $this->earlyExitIfPositions = $frame['earlyExitIfPositions'];
+        $this->guardClauseElsePositions = $frame['guardClauseElsePositions'];
+        $this->ifElseBranchStack = $frame['ifElseBranchStack'];
+        $this->maxClosureWrites = $frame['maxClosureWrites'];
+        $this->maxClosureUnprotected = $frame['maxClosureUnprotected'];
+        $this->maxClosureLines = $frame['maxClosureLines'];
+
+        // Fold the just-left closure into the restored parent as the heaviest sibling.
+        if ($effClosureWrites > $this->maxClosureWrites) {
+            $this->maxClosureWrites = $effClosureWrites;
+        }
+        if ($effClosureUnprotected > $this->maxClosureUnprotected) {
+            $this->maxClosureUnprotected = $effClosureUnprotected;
+            $this->maxClosureLines = $effClosureLines;
+        }
     }
 
     /**

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -182,6 +182,9 @@ class TransactionVisitor extends NodeVisitorAbstract
     /** @var list<int> Unprotected write lines of the heaviest sibling closure. */
     private array $maxClosureLines = [];
 
+    /** Declaration line of the heaviest sibling closure, used to locate the issue. */
+    private int $maxClosureLine = 0;
+
     /**
      * Stack of saved parent-scope counters while traversing a callback closure.
      * Each callback closure is its own write-counting unit; on entry we snapshot
@@ -199,7 +202,8 @@ class TransactionVisitor extends NodeVisitorAbstract
      *   ifElseBranchStack: list<array{pos: int, elsePos: int, inElse: bool, ifWrites: int, elseWrites: int, ifLines: list<int>, elseLines: list<int>}>,
      *   maxClosureWrites: int,
      *   maxClosureUnprotected: int,
-     *   maxClosureLines: list<int>
+     *   maxClosureLines: list<int>,
+     *   maxClosureLine: int
      * }>
      */
     private array $closureScopeStack = [];
@@ -281,6 +285,7 @@ class TransactionVisitor extends NodeVisitorAbstract
             $this->maxClosureWrites = 0;
             $this->maxClosureUnprotected = 0;
             $this->maxClosureLines = [];
+            $this->maxClosureLine = 0;
             $this->closureScopeStack = [];
         }
 
@@ -428,7 +433,7 @@ class TransactionVisitor extends NodeVisitorAbstract
                     $this->transactionDepth--;
                 }
             } else {
-                $this->popClosureScope();
+                $this->popClosureScope($node);
             }
         }
 
@@ -513,14 +518,24 @@ class TransactionVisitor extends NodeVisitorAbstract
 
             // If effective writes >= threshold, they should be protected
             if ($effectiveWrites >= $this->threshold) {
+                // When every unprotected write lives inside a callback closure (the
+                // method's own body has none), attribute the issue to that closure's
+                // location instead of the method declaration. Otherwise a long Filament
+                // table()/form() would be reported at its signature line, far from the
+                // offending callback (e.g. an ->action(fn ...) handler).
+                $closureDriven = $mainFlowUnprotected <= 0 && $this->maxClosureLine > 0;
+
+                $subject = $closureDriven
+                    ? sprintf('Closure in "%s::%s()"', $this->currentClassName ?? 'Unknown', $this->currentMethodName ?? 'unknown')
+                    : sprintf('Method "%s::%s()"', $this->currentClassName ?? 'Unknown', $this->currentMethodName ?? 'unknown');
+
                 $this->issues[] = [
                     'message' => sprintf(
-                        'Method "%s::%s()" has %d database write operation(s) outside transaction protection',
-                        $this->currentClassName ?? 'Unknown',
-                        $this->currentMethodName ?? 'unknown',
+                        '%s has %d database write operation(s) outside transaction protection',
+                        $subject,
                         $effectiveUnprotected
                     ),
-                    'line' => $this->methodStartLine,
+                    'line' => $closureDriven ? $this->maxClosureLine : $this->methodStartLine,
                     'severity' => Severity::High,
                     'recommendation' => sprintf(
                         'Wrap all related write operations in a database transaction to ensure atomicity. '.
@@ -555,6 +570,7 @@ class TransactionVisitor extends NodeVisitorAbstract
             'maxClosureWrites' => $this->maxClosureWrites,
             'maxClosureUnprotected' => $this->maxClosureUnprotected,
             'maxClosureLines' => $this->maxClosureLines,
+            'maxClosureLine' => $this->maxClosureLine,
         ];
 
         $this->writeOperations = 0;
@@ -568,6 +584,7 @@ class TransactionVisitor extends NodeVisitorAbstract
         $this->maxClosureWrites = 0;
         $this->maxClosureUnprotected = 0;
         $this->maxClosureLines = [];
+        $this->maxClosureLine = 0;
     }
 
     /**
@@ -575,7 +592,7 @@ class TransactionVisitor extends NodeVisitorAbstract
      * its effective writes (own main flow + its own heaviest child closure)
      * contribute to the parent via max(), never summed across siblings.
      */
-    private function popClosureScope(): void
+    private function popClosureScope(Node $closure): void
     {
         if ($this->closureScopeStack === []) {
             return;
@@ -601,6 +618,7 @@ class TransactionVisitor extends NodeVisitorAbstract
         $this->maxClosureWrites = $frame['maxClosureWrites'];
         $this->maxClosureUnprotected = $frame['maxClosureUnprotected'];
         $this->maxClosureLines = $frame['maxClosureLines'];
+        $this->maxClosureLine = $frame['maxClosureLine'];
 
         // Fold the just-left closure into the restored parent as the heaviest sibling.
         if ($effClosureWrites > $this->maxClosureWrites) {
@@ -609,6 +627,8 @@ class TransactionVisitor extends NodeVisitorAbstract
         if ($effClosureUnprotected > $this->maxClosureUnprotected) {
             $this->maxClosureUnprotected = $effClosureUnprotected;
             $this->maxClosureLines = $effClosureLines;
+            // Record this closure's declaration line so the issue can point at it.
+            $this->maxClosureLine = $closure->getStartLine();
         }
     }
 

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -127,7 +127,7 @@ class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
         }
 
         return $this->resultBySeverity(
-            sprintf('Found %d method(s) with multiple writes missing transaction protection', count($issues)),
+            sprintf('Found %d location(s) with multiple writes missing transaction protection', count($issues)),
             $issues
         );
     }

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -621,10 +621,16 @@ class TransactionVisitor extends NodeVisitorAbstract
         $this->maxClosureLine = $frame['maxClosureLine'];
 
         // Fold the just-left closure into the restored parent as the heaviest sibling.
-        if ($effClosureWrites > $this->maxClosureWrites) {
+        // Only closures that contain unprotected writes can add transaction risk to the
+        // parent; fully-protected closures (e.g. an ->action() that wraps its writes in
+        // DB::transaction()) contribute nothing. Among the unprotected siblings we keep
+        // the heaviest (by write count) as a COHERENT unit — its own writes, unprotected
+        // count, lines and declaration line are kept together. Metrics are never mixed
+        // across siblings, which never co-execute on the same request: doing so would,
+        // for example, pair a protected sibling's write count with another sibling's lone
+        // unprotected write and report a phantom multi-write transaction gap.
+        if ($effClosureUnprotected > 0 && $effClosureWrites > $this->maxClosureWrites) {
             $this->maxClosureWrites = $effClosureWrites;
-        }
-        if ($effClosureUnprotected > $this->maxClosureUnprotected) {
             $this->maxClosureUnprotected = $effClosureUnprotected;
             $this->maxClosureLines = $effClosureLines;
             // Record this closure's declaration line so the issue can point at it.
@@ -737,6 +743,27 @@ class TransactionVisitor extends NodeVisitorAbstract
         return false;
     }
 
+    /**
+     * Detect a fluent builder chain rooted at a `SomeComponent::make(...)` static call
+     * — the universal factory convention for Filament/Livewire/Forms builders. Methods
+     * such as ->toggle()/->sync() on such a chain configure UI; they are not Eloquent
+     * relationship writes. A real relationship op is rooted on a model instance
+     * (e.g. $user->roles()->toggle()) or a query (User::find($id)->roles()->sync()),
+     * neither of which has a `make` root.
+     */
+    private function isFluentMakeBuilderChain(Node\Expr\MethodCall $node): bool
+    {
+        $current = $node->var;
+
+        while ($current instanceof Node\Expr\MethodCall) {
+            $current = $current->var;
+        }
+
+        return $current instanceof Node\Expr\StaticCall
+            && $current->name instanceof Node\Identifier
+            && $current->name->toString() === 'make';
+    }
+
     private function isWriteOperation(Node $node): bool
     {
         // Static method calls
@@ -801,6 +828,13 @@ class TransactionVisitor extends NodeVisitorAbstract
                 // Relationship sync/attach/detach
                 $relationMethods = ['sync', 'attach', 'detach', 'toggle', 'syncWithoutDetaching'];
                 if (in_array($method, $relationMethods, true)) {
+                    // Skip fluent builder chains like Filament's
+                    // Filter::make('x')->...->toggle(), which configure UI and are not
+                    // Eloquent relationship writes.
+                    if ($this->isFluentMakeBuilderChain($node)) {
+                        return false;
+                    }
+
                     return true;
                 }
             }

--- a/src/Analyzers/CodeQuality/MethodLengthAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MethodLengthAnalyzer.php
@@ -15,6 +15,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Concerns\ClassifiesFiles;
 
 /**
  * Flags methods and functions exceeding recommended line count.
@@ -24,10 +25,14 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
  * - Counts physical lines (from declaration to closing brace)
  * - Excludes simple getter/setter patterns (get*, set*, is*, has*) only if ≤ 10 lines
  * - Large methods matching exclude patterns are still flagged (prevents hiding real problems)
+ * - Skips development/data files (seeders, migrations, factories, tests) where method
+ *   length measures data/schema volume rather than code complexity
  * - Differentiates between global functions and class methods in messaging
  */
 class MethodLengthAnalyzer extends AbstractFileAnalyzer
 {
+    use ClassifiesFiles;
+
     public const DEFAULT_THRESHOLD = 50;
 
     /** @var array<string> */
@@ -95,6 +100,13 @@ class MethodLengthAnalyzer extends AbstractFileAnalyzer
         $ignoreFluentChains = $this->ignoreFluentChains;
 
         foreach ($this->getPhpFiles() as $file) {
+            // Skip development/data files (seeders, migrations, factories, tests):
+            // their methods are data dumps or schema definitions whose length reflects
+            // data volume, not code complexity — flagging them is noise.
+            if ($this->isTestFile($file) || $this->isDevelopmentFile($file)) {
+                continue;
+            }
+
             $ast = $this->parser->parseFile($file);
 
             if (empty($ast)) {

--- a/src/Analyzers/CodeQuality/MethodLengthAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MethodLengthAnalyzer.php
@@ -39,12 +39,21 @@ class MethodLengthAnalyzer extends AbstractFileAnalyzer
      */
     public const SIMPLE_ACCESSOR_MAX_LINES = 10;
 
+    /**
+     * Maximum number of top-level statements a method may have to still qualify as a
+     * declarative fluent-builder (e.g. Filament form()/table()/panel(), migration up()).
+     * Such methods derive their length from configuration size, not branching logic.
+     */
+    public const MAX_DECLARATIVE_STATEMENTS = 5;
+
     private int $threshold;
 
     /** @var array<string> */
     private array $excludedPatterns;
 
     private int $simpleAccessorMaxLines;
+
+    private bool $ignoreFluentChains;
 
     public function __construct(
         private ParserInterface $parser,
@@ -76,11 +85,14 @@ class MethodLengthAnalyzer extends AbstractFileAnalyzer
         $this->excludedPatterns = is_array($excludePatterns) ? array_values(array_filter($excludePatterns, 'is_string')) : self::DEFAULT_EXCLUDED_PATTERNS;
         $simpleAccessorVal = $analyzerConfig['simple_accessor_max_lines'] ?? self::SIMPLE_ACCESSOR_MAX_LINES;
         $this->simpleAccessorMaxLines = is_int($simpleAccessorVal) ? $simpleAccessorVal : self::SIMPLE_ACCESSOR_MAX_LINES;
+        $ignoreFluentVal = $analyzerConfig['ignore_fluent_chains'] ?? true;
+        $this->ignoreFluentChains = is_bool($ignoreFluentVal) ? $ignoreFluentVal : true;
 
         $issues = [];
         $threshold = $this->threshold;
         $excludePatterns = $this->excludedPatterns;
         $simpleAccessorMaxLines = $this->simpleAccessorMaxLines;
+        $ignoreFluentChains = $this->ignoreFluentChains;
 
         foreach ($this->getPhpFiles() as $file) {
             $ast = $this->parser->parseFile($file);
@@ -89,7 +101,7 @@ class MethodLengthAnalyzer extends AbstractFileAnalyzer
                 continue;
             }
 
-            $visitor = new MethodLengthVisitor($threshold, $excludePatterns, $simpleAccessorMaxLines);
+            $visitor = new MethodLengthVisitor($threshold, $excludePatterns, $simpleAccessorMaxLines, $ignoreFluentChains);
             $traverser = new NodeTraverser;
             $traverser->addVisitor($visitor);
             $traverser->traverse($ast);
@@ -184,11 +196,13 @@ class MethodLengthVisitor extends NodeVisitorAbstract
     /**
      * @param  array<string>  $excludePatterns
      * @param  int  $simpleAccessorMaxLines  Maximum lines for a method to be considered a simple accessor
+     * @param  bool  $ignoreFluentChains  Skip declarative single-expression builder methods
      */
     public function __construct(
         private int $threshold,
         private array $excludePatterns = [],
-        private int $simpleAccessorMaxLines = MethodLengthAnalyzer::SIMPLE_ACCESSOR_MAX_LINES
+        private int $simpleAccessorMaxLines = MethodLengthAnalyzer::SIMPLE_ACCESSOR_MAX_LINES,
+        private bool $ignoreFluentChains = true
     ) {}
 
     public function enterNode(Node $node)
@@ -203,6 +217,13 @@ class MethodLengthVisitor extends NodeVisitorAbstract
 
             // Only exclude if it matches pattern AND is small (simple accessor)
             if ($this->shouldExclude($name, $physicalLines)) {
+                return null;
+            }
+
+            // Declarative fluent-builder methods (Filament form()/table(), migration
+            // up(), route definitions) get their length from configuration size, not
+            // branching complexity — exclude them when enabled.
+            if ($this->ignoreFluentChains && $this->isDeclarativeFluentMethod($node)) {
                 return null;
             }
 
@@ -241,6 +262,117 @@ class MethodLengthVisitor extends NodeVisitorAbstract
             $regex = '/^'.str_replace('\\*', '.*', $escaped).'$/i';
             if (preg_match($regex, $name)) {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether a method/function is a declarative fluent-builder.
+     *
+     * These methods consist of a handful of top-level statements that build or
+     * return a fluent chain / nested array (e.g. Filament form()/table()/panel(),
+     * a migration's Schema::create() call, or a route group). Their physical length
+     * tracks how much configuration they declare, not branching logic, so counting
+     * lines produces noise. Control flow nested inside callback closures (e.g.
+     * ->action(fn () => ...) or the Blueprint closure) is intentionally ignored —
+     * only the method's own top-level statements are inspected.
+     */
+    private function isDeclarativeFluentMethod(Node $node): bool
+    {
+        if (! $node instanceof Stmt\Function_ && ! $node instanceof Stmt\ClassMethod) {
+            return false;
+        }
+
+        $stmts = $node->stmts;
+        if ($stmts === null || $stmts === []) {
+            return false;
+        }
+
+        if (count($stmts) > MethodLengthAnalyzer::MAX_DECLARATIVE_STATEMENTS) {
+            return false;
+        }
+
+        $hasChainOrArray = false;
+
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Stmt\Return_) {
+                $expr = $stmt->expr;
+            } elseif ($stmt instanceof Stmt\Expression) {
+                $expr = $stmt->expr;
+            } else {
+                // Any other top-level statement (control flow, echo, etc.) means the
+                // method is not a pure declarative builder.
+                return false;
+            }
+
+            if ($expr === null) {
+                return false;
+            }
+
+            // Unwrap assignments to inspect the assigned value.
+            if ($expr instanceof Node\Expr\Assign) {
+                $expr = $expr->expr;
+            }
+
+            if (! $this->isBuilderExpression($expr)) {
+                return false;
+            }
+
+            if ($this->isFluentChainOrArray($expr)) {
+                $hasChainOrArray = true;
+            }
+        }
+
+        return $hasChainOrArray;
+    }
+
+    /**
+     * A builder expression is a call, instantiation, or array literal — the kinds of
+     * expressions a declarative method is built from. Scalars, variables, and
+     * operators disqualify the statement.
+     */
+    private function isBuilderExpression(Node\Expr $expr): bool
+    {
+        return $expr instanceof Node\Expr\MethodCall
+            || $expr instanceof Node\Expr\StaticCall
+            || $expr instanceof Node\Expr\New_
+            || $expr instanceof Node\Expr\Array_;
+    }
+
+    /**
+     * Detect the signature of a builder DSL: a fluent method chain (a call chained
+     * off another call) or a call carrying an array/closure argument (e.g.
+     * $form->schema([...]) or Schema::create('t', fn () => ...)).
+     */
+    private function isFluentChainOrArray(Node\Expr $expr): bool
+    {
+        if ($expr instanceof Node\Expr\Array_) {
+            return true;
+        }
+
+        if (
+            $expr instanceof Node\Expr\MethodCall
+            && ($expr->var instanceof Node\Expr\MethodCall || $expr->var instanceof Node\Expr\StaticCall)
+        ) {
+            return true;
+        }
+
+        if ($expr instanceof Node\Expr\MethodCall || $expr instanceof Node\Expr\StaticCall) {
+            foreach ($expr->args as $arg) {
+                if (! $arg instanceof Node\Arg) {
+                    continue;
+                }
+
+                $value = $arg->value;
+                if (
+                    $value instanceof Node\Expr\Array_
+                    || $value instanceof Node\Expr\Closure
+                    || $value instanceof Node\Expr\ArrowFunction
+                ) {
+                    return true;
+                }
             }
         }
 

--- a/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
@@ -2093,4 +2093,172 @@ PHP;
 
         $this->assertPassed($result);
     }
+
+    public function test_passes_with_filament_sibling_action_closures(): void
+    {
+        // Each Filament action closure fires on a different user action / request, so
+        // the writes never co-execute and must not be summed across sibling closures.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Models\Order;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Table;
+
+class OrderResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->actions([
+                Action::make('approve')
+                    ->action(function (Order $record) {
+                        $record->update(['status' => 'approved']);
+                    }),
+                Action::make('reject')
+                    ->action(function (Order $record) {
+                        $record->delete();
+                    }),
+            ]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Filament/Resources/OrderResource.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // One write per independent callback → below threshold → passes.
+        $this->assertPassed($result);
+    }
+
+    public function test_fails_when_single_action_closure_has_multiple_writes(): void
+    {
+        // A single closure that performs two writes is a genuine atomicity risk and
+        // must still be flagged (guards against over-relaxing the closure scoping).
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Models\Order;
+use App\Models\Log;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Table;
+
+class OrderResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->actions([
+                Action::make('approve')
+                    ->action(function (Order $record) {
+                        $record->update(['status' => 'approved']);
+                        Log::create(['action' => 'approved', 'order_id' => $record->id]);
+                    }),
+            ]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Filament/Resources/OrderResource.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('database write operation(s) outside transaction protection', $result);
+    }
+
+    public function test_fails_with_main_flow_write_plus_synchronous_closure_write(): void
+    {
+        // A main-flow write co-executes with a write inside a synchronous closure
+        // (each()), so together they exceed the threshold and must be flagged.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Order;
+use App\Models\OrderItem;
+
+class OrderService
+{
+    public function createOrder(array $data, array $items)
+    {
+        $order = Order::create($data);
+
+        collect($items)->each(function (array $item) use ($order) {
+            OrderItem::create(['order_id' => $order->id] + $item);
+        });
+
+        return $order;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/OrderService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('database write operation(s) outside transaction protection', $result);
+    }
+
+    public function test_passes_with_synchronous_closure_inside_transaction(): void
+    {
+        // Writes inside a synchronous closure that is itself inside DB::transaction()
+        // are protected — the closure inherits the enclosing transaction.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Log;
+use Illuminate\Support\Facades\DB;
+
+class OrderService
+{
+    public function createOrder(array $data, array $items)
+    {
+        return DB::transaction(function () use ($data, $items) {
+            $order = Order::create($data);
+
+            collect($items)->each(function (array $item) use ($order) {
+                OrderItem::create(['order_id' => $order->id] + $item);
+                Log::create(['order_id' => $order->id]);
+            });
+
+            return $order;
+        });
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/OrderService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
 }

--- a/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
@@ -2325,4 +2325,133 @@ PHP;
         $this->assertNotSame($methodLine, $issues[0]->location->line);
         $this->assertStringContainsString('Closure in', $issues[0]->message);
     }
+
+    public function test_passes_with_protected_sibling_and_single_write_sibling(): void
+    {
+        // One action wraps two writes in a transaction (protected); a sibling action
+        // performs a single write. Neither closure is a problem on its own, and they
+        // never co-execute, so the method must not be flagged. Guards against mixing
+        // the write count of one sibling with the unprotected count of another.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Models\Quotation;
+use App\Models\WorkOrder;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\DB;
+
+class QuotationResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordActions([
+                Action::make('approve')
+                    ->action(function (Quotation $record): void {
+                        DB::transaction(function () use ($record): void {
+                            $record->update(['client_approved' => 1]);
+                            $record->touch();
+                        });
+                    }),
+                Action::make('work_order')
+                    ->action(function (Quotation $record, array $data): void {
+                        WorkOrder::create($data);
+                    }),
+            ]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Filament/Resources/QuotationResource.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_ignores_filament_filter_toggle_as_write(): void
+    {
+        // Filament's Filter::make('x')->...->toggle() configures a UI toggle filter;
+        // it is not an Eloquent relationship toggle and must not count as a DB write.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Models\WorkOrder;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class QuotationResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->filters([
+                Filter::make('approved')
+                    ->query(fn (Builder $query): Builder => $query->where('approved', 1))
+                    ->toggle(),
+            ])
+            ->recordActions([
+                Action::make('work_order')
+                    ->action(function (array $data): void {
+                        WorkOrder::create($data);
+                    }),
+            ]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Filament/Resources/QuotationResource.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_still_detects_real_relationship_toggle_on_model(): void
+    {
+        // A genuine Eloquent relationship toggle/attach (rooted on a model instance,
+        // not a ::make() builder) must still be flagged.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+class RoleService
+{
+    public function manageRoles(User $user, array $roleIds, array $permIds): void
+    {
+        $user->roles()->toggle($roleIds);
+        $user->permissions()->attach($permIds);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/RoleService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('database write operation(s) outside transaction protection', $result);
+    }
 }

--- a/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
@@ -2261,4 +2261,68 @@ PHP;
 
         $this->assertPassed($result);
     }
+
+    public function test_closure_driven_issue_is_located_at_the_closure_not_the_method(): void
+    {
+        // Mirrors a Filament table() resource: the writes live in an ->action() callback
+        // far below the (long) method declaration. The issue must point at the closure,
+        // not at the method's signature line.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Models\Order;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Table;
+
+class OrderResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordActions([
+                Action::make('approve')
+                    ->action(function (Order $record): void {
+                        $record->status = 'approved';
+                        $record->save();
+                        $record->touch();
+                    }),
+            ]);
+    }
+}
+PHP;
+
+        // Resolve the expected line dynamically so the assertion is not brittle.
+        $closureLine = null;
+        $methodLine = null;
+        foreach (explode("\n", $code) as $index => $lineText) {
+            if (str_contains($lineText, '->action(function')) {
+                $closureLine = $index + 1;
+            }
+            if (str_contains($lineText, 'public function table')) {
+                $methodLine = $index + 1;
+            }
+        }
+        $this->assertNotNull($closureLine);
+        $this->assertNotNull($methodLine);
+
+        $tempDir = $this->createTempDirectory(['Filament/Resources/OrderResource.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+
+        // The issue points at the closure, not the method signature.
+        $this->assertNotNull($issues[0]->location);
+        $this->assertSame($closureLine, $issues[0]->location->line);
+        $this->assertNotSame($methodLine, $issues[0]->location->line);
+        $this->assertStringContainsString('Closure in', $issues[0]->message);
+    }
 }

--- a/tests/Unit/Analyzers/CodeQuality/MethodLengthAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/MethodLengthAnalyzerTest.php
@@ -835,4 +835,213 @@ PHP;
         $this->assertSame('Method Length Analyzer', $metadata->name);
         $this->assertContains('maintainability', $metadata->tags);
     }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_filament_form_builder_chain(): void
+    {
+        // A Filament resource form() is a single return of a builder chain whose
+        // length reflects the number of UI fields, not code complexity.
+        $fields = str_repeat("            TextInput::make('field')->required()->maxLength(255),\n", 60);
+
+        $code = <<<PHP
+<?php
+
+namespace App\Filament\Resources;
+
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+
+class UserResource
+{
+    public function form(Form \$form): Form
+    {
+        return \$form
+            ->schema([
+{$fields}
+            ]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/UserResource.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass: a single-expression builder chain is declarative, not complex.
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_filament_table_builder_chain(): void
+    {
+        $columns = str_repeat("                TextColumn::make('column')->sortable()->searchable(),\n", 30);
+        $actions = str_repeat("                Action::make('do')->icon('heroicon-o-eye'),\n", 30);
+
+        $code = <<<PHP
+<?php
+
+namespace App\Filament\Resources;
+
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Table;
+
+class UserResource
+{
+    public function table(Table \$table): Table
+    {
+        return \$table
+            ->columns([
+{$columns}
+            ])
+            ->actions([
+{$actions}
+            ]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/UserResource.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_migration_schema_builder(): void
+    {
+        // Migration up() is a single Schema::create() expression; the closure body
+        // (column definitions) must not count as method-level control flow.
+        $columns = str_repeat("            \$table->string('column')->nullable();\n", 60);
+
+        $code = <<<PHP
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint \$table) {
+            \$table->id();
+{$columns}
+            \$table->timestamps();
+        });
+    }
+};
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'database/migrations/2024_01_01_000000_create_users.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['database']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_long_imperative_method_without_control_flow(): void
+    {
+        // Regression guard: many separate scalar-assignment statements are NOT a
+        // declarative builder and must remain flagged even with no control flow.
+        $statements = str_repeat('        $var = "value";'."\n", 60);
+
+        $code = <<<PHP
+<?php
+
+namespace App\Services;
+
+class DataProcessor
+{
+    public function processData(\$input)
+    {
+{$statements}
+        return \$var;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/DataProcessor.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('processData', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_fluent_chain_exclusion_can_be_disabled_via_config(): void
+    {
+        $fields = str_repeat("            TextInput::make('field')->required()->maxLength(255),\n", 60);
+
+        $code = <<<PHP
+<?php
+
+namespace App\Filament\Resources;
+
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+
+class UserResource
+{
+    public function form(Form \$form): Form
+    {
+        return \$form
+            ->schema([
+{$fields}
+            ]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/UserResource.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer([
+            'method-length' => [
+                'ignore_fluent_chains' => false,
+            ],
+        ]);
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // With the exclusion disabled, the long builder method is flagged again.
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('form', $result);
+    }
 }

--- a/tests/Unit/Analyzers/CodeQuality/MethodLengthAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/MethodLengthAnalyzerTest.php
@@ -1044,4 +1044,112 @@ PHP;
         $this->assertWarning($result);
         $this->assertHasIssueContaining('form', $result);
     }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_seeder_files(): void
+    {
+        // A seeder's run() is a data dump (huge insert arrays / JSON); its length
+        // measures data volume, not code complexity, so it must not be flagged.
+        $statements = str_repeat('        $var = "value";'."\n", 60);
+
+        $code = <<<PHP
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class BankSeeder extends Seeder
+{
+    public function run(): void
+    {
+{$statements}
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'database/seeders/BankSeeder.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['database']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_migration_files(): void
+    {
+        // A migration's up() is schema definition; length reflects table/column count,
+        // not branching complexity.
+        $statements = str_repeat('        $var = "value";'."\n", 60);
+
+        $code = <<<PHP
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+{$statements}
+    }
+};
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'database/migrations/2024_01_01_000000_create_things.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['database']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_factory_files(): void
+    {
+        $statements = str_repeat('        $var = "value";'."\n", 60);
+
+        $code = <<<PHP
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class UserFactory extends Factory
+{
+    public function definition(): array
+    {
+{$statements}
+        return [];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'database/factories/UserFactory.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['database']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a cluster of false positives the `method-length` and `missing-database-transactions` analyzers produced on Filament 4 projects, where declarative DSL and callback-driven code was mis-modeled as imperative/aggregated logic. Each fix is scoped to one analyzer, test-driven, and verified at PHPStan Level 9.

## `method-length`

- **Exclude declarative fluent-builder methods.** Filament `form()`/`table()`/`panel()` and migration `up()` are single-expression builder chains whose physical length reflects configuration size, not branching complexity. The visitor now skips a method whose body is a small set of top-level statements that build/return a fluent chain or nested array, with no top-level control flow (control flow inside callback closures is ignored). Gated behind a new `code-quality.method-length.ignore_fluent_chains` config flag (default `true`).
- **Skip development/data files.** `MethodLengthAnalyzer` was the only analyzer not using the `ClassifiesFiles` trait, so it reached into `database/seeders` and `database/migrations` and flagged data dumps / schema definitions (e.g. an 8079-line `run()` that is one `json_decode()` blob). It now skips `isTestFile()` / `isDevelopmentFile()`, matching every other analyzer.

## `missing-database-transactions`

- **Scope writes per callback closure.** The analyzer summed every write in a method, so two sibling Filament `Action::make()->action(fn …)` handlers (one write each) were counted together and flagged. Each non-transaction callback closure is now its own write-counting unit; following the existing mutually-exclusive-branch model, sibling closures contribute their heaviest (max), main-flow writes still accumulate, and closures inherit the enclosing transaction protection.
- **Locate closure-driven issues at the closure.** When all unprotected writes live inside a callback, the issue is now attributed to the closure's declaration line and labelled `Closure in "Class::method()"` (instead of the far-away method signature line). Mixed findings still report at the method. The summary wording was made neutral (`location(s)` rather than `method(s)`).
- **Ignore Filament filter `->toggle()` as a write.** `Filter::make('x')->…->toggle()` is a UI toggle, not an Eloquent relationship op. Relationship methods (`sync`/`attach`/`detach`/`toggle`/`syncWithoutDetaching`) are skipped when the chain is rooted at a `::make()` fluent builder; genuine relationship ops rooted on a model instance or query are still flagged.
- **Fix mixed-max across sibling closures.** The fold tracked max writes and max unprotected independently, pairing a protected sibling's write count with another sibling's lone unprotected write into a phantom finding. The heaviest unprotected sibling is now kept as a coherent unit; fully-protected closures contribute nothing.
