### PR TITLE
fix: only flag .env permissions in staging/production

### DIFF
--- a/src/Analyzers/Security/FilePermissionsAnalyzer.php
+++ b/src/Analyzers/Security/FilePermissionsAnalyzer.php
@@ -22,6 +22,11 @@ use ShieldCI\Concerns\DetectsDeploymentPlatform;
  * - Sensitive files (.env, config files) with insecure permissions
  * - Executable permissions on non-executable files
  * - Group-writable permissions on sensitive files
+ *
+ * Sensitive-file readability checks (world-readable / group-writable on .env) only
+ * run in staging/production, where untrusted local users could read secrets. They are
+ * suppressed in local/development/testing, where the default umask (644) would
+ * otherwise flag nearly every .env. World-writable is flagged in every environment.
  */
 class FilePermissionsAnalyzer extends AbstractFileAnalyzer
 {
@@ -207,6 +212,16 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
             return; // Don't check further - world-writable is the main issue
         }
 
+        // Sensitive-file readability/permissiveness checks only matter on shared
+        // production/staging hosts, where other untrusted local users could read
+        // secrets (CWE-732). On local/development/testing the multi-user threat
+        // model doesn't apply, and the default umask (644) would flag nearly every
+        // .env, so suppress these checks. World-writable (above) stays flagged in
+        // every environment since it's a genuine tampering vector.
+        if ($isCritical && ! $this->isProductionOrStaging()) {
+            return;
+        }
+
         // Check 2: World-readable on critical files (CRITICAL - for sensitive files)
         if ($isCritical && $this->isWorldReadable($permissions['raw'])) {
             $issues[] = $this->createIssue(
@@ -370,6 +385,17 @@ class FilePermissionsAnalyzer extends AbstractFileAnalyzer
             'octal' => $octal,
             'numeric' => $permissionBits,
         ];
+    }
+
+    /**
+     * Whether the current application environment is staging or production.
+     *
+     * Uses the shared environment resolution (honoring shieldci.environment_mapping)
+     * provided by the base analyzer.
+     */
+    private function isProductionOrStaging(): bool
+    {
+        return in_array($this->getEnvironment(), ['staging', 'production'], true);
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/FilePermissionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FilePermissionsAnalyzerTest.php
@@ -225,7 +225,7 @@ class FilePermissionsAnalyzerTest extends AnalyzerTestCase
     public function test_detects_env_file_with_644_permissions(): void
     {
         $tempDir = $this->createTempDirectory([
-            '.env' => 'APP_KEY=test',
+            '.env' => "APP_ENV=production\nAPP_KEY=test",
         ]);
 
         chmod($tempDir.'/.env', 0644);
@@ -241,6 +241,63 @@ class FilePermissionsAnalyzerTest extends AnalyzerTestCase
         $issues = $result->getIssues();
         $this->assertEquals(Severity::Critical, $issues[0]->severity);
         $this->assertTrue($issues[0]->metadata['world_readable'] ?? false);
+    }
+
+    public function test_ignores_env_file_with_644_permissions_in_local(): void
+    {
+        // In local/dev the multi-user threat model doesn't apply and the default
+        // umask (644) would flag nearly every .env. The world-readable check is
+        // suppressed outside staging/production.
+        $tempDir = $this->createTempDirectory([
+            '.env' => "APP_ENV=local\nAPP_KEY=test",
+        ]);
+
+        chmod($tempDir.'/.env', 0644);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_detects_env_file_with_644_permissions_in_staging(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env' => "APP_ENV=staging\nAPP_KEY=test",
+        ]);
+
+        chmod($tempDir.'/.env', 0644);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('world-readable', $result);
+        $this->assertEquals(Severity::Critical, $result->getIssues()[0]->severity);
+    }
+
+    public function test_detects_world_writable_env_file_in_local(): void
+    {
+        // World-writable is a genuine tampering vector regardless of environment,
+        // so it is flagged even in local.
+        $tempDir = $this->createTempDirectory([
+            '.env' => "APP_ENV=local\nAPP_KEY=test",
+        ]);
+
+        chmod($tempDir.'/.env', 0666);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('world-writable', $result);
+        $this->assertEquals(Severity::Critical, $result->getIssues()[0]->severity);
     }
 
     public function test_passes_env_file_with_600_permissions(): void
@@ -400,7 +457,7 @@ class FilePermissionsAnalyzerTest extends AnalyzerTestCase
     {
         $tempDir = $this->createTempDirectory([
             'app/Models/User.php' => '<?php class User {}',
-            '.env' => 'APP_KEY=test',
+            '.env' => "APP_ENV=production\nAPP_KEY=test",
         ]);
 
         chmod($tempDir.'/app', 0777);
@@ -475,12 +532,14 @@ class FilePermissionsAnalyzerTest extends AnalyzerTestCase
     public function test_overly_permissive_stops_further_checks(): void
     {
         $tempDir = $this->createTempDirectory([
-            '.env' => 'APP_KEY=test',
+            '.env' => "APP_ENV=production\nAPP_KEY=test",
         ]);
 
         // 0620 exceeds max 0600 (group-write bit set) but is not world-writable/world-readable.
         // Overly-permissive (check 3) should fire and return early,
         // preventing the group-writable-on-critical-file check (check 4) from also running.
+        // Requires production env, since sensitive-file permissiveness checks are
+        // suppressed outside staging/production.
         chmod($tempDir.'/.env', 0620);
 
         $analyzer = $this->createAnalyzer();


### PR DESCRIPTION
## Problem

`FilePermissionsAnalyzer` flagged `.env` as **Critical** for being world-readable (`644`), gating only on deployment platform (Docker, Cloud) but ignoring the app environment. Since the default umask creates files as `644`, this fired Critical on nearly every dev machine. The threat (CWE-732 — untrusted local users reading secrets) is a production/staging concern, not a single-user laptop.

## Change

Sensitive-file checks (world-readable, exceeds-max, group-writable on `.env`) now run **only in staging/production**, via the existing `getEnvironment()` API — consistent with `DebugModeAnalyzer`, `CacheDriverAnalyzer`, etc. **World-writable stays Critical everywhere** (a real tampering vector). Production behavior unchanged.

## Tests

Updated 3 tests to set `APP_ENV=production` in their fixture; added regression tests for `.env` 644 in local (passes), staging (Critical), and world-writable in local (Critical). PHPStan L9 clean, Pint passed.