### PR TITLE
fix: block partial reports from skewing platform data

### DIFF
--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -208,8 +208,10 @@ class AnalyzeCommand extends Command
         // Output report to STDOUT (skip if saved to file or already streamed)
         if (! $output && ! $useStreaming) {
             $this->outputReport($report, $reporter);
-        } elseif (! $output && $useStreaming) {
-            // For streaming mode, just output the report card
+        } elseif (! $output && $useStreaming && ! $this->isSingleAnalyzerRun()) {
+            // For streaming mode, output the report card — but skip it for a single-analyzer
+            // run, where the percentage table degenerates to a meaningless 100%/0% summary
+            // already conveyed by the streamed result line.
             $this->newLine();
             $this->line($this->color('Report Card', 'bright_yellow'));
             $this->line($this->color('===========', 'bright_yellow'));
@@ -220,7 +222,13 @@ class AnalyzeCommand extends Command
 
         // Send to API if configured
         if ($this->shouldSendToApi()) {
-            $this->sendToApi($client, $reporter, $report);
+            if ($this->isScopedRun()) {
+                $this->warn('⚠️  Skipping platform upload: --analyzer/--category produces a partial '
+                    .'report that would skew your project score and history. Run a full scan '
+                    .'(php artisan shield:analyze --report) to upload.');
+            } else {
+                $this->sendToApi($client, $reporter, $report);
+            }
         }
 
         // Determine exit code
@@ -1037,6 +1045,40 @@ class AnalyzeCommand extends Command
         file_put_contents($path, $content);
 
         $this->info("Report saved to: {$path}");
+    }
+
+    /**
+     * Determine whether this run is scoped to a subset of analyzers via --analyzer or --category.
+     *
+     * Scoped runs produce a partial report whose score/summary reflect only the requested
+     * subset, so they must not be uploaded as a full project snapshot.
+     */
+    protected function isScopedRun(): bool
+    {
+        $analyzer = $this->option('analyzer');
+        $category = $this->option('category');
+
+        return (is_string($analyzer) && $analyzer !== '')
+            || (is_string($category) && $category !== '');
+    }
+
+    /**
+     * Determine whether this run targets exactly one analyzer via --analyzer.
+     */
+    protected function isSingleAnalyzerRun(): bool
+    {
+        $analyzer = $this->option('analyzer');
+
+        if (! is_string($analyzer) || $analyzer === '') {
+            return false;
+        }
+
+        $ids = array_filter(
+            array_map('trim', explode(',', $analyzer)),
+            fn (string $id) => $id !== ''
+        );
+
+        return count($ids) === 1;
     }
 
     /**

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -2274,6 +2274,111 @@ PHP);
 
     /** @test */
     #[Test]
+    public function it_does_not_send_to_api_for_single_analyzer_run(): void
+    {
+        $this->registerTestAnalyzers();
+
+        Http::fake([
+            'api.test.shieldci.com/api/reports' => Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'test-security-analyzer',
+            '--format' => 'json',
+            '--report' => true,
+        ])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Skipping platform upload');
+
+        Http::assertNotSent(fn ($request) => str_contains($request->url(), '/api/reports'));
+    }
+
+    /** @test */
+    #[Test]
+    public function it_does_not_send_to_api_for_category_run(): void
+    {
+        $this->registerTestAnalyzers();
+
+        Http::fake([
+            'api.test.shieldci.com/api/reports' => Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('shield:analyze', [
+            '--category' => 'security',
+            '--format' => 'json',
+            '--report' => true,
+        ])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Skipping platform upload');
+
+        Http::assertNotSent(fn ($request) => str_contains($request->url(), '/api/reports'));
+    }
+
+    /** @test */
+    #[Test]
+    public function it_still_sends_to_api_for_unscoped_ci_run(): void
+    {
+        $this->registerTestAnalyzers();
+
+        Http::fake([
+            'api.test.shieldci.com/api/reports' => Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('shield:analyze', [
+            '--ci' => true,
+            '--format' => 'json',
+            '--report' => true,
+        ])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Report sent successfully');
+    }
+
+    /** @test */
+    #[Test]
+    public function it_suppresses_report_card_for_single_analyzer_run(): void
+    {
+        $this->registerTestAnalyzers();
+
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'test-security-analyzer',
+            '--format' => 'console',
+        ])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Test Security Analyzer')
+            ->doesntExpectOutputToContain('Report Card');
+    }
+
+    /** @test */
+    #[Test]
+    public function it_shows_report_card_for_category_run(): void
+    {
+        $this->registerTestAnalyzers();
+
+        $this->artisan('shield:analyze', [
+            '--category' => 'security',
+            '--format' => 'console',
+        ])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Report Card');
+    }
+
+    /** @test */
+    #[Test]
+    public function it_shows_report_card_for_multiple_analyzer_run(): void
+    {
+        $this->registerTestAnalyzers();
+
+        // Suppression is keyed on a single analyzer; a multi-analyzer run keeps the card.
+        $this->artisan('shield:analyze', [
+            '--analyzer' => 'test-security-analyzer,test-performance-analyzer',
+            '--format' => 'console',
+        ])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Report Card');
+    }
+
+    /** @test */
+    #[Test]
     public function it_rejects_invalid_triggered_by_value(): void
     {
         $this->registerTestAnalyzers();


### PR DESCRIPTION
## Problem

`shield:analyze --analyzer=X --report` (or `--category=Y --report`) transmitted a **partial** report to the platform as if it were a full project scan.

- `AnalysisReport::score()`/`summary()` are computed over the result subset — one passing analyzer ⇒ `score=100`, `total=1`.
- The payload carries **no scope marker** (`buildConfiguration()` reads only config, never the `--analyzer`/`--category` flags), so the platform can't tell a one-analyzer run from a full scan.
- Nothing gated the send.

Result: a scoped `--report` run overwrote the real score, made other analyzers' issues look resolved, and skewed trend/severity history.

## Fix

- Add `isScopedRun()` / `isSingleAnalyzerRun()` detectors.
- Skip the API upload for scoped runs, printing a warning that points to a full scan.
- Suppress the streaming report card for single-analyzer runs (meaningless 100%/0% table, already conveyed by the streamed result line).

## Deliberate non-changes

- **Failure notifications** stay enabled for scoped runs (diagnostic, not a health snapshot).
- **`--ci`** is not treated as scoped — it runs a config-defined subset already disclosed in the `configuration` snapshot.
- Non-streaming `Reporter::generateReportCard` left alone (streaming console is the default).

## Tests

6 new tests covering both directions of every new branch (scoped → not sent / unscoped → sent; single → card suppressed / category & multi → card shown). Verified via pcov that every changed line is covered. PHPStan Level 9 clean, Pint passed.