### PR TITLE
fix: suppress service-container-resolution false positives for helpers, factory calls, and Filament

### DIFF
--- a/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
+++ b/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
@@ -54,6 +54,15 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
  *   queue jobs) don't support automatic injection. A closure-aware recommendation is
  *   provided. Note: Binding inside closures is still flagged at High severity as it's always wrong.
  * - Route files: Use closures without DI support
+ * - Global helper functions: Resolution inside a free function (e.g. a helper like
+ *   employeeConfig()) is the canonical Laravel pattern, mirroring the framework's own
+ *   auth()/cache() helpers. Top-level script code (not in a function) is still flagged.
+ * - Container-as-factory: app(Class::class, [$params]) / make($abstract, $parameters) passes a
+ *   runtime parameters array the container cannot infer. DI cannot supply per-request args, so
+ *   any resolution call carrying a second (parameters) argument is suppressed.
+ * - Filament Resource/Page/RelationManager: static table()/form() and framework-evaluated action
+ *   closures expose no constructor or injectable method, so manual resolution is unavoidable.
+ *   Suppressed only inside static methods or closures; binding is still flagged.
  *
  * Configuration:
  * - whitelist_dirs: Directories to skip (e.g., tests, database/migrations, routes)
@@ -300,6 +309,7 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
             $isServiceProvider = $this->isServiceProviderFromAst($ast, $file);
             $isEloquentModel = $this->isEloquentModelFromAst($ast);
             $isShouldQueue = $this->isShouldQueueFromAst($ast);
+            $isFilamentClass = $this->isFilamentClassFromAst($ast);
 
             $visitor = new ServiceContainerVisitor(
                 $this->whitelistClasses,
@@ -311,7 +321,8 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
                 $this->manualInstantiationExcludePatterns,
                 $isServiceProvider,
                 $isEloquentModel,
-                $isShouldQueue
+                $isShouldQueue,
+                $isFilamentClass
             );
             $traverser = new NodeTraverser;
             $traverser->addVisitor($visitor);
