### PR TITLE
fix: correct missing-password-defaults recommendation

### DIFF
--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -1109,7 +1109,7 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
                 message: 'No Password::defaults() configured in service providers',
                 location: new Location('app/Providers/AppServiceProvider.php'),
                 severity: Severity::Medium,
-                recommendation: 'Define password validation defaults in a service provider boot() method or in bootstrap/app.php. Defaults should enforce minimum length, mixed case, numbers, symbols, and rejection of known-breached passwords.',
+                recommendation: "Define password validation defaults by calling Password::defaults() in a service provider's boot() method. Defaults should enforce a minimum length of at least 8 characters, mixed case, and rejection of known-breached passwords.",
                 metadata: ['issue_type' => 'missing_password_defaults']
             );
 


### PR DESCRIPTION
## What

Fixes the recommendation text for the `missing_password_defaults` issue in `PasswordSecurityAnalyzer`.

## Why

The previous wording had two defects:

1. **"or in bootstrap/app.php" was wrong for Laravel 11/12.** The `Application::configure()` fluent builder exposes `withRouting`/`withMiddleware`/`withExceptions`/`withSchedule`/`withProviders` — none is a hook for defining a validation rule. A bare `Password::defaults()` in the file body runs during bootstrapping *before providers boot*. The documented home is a service provider's `boot()` method.
2. **"numbers, symbols" was over-promised.** `analyzePasswordDefaultsBody()` only checks `min(>=8)`, `mixedCase()`, and `uncompromised()` — it never verifies `numbers()`/`symbols()`.

The recommendation now names the canonical location and lists only the requirements the analyzer actually enforces. Analyzer logic and scan paths are unchanged (the `booting()`-callback case in `bootstrap/app.php` is still accepted).

## Verification

- `PasswordSecurityAnalyzerTest`: 163 tests, 202 assertions, all green
- Pint: passed
- PHPStan Level 9: 0 errors