### PR TITLE
fix: skip published vendor views in logic-in-blade analyzer

### DIFF
--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -109,9 +109,18 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
         $files = [];
 
         foreach ($this->getFilesToAnalyze() as $file) {
-            if (str_ends_with($file->getFilename(), '.blade.php')) {
-                $files[] = $file->getPathname();
+            if (! str_ends_with($file->getFilename(), '.blade.php')) {
+                continue;
             }
+
+            // Skip published vendor views (resources/views/vendor/*) — these are
+            // third-party package templates, not developer-authored code.
+            $normalized = strtolower(str_replace('\\', '/', $file->getPathname()));
+            if (str_contains($normalized, '/vendor/')) {
+                continue;
+            }
+
+            $files[] = $file->getPathname();
         }
 
         return $files;

--- a/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
@@ -53,6 +53,67 @@ BLADE;
         $this->assertPassed($result);
     }
 
+    public function test_skips_published_vendor_views(): void
+    {
+        // Laravel's published notification mail template — framework-authored
+        // code under resources/views/vendor/ that the developer cannot fix.
+        $blade = <<<'BLADE'
+@isset($actionText)
+<?php
+    $color = match ($level) {
+        'success', 'error' => $level,
+        default => 'primary',
+    };
+?>
+@endisset
+@php
+    $rows = \App\Models\Order::where('status', 'paid')->get();
+@endphp
+BLADE;
+
+        $tempDir = $this->createTempDirectory([
+            'views/vendor/notifications/email.blade.php' => $blade,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['views']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_flags_same_content_outside_vendor_directory(): void
+    {
+        // Identical content as the vendor test, but developer-authored — must flag.
+        $blade = <<<'BLADE'
+@isset($actionText)
+<?php
+    $color = match ($level) {
+        'success', 'error' => $level,
+        default => 'primary',
+    };
+?>
+@endisset
+@php
+    $rows = \App\Models\Order::where('status', 'paid')->get();
+@endphp
+BLADE;
+
+        $tempDir = $this->createTempDirectory([
+            'views/notifications/email.blade.php' => $blade,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['views']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertHasIssueContaining('Inline PHP found in Blade template', $result);
+    }
+
     public function test_passes_with_simple_single_calculation(): void
     {
         $blade = <<<'BLADE'


### PR DESCRIPTION
## Problem

`LogicInBladeAnalyzer` scans `resources/views`, but `getBladeFiles()` filtered candidates by extension only — it never excluded `resources/views/vendor/`, where `php artisan vendor:publish` drops third-party templates (mail, notifications, pagination).

On a real project this flagged `resources/views/vendor/notifications/email.blade.php` (Laravel's own notification mail template) for "Inline PHP found in Blade template". That `<?php match() ?>` block is framework-authored code the developer can't meaningfully fix — a false positive.

## Fix

`getBladeFiles()` now skips any path containing `/vendor/`, reusing the `strtolower` + `str_contains` convention already established in `ConfigOutsideConfigAnalyzer::shouldSkipFile()` and `FrameworkOverrideAnalyzer::isVendorPackage()`. Using the generic `/vendor/` segment keeps it robust across both real (`resources/views/vendor/...`) and test temp-dir (`views/vendor/...`) paths.

Findings in the developer's own templates (DB queries, business logic, calculations) are unaffected and still flagged.

## Tests

- `test_skips_published_vendor_views` — a vendor file with inline PHP + a DB query passes (skipped).
- `test_flags_same_content_outside_vendor_directory` — identical content outside `vendor/` is still flagged, proving the skip is scoped to `/vendor/`.

130 tests pass, PHPStan Level 9 clean, Pint passed.