### PR TITLE
fix: support wildcard public_routes and suppress fully-public route groups

### DIFF
--- a/src/Analyzers/Security/AuthenticationAnalyzer.php
+++ b/src/Analyzers/Security/AuthenticationAnalyzer.php
@@ -189,6 +189,29 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
+     * Determine whether a route URI is considered public.
+     *
+     * Matching is leading-slash insensitive and supports glob "*" wildcards
+     * via fnmatch(), so a configured pattern like "/welcome/*" matches a route
+     * registered as "welcome/{employee}". Patterns without wildcards fall back
+     * to an exact (slash-normalized) comparison.
+     */
+    private function isPublicRoute(string $uri): bool
+    {
+        $normalizedUri = '/'.ltrim($uri, '/');
+
+        foreach ($this->publicRoutes as $pattern) {
+            $normalizedPattern = '/'.ltrim($pattern, '/');
+
+            if ($normalizedPattern === $normalizedUri || fnmatch($normalizedPattern, $normalizedUri)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Build route-level authentication statistics per controller method.
      *
      * Uses PHP-Parser AST via RouteAuthVisitor so that all valid PHP formatting
@@ -223,7 +246,7 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
             $controllerMethods = $this->expandControllerMethods($controller, $route['action'], $route['http_methods']);
 
             $isGuestRoute = in_array('guest', $route['middleware'], true);
-            $isPublicUri = in_array($route['uri'], $this->publicRoutes, true);
+            $isPublicUri = $this->isPublicRoute($route['uri']);
             $hasExplicitAuthRemoval = $this->routeDirectRemoveHasAuth($route['direct_remove']);
 
             foreach ($controllerMethods as $method) {
@@ -347,6 +370,12 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
             $hasAuth = $this->isRouteMiddlewareAuthenticated($allMiddleware);
 
             if (! $hasAuth && ! $group['has_guest']) {
+                // Skip when every route inside this group is explicitly public —
+                // the user has opted these URIs out via the public_routes config.
+                if ($this->groupContainsOnlyPublicRoutes($group, $visitor->getCollectedRoutes())) {
+                    continue;
+                }
+
                 $issues[] = $this->createIssueWithSnippet(
                     message: 'Route group without authentication middleware',
                     filePath: $file,
@@ -361,7 +390,7 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
         // Check individual routes
         foreach ($visitor->getCollectedRoutes() as $route) {
             // Skip public URIs
-            if (in_array($route['uri'], $this->publicRoutes, true)) {
+            if ($this->isPublicRoute($route['uri'])) {
                 continue;
             }
 
@@ -400,6 +429,40 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
                 );
             }
         }
+    }
+
+    /**
+     * Determine whether every route physically nested within a group's line
+     * range is explicitly public (whitelisted URI, guest, or auth removed).
+     *
+     * Returns false when the group contains no routes, so genuinely empty or
+     * non-whitelisted groups continue to be flagged.
+     *
+     * @param  array{middleware: list<string>, inherited_middleware: list<string>, line: int, end_line: int, has_guest: bool, is_static_group: bool}  $group
+     * @param  list<array{uri: string, http_methods: list<string>, controller: string|null, action: string|null, is_closure: bool, middleware: list<string>, direct_remove: list<string>, line: int}>  $routes
+     */
+    private function groupContainsOnlyPublicRoutes(array $group, array $routes): bool
+    {
+        $found = false;
+
+        foreach ($routes as $route) {
+            // Only consider routes that physically sit inside this group's braces.
+            if ($route['line'] < $group['line'] || $route['line'] > $group['end_line']) {
+                continue;
+            }
+
+            $found = true;
+
+            $isPublic = $this->isPublicRoute($route['uri'])
+                || in_array('guest', $route['middleware'], true)
+                || $this->routeDirectRemoveHasAuth($route['direct_remove']);
+
+            if (! $isPublic) {
+                return false;
+            }
+        }
+
+        return $found;
     }
 
     /**
@@ -1384,7 +1447,7 @@ class RouteAuthVisitor extends NodeVisitorAbstract
     private array $collectedRoutes = [];
 
     /**
-     * @var list<array{middleware: list<string>, inherited_middleware: list<string>, line: int, has_guest: bool, is_static_group: bool}>
+     * @var list<array{middleware: list<string>, inherited_middleware: list<string>, line: int, end_line: int, has_guest: bool, is_static_group: bool}>
      */
     private array $collectedGroups = [];
 
@@ -1402,7 +1465,7 @@ class RouteAuthVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * @return list<array{middleware: list<string>, inherited_middleware: list<string>, line: int, has_guest: bool, is_static_group: bool}>
+     * @return list<array{middleware: list<string>, inherited_middleware: list<string>, line: int, end_line: int, has_guest: bool, is_static_group: bool}>
      */
     public function getCollectedGroups(): array
     {
@@ -1421,6 +1484,7 @@ class RouteAuthVisitor extends NodeVisitorAbstract
                 'middleware' => $own['add'],
                 'inherited_middleware' => $inherited,
                 'line' => $node->getStartLine(),
+                'end_line' => $node->getEndLine(),
                 'has_guest' => in_array('guest', $own['add'], true),
                 'is_static_group' => $node instanceof Node\Expr\StaticCall,
             ];

--- a/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
@@ -940,6 +940,117 @@ PHP;
         $this->assertPassed($result);
     }
 
+    public function test_skips_wildcard_public_routes_from_config(): void
+    {
+        $routes = <<<'PHP'
+<?php
+
+Route::post('welcome/{employee}', [WelcomeController::class, 'savePassword']);
+PHP;
+
+        $tempDir = $this->createTempDirectory(['routes/web.php' => $routes]);
+
+        // Wildcard pattern should match the route URI even though it contains a
+        // {parameter} placeholder and is registered without a leading slash.
+        $analyzer = $this->createAnalyzer([
+            'authentication-authorization' => [
+                'public_routes' => [
+                    '/welcome/*',
+                ],
+            ],
+        ]);
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_matches_public_route_registered_without_leading_slash(): void
+    {
+        $routes = <<<'PHP'
+<?php
+
+Route::post('api/webhook', [WebhookController::class, 'handle']);
+PHP;
+
+        $tempDir = $this->createTempDirectory(['routes/web.php' => $routes]);
+
+        // Config pattern has a leading slash; route URI does not. They should match.
+        $analyzer = $this->createAnalyzer([
+            'authentication-authorization' => [
+                'public_routes' => [
+                    '/api/webhook',
+                ],
+            ],
+        ]);
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_skips_route_group_when_all_routes_are_public(): void
+    {
+        $routes = <<<'PHP'
+<?php
+
+Route::group(['middleware' => ['web']], function () {
+    Route::get('welcome/{employee}', [WelcomeController::class, 'showWelcomeForm']);
+    Route::post('welcome/{employee}', [WelcomeController::class, 'savePassword']);
+});
+PHP;
+
+        $tempDir = $this->createTempDirectory(['routes/web.php' => $routes]);
+
+        // Both routes inside the group are covered by the wildcard, so the group
+        // warning must be suppressed too.
+        $analyzer = $this->createAnalyzer([
+            'authentication-authorization' => [
+                'public_routes' => [
+                    '/welcome/*',
+                ],
+            ],
+        ]);
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_flags_route_group_when_a_route_is_not_public(): void
+    {
+        $routes = <<<'PHP'
+<?php
+
+Route::group(['middleware' => ['web']], function () {
+    Route::post('welcome/{employee}', [WelcomeController::class, 'savePassword']);
+    Route::post('admin/settings', [AdminController::class, 'update']);
+});
+PHP;
+
+        $tempDir = $this->createTempDirectory(['routes/web.php' => $routes]);
+
+        // Only the welcome route is whitelisted; the admin route is not, so the
+        // group warning must still fire.
+        $analyzer = $this->createAnalyzer([
+            'authentication-authorization' => [
+                'public_routes' => [
+                    '/welcome/*',
+                ],
+            ],
+        ]);
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('Route group without authentication middleware', $result);
+        $this->assertHasIssueContaining('POST route without authentication middleware', $result);
+    }
+
     public function test_skips_default_public_routes(): void
     {
         $routes = <<<'PHP'
@@ -1028,7 +1139,7 @@ PHP;
         $this->assertPassed($result);
     }
 
-    public function test_detects_route_group_even_with_public_route_names(): void
+    public function test_skips_route_group_when_inner_routes_are_default_public(): void
     {
         $routes = <<<'PHP'
 <?php
@@ -1046,9 +1157,10 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // Route group itself is flagged (prefix contains 'auth' but that's just a name)
-        // The individual routes inside are skipped because they contain 'login' and 'register'
-        $this->assertFalse($result->isSuccess());
+        // Every route inside the group is a default-public auth-entry route
+        // (/login, /register), so requiring auth here would be nonsensical.
+        // The group warning must be suppressed along with the individual routes.
+        $this->assertPassed($result);
     }
 
     public function test_without_middleware_removes_auth_from_route(): void


### PR DESCRIPTION
## Problem

The `authentication-authorization` analyzer ignored `public_routes` config in two cases:

1. **Wildcards / leading slashes never matched.** A strict `in_array()` compare meant `/welcome/*` never matched a route registered as `welcome/{employee}`.
2. **Route groups were flagged unconditionally.** The group check never consulted `public_routes`, so a group wrapping only public routes was always reported at High severity — a false positive.

## Fix

- `isPublicRoute()` — slash-insensitive matching with `fnmatch()` globs (consistent with `ignore_errors` `path_pattern`); exact patterns still match exactly.
- `groupContainsOnlyPublicRoutes()` — suppress a group warning only when every route nested in the group is explicitly public (whitelisted URI, `guest`, or `withoutMiddleware('auth')`).
- `RouteAuthVisitor` records each group's `end_line` to map routes to their group.

## Note

`test_detects_route_group_even_with_public_route_names` (which asserted a `/login`+`/register` group was flagged — the false positive above) is renamed to `test_skips_route_group_when_inner_routes_are_default_public` and now asserts pass.

Verified: PHPStan L9 clean, Pint passed, 4120 tests / 0 failures.