### PR TITLE
fix: suppress php-side-filtering false positives for chained filters and authorization closures

### DIFF
--- a/src/Analyzers/BestPractices/PhpSideFilteringAnalyzer.php
+++ b/src/Analyzers/BestPractices/PhpSideFilteringAnalyzer.php
@@ -6,6 +6,7 @@ namespace ShieldCI\Analyzers\BestPractices;
 
 use Illuminate\Contracts\Config\Repository as Config;
 use PhpParser\Node;
+use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
@@ -232,6 +233,26 @@ class PhpFilteringVisitor extends NodeVisitorAbstract
     ];
 
     /**
+     * Authorization/permission methods whose results cannot be expressed as SQL.
+     *
+     * When a filter()/reject() closure filters on one of these (Gate, policies,
+     * spatie/laravel-permission), there is no database-level equivalent, so the
+     * pattern is intentionally PHP-side and should not be flagged.
+     *
+     * @var array<string>
+     */
+    private const AUTHORIZATION_METHODS = [
+        // Gate / policy abilities
+        'can', 'cannot', 'cant', 'canAny',
+        'authorize', 'authorizeForUser',
+        'allows', 'denies', 'check',
+        // Roles / permissions (spatie/laravel-permission)
+        'hasRole', 'hasAnyRole', 'hasAllRoles',
+        'hasPermissionTo', 'hasAnyPermission', 'hasAllPermissions',
+        'hasDirectPermission', 'hasPermissionViaRole', 'checkPermissionTo',
+    ];
+
+    /**
      * Classes that are not Eloquent models/queries.
      * Static calls on these classes should not be flagged.
      *
@@ -363,6 +384,24 @@ class PhpFilteringVisitor extends NodeVisitorAbstract
 
     private function analyzeMethodChain(Node\Expr\MethodCall $node): void
     {
+        // Only treat the current node as a detection point if it IS the filtering
+        // call itself (filter/reject/whereIn/whereNotIn). Downstream chained calls
+        // like ->each(), ->map(), ->values() would otherwise re-detect the same
+        // filter and emit duplicate issues for one location.
+        if (! $node->name instanceof Node\Identifier
+            || ! in_array($node->name->toString(), self::FILTER_METHODS, true)) {
+            return;
+        }
+
+        // Filtering by an authorization check (->can(), ->hasRole(), Gate::allows())
+        // cannot be expressed as a SQL where clause, so flagging it as "filter in the
+        // database" is a false positive. Skip filter()/reject() with such closures.
+        $methodName = $node->name->toString();
+        if (in_array($methodName, ['filter', 'reject'], true)
+            && $this->filterCallbackUsesAuthorization($node)) {
+            return;
+        }
+
         // Get the full chain of methods
         $chain = $this->getMethodChain($node);
 
@@ -400,6 +439,49 @@ class PhpFilteringVisitor extends NodeVisitorAbstract
                 'code' => null,
             ];
         }
+    }
+
+    /**
+     * Check whether a filter()/reject() closure filters by an authorization check.
+     *
+     * Patterns like ->filter(fn ($u) => $u->can('update', $x)) or closures using
+     * hasRole()/hasPermissionTo()/Gate::allows() cannot be translated to SQL where
+     * clauses, so they are legitimate PHP-side filtering and must not be flagged.
+     */
+    private function filterCallbackUsesAuthorization(Node\Expr\MethodCall $node): bool
+    {
+        $firstArg = $node->args[0] ?? null;
+        if (! ($firstArg instanceof Node\Arg)) {
+            return false;
+        }
+
+        $callback = $firstArg->value;
+        if (! ($callback instanceof Node\Expr\Closure) && ! ($callback instanceof Node\Expr\ArrowFunction)) {
+            return false;
+        }
+
+        $finder = new NodeFinder;
+        $found = $finder->findFirst($callback, function (Node $inner): bool {
+            // Instance calls: $user->can(...), $user->hasRole(...)
+            if ($inner instanceof Node\Expr\MethodCall && $inner->name instanceof Node\Identifier) {
+                return in_array($inner->name->toString(), self::AUTHORIZATION_METHODS, true);
+            }
+
+            // Static calls: Gate::allows(...), Gate::denies(...), Gate::check(...)
+            if ($inner instanceof Node\Expr\StaticCall) {
+                if ($inner->class instanceof Node\Name && $inner->class->getLast() === 'Gate') {
+                    return true;
+                }
+
+                if ($inner->name instanceof Node\Identifier) {
+                    return in_array($inner->name->toString(), self::AUTHORIZATION_METHODS, true);
+                }
+            }
+
+            return false;
+        });
+
+        return $found !== null;
     }
 
     /**

--- a/tests/Unit/Analyzers/BestPractices/PhpSideFilteringAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/PhpSideFilteringAnalyzerTest.php
@@ -2991,4 +2991,233 @@ PHP;
         $issues = $result->getIssues();
         $this->assertCount(2, $issues);
     }
+
+    // ========================================================================
+    // DUPLICATE-REPORTING & AUTHORIZATION FALSE POSITIVE TESTS
+    // ========================================================================
+
+    public function test_does_not_duplicate_filter_followed_by_each(): void
+    {
+        // filter() followed by a non-fetch chained call (each) must not be
+        // reported twice for the same location.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class UserService
+{
+    public function activateUsers()
+    {
+        \App\Models\User::get()
+            ->filter(fn($u) => $u->active)
+            ->each(fn($u) => $u->save());
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/UserService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+    }
+
+    public function test_ignores_filter_with_authorization_can_check(): void
+    {
+        // Filtering by a Gate/policy ability cannot be done in SQL - not a FP target.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class SiteService
+{
+    public function authorizedEmployees($site)
+    {
+        return \App\Models\Employee::get()->filter(function ($employee) use ($site) {
+            $user = $employee->user;
+
+            return $user ? $user->can('update', $site) : false;
+        });
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/SiteService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_ignores_reject_with_role_check(): void
+    {
+        // Filtering by roles/permissions has no database-level equivalent.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class UserService
+{
+    public function nonAdmins()
+    {
+        return \App\Models\User::all()->reject(fn($u) => $u->hasRole('admin'));
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/UserService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_ignores_filter_with_gate_facade(): void
+    {
+        // Gate::allows() inside the closure is a non-SQL authorization check.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Gate;
+
+class UserService
+{
+    public function editable($resource)
+    {
+        return \App\Models\User::get()->filter(fn($u) => Gate::forUser($u)->allows('update', $resource));
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/UserService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_ignores_real_world_authorization_chain(): void
+    {
+        // Mirrors the reported false positive: active()->with()->get()->filter(can)->each()
+        // Must produce zero issues (no duplicate, no authorization flag).
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Livewire\Listeners;
+
+class GlobalEvents
+{
+    public function addBillingRateToSite($site, $product)
+    {
+        \App\Models\Employee::active()
+            ->with('user')
+            ->get()
+            ->filter(function ($employee) use ($site) {
+                $user = $employee->user;
+
+                return $user ? $user->can('update', $site) : false;
+            })
+            ->each(function ($employee) use ($site, $product) {
+                $employee->save();
+            });
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Listeners/GlobalEvents.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_still_detects_non_authorization_filter_once(): void
+    {
+        // A column-based filter remains a single, valid detection.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class UserService
+{
+    public function active()
+    {
+        return \App\Models\User::get()->filter(fn($u) => $u->status === 'active')->values();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/UserService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+    }
+
+    public function test_still_detects_filter_without_inspectable_closure(): void
+    {
+        // A variable callback (non-closure) and an argument-less filter() cannot be
+        // inspected for authorization calls, so both are still flagged. This also
+        // exercises the non-closure and missing-argument branches.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class UserService
+{
+    public function process(callable $check)
+    {
+        \App\Models\User::get()->filter($check);
+        \App\Models\Post::get()->filter();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/UserService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertCount(2, $issues);
+    }
 }


### PR DESCRIPTION
## Problem

A real-project `php-side-filtering` report produced 3 CRITICAL issues that are all false positives:

1. **Issues `#1` and `#2`** flagged the *same* `filter()` call twice (`...->get()->filter()->each()` and `...->get()->filter()`).
2. **All 3 issues** flagged `filter()` closures filtering by authorization checks (`$user->can(...)`), which have no SQL `where`-clause equivalent — so "filter at the database level" isn't actionable.

## Root causes

- **Duplicate:** `enterNode()` ran detection on *every* `MethodCall`, and the chain scan looked downward — so a trailing `->each()` re-detected the same `get()->filter()`. (Chains ending in `->all()` masked the dup, since `all` is a fetch method.)
- **Authorization:** detection was purely method-name based and never inspected the closure body.

## Fix

In `PhpFilteringVisitor`:
- Anchor detection to the filtering node itself (`filter`/`reject`/`whereIn`/`whereNotIn`), so downstream chained calls no longer re-fire.
- Add `filterCallbackUsesAuthorization()` using `NodeFinder` to detect Gate/policy/permission calls (`can`, `cannot`, `hasRole`, `hasPermissionTo`, `Gate::allows()`, …) in `filter`/`reject` closures and suppress those.

## Tests

7 new fixture-based tests, including one mirroring the exact reported chain (→ 0 issues), plus non-closure / zero-arg branch coverage.

- `PhpSideFilteringAnalyzerTest`: 104 passed
- PHPStan Level 9: 0 errors
- Pint: passed