@@ -564,6 +575,73 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
+     * Check if AST represents a Filament Resource/Page/RelationManager.
+     *
+     * Uses the same CloningVisitor + NameResolver pattern as the other detectors
+     * to resolve parent class names to FQN before checking. A class is treated as
+     * a Filament UI class when it extends a Filament base class OR lives in a
+     * Filament namespace (catches project-local intermediate bases such as
+     * App\Filament\BaseResource that ultimately extend a Filament class).
+     *
+     * @param  array<Node>  $ast
+     */
+    private function isFilamentClassFromAst(array $ast): bool
+    {
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor(new CloningVisitor);
+        $traverser->addVisitor(new NameResolver);
+        $resolvedAst = $traverser->traverse($ast);
+
+        foreach ($resolvedAst as $node) {
+            if ($node instanceof Stmt\Namespace_) {
+                $namespace = $node->name?->toString();
+
+                foreach ($node->stmts as $stmt) {
+                    if ($stmt instanceof Stmt\Class_ &&
+                        ($this->extendsFilamentBase($stmt) || $this->isFilamentNamespace($namespace))) {
+                        return true;
+                    }
+                }
+            } elseif ($node instanceof Stmt\Class_ && $this->extendsFilamentBase($node)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a class extends a Filament base class.
+     *
+     * After NameResolver has been applied, the parent class name is FQN, so any
+     * parent in the Filament\ namespace (e.g. Filament\Resources\Resource,
+     * Filament\Resources\Pages\ViewRecord) marks a Filament UI class.
+     */
+    private function extendsFilamentBase(Stmt\Class_ $class): bool
+    {
+        if ($class->extends === null) {
+            return false;
+        }
+
+        $parent = ltrim($class->extends->toString(), '\\');
+
+        return str_starts_with($parent, 'Filament\\');
+    }
+
+    /**
+     * Check if a namespace is a Filament namespace (e.g. App\Filament\Resources).
+     */
+    private function isFilamentNamespace(?string $namespace): bool
+    {
+        if ($namespace === null) {
+            return false;
+        }
+
+        return str_starts_with($namespace, 'Filament\\')
+            || str_contains($namespace, '\\Filament\\');
+    }
+
+    /**
      * Get recommendation for container resolution.
      */
     private function getRecommendation(string $pattern, string $location, string $argumentType, bool $inClosure = false): string
@@ -633,6 +711,19 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
     private int $closureDepth = 0;
 
     /**
+     * Global function depth. Resolution inside a free function (e.g. a helper
+     * function like employeeConfig()) is the canonical Laravel pattern, just
+     * like the framework's own auth()/cache() helpers.
+     */
+    private int $functionDepth = 0;
+
+    /**
+     * Whether the enclosing method is declared static. Static methods (e.g.
+     * Filament's table()/form()) have no instance to inject into.
+     */
+    private bool $currentMethodIsStatic = false;
+
+    /**
      * Namespaces where severity should be escalated to High.
      * These classes are fully DI-capable and manual resolution is almost always wrong.
      *
@@ -661,7 +752,8 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
         private array $manualInstantiationExcludePatterns = [],
         private bool $isServiceProvider = false,
         private bool $isEloquentModel = false,
-        private bool $isShouldQueue = false
+        private bool $isShouldQueue = false,
+        private bool $isFilamentClass = false
     ) {}
 
     public function enterNode(Node $node)
@@ -680,9 +772,17 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
             return null;
         }
 
+        // Track global function entry (free functions support no constructor DI)
+        if ($node instanceof Stmt\Function_) {
+            $this->functionDepth++;
+
+            return null;
+        }
+
         // Track method entry
         if ($node instanceof Stmt\ClassMethod) {
             $this->currentMethod = $node->name->toString();
+            $this->currentMethodIsStatic = $node->isStatic();
 
             return null;
         }
@@ -1038,9 +1138,15 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
 
     public function leaveNode(Node $node)
     {
+        // Track global function exit
+        if ($node instanceof Stmt\Function_) {
+            $this->functionDepth--;
+        }
+
         // Clear method context on exit
         if ($node instanceof Stmt\ClassMethod) {
             $this->currentMethod = null;
+            $this->currentMethodIsStatic = false;
         }
 
         // Clear class context on exit
@@ -1066,6 +1172,27 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
      */
     private function addIssue(string $pattern, int $line, Severity $severity, string $argumentType, bool $inClosure = false): void
     {
+        // Container-as-factory: runtime parameters can't come from DI.
+        if ($argumentType === 'factory') {
+            return;
+        }
+
+        // Resolution inside a global helper function is the canonical Laravel
+        // pattern (mirrors the framework's own auth()/cache() helpers). Bindings
+        // ('binding') are always wrong outside a provider, so keep flagging them.
+        if ($this->functionDepth > 0 && $argumentType !== 'binding') {
+            return;
+        }
+
+        // Filament Resource/Page/RelationManager: static table()/form() and
+        // framework-evaluated action closures expose no constructor or injectable
+        // method, so manual resolution there is unavoidable. Bindings stay flagged.
+        if ($this->isFilamentClass
+            && $argumentType !== 'binding'
+            && ($this->closureDepth > 0 || $this->currentMethodIsStatic)) {
+            return;
+        }
+
         $key = "{$line}:{$pattern}";
 
         // Skip if already seen (deduplication)
@@ -1184,6 +1311,14 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
     {
         if (empty($args)) {
             return 'none';
+        }
+
+        // Container-as-factory: a second (parameters) argument supplies
+        // constructor values the container cannot infer (e.g.
+        // app(Notification::class, ['token' => $token])). DI categorically
+        // cannot provide per-request args, so this is not a DI smell.
+        if (count($args) >= 2) {
+            return 'factory';
         }
 
         // Skip VariadicPlaceholder

--- a/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
@@ -183,8 +183,11 @@ PHP;
         $this->assertHasIssueContaining('app()->make()', $result);
     }
 
-    public function test_detects_app_make_with(): void
+    public function test_skips_make_with_runtime_parameters(): void
     {
+        // makeWith() always carries a runtime parameters array, making it a
+        // container-as-factory call. DI cannot supply per-request args, so it
+        // is not a DI smell and must not be flagged.
         $code = <<<'PHP'
 <?php
 
@@ -210,8 +213,7 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
-        $this->assertHasIssueContaining('app()->makeWith()', $result);
+        $this->assertPassed($result);
     }
 
     public function test_detects_app_static_make(): void
@@ -782,6 +784,185 @@ PHP;
 
         $this->assertWarning($result);
         $this->assertHasIssueContaining('global scope', $result);
+    }
+
+    public function test_skips_app_resolution_in_global_helper_function(): void
+    {
+        // app() inside a free helper function is the canonical Laravel pattern,
+        // mirroring the framework's own auth()/cache() helpers. Unlike top-level
+        // script code, a function body has no constructor to inject into.
+        $code = <<<'PHP'
+<?php
+
+use App\Services\EmployeeConfigService;
+
+if (! function_exists('employeeConfig')) {
+    function employeeConfig(): EmployeeConfigService
+    {
+        return app(EmployeeConfigService::class);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Helpers/Helpers.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_skips_container_factory_with_parameters(): void
+    {
+        // A runtime parameters array makes this a container-as-factory call.
+        // DI cannot provide per-request args, so it is not a DI smell.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class PasswordResetService
+{
+    public function build(string $token)
+    {
+        return app(ResetPasswordNotification::class, ['token' => $token]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/PasswordResetService.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_skips_app_resolution_in_filament_resource_closure(): void
+    {
+        // Static table()/form() builders and framework-evaluated action closures
+        // expose no constructor or injectable method.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources\HR\Employees;
+
+use Filament\Resources\Resource;
+
+class EmployeeResource extends Resource
+{
+    public static function table($table)
+    {
+        return $table->actions([
+            Action::make('download')
+                ->action(function ($record) {
+                    $qrService = app(QrCodeService::class);
+
+                    return $qrService->generate($record);
+                }),
+        ]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/HR/Employees/EmployeeResource.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_skips_app_resolution_in_filament_namespace_fallback(): void
+    {
+        // Class extends a project-local base (not a Filament\ class directly),
+        // but the App\Filament\... namespace marks it as a Filament UI class.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources\HR\Employees\Pages;
+
+use App\Filament\BasePage;
+
+class ViewEmployee extends BasePage
+{
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('view')
+                ->action(function () {
+                    $qrService = app(QrCodeService::class);
+
+                    return $qrService->generate($this->record);
+                }),
+        ];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/HR/Employees/Pages/ViewEmployee.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_flags_bare_app_in_filament_regular_method(): void
+    {
+        // Suppression only applies inside static methods or closures. A regular
+        // (non-static, non-closure) method does have an injectable surface, so
+        // bare resolution there is still flagged.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources\HR\Employees\Pages;
+
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewEmployee extends ViewRecord
+{
+    public function loadData()
+    {
+        $service = app(EmployeeConfigService::class);
+
+        return $service->all();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/HR/Employees/Pages/ViewEmployee.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('app()', $result);
     }
 
     public function test_detects_multiple_patterns_in_one_file(): void


### PR DESCRIPTION
Suppresses three false-positive contexts in the service-container-resolution analyzer where `app()` has no DI surface to migrate to:

1. **Global helper functions** — `app()` in a free function (like Laravel's own `auth()`/`cache()`).
2. **Container-as-factory** — `app(Class::class, [$params])`; runtime args DI can't supply.
3. **Filament static methods & closures** — `table()`/`form()` and action closures have no injectable method.

All three route through a single guard in `addIssue()`. Bindings stay flagged everywhere; bare `app(X::class)` in services/controllers and top-level script code stay flagged. `makeWith` now treated as factory (test updated).

PHPStan L9 clean, 4125 tests pass.