### PR TITLE
fix: stop missing-docblock flagging Filament overrides and scaffolding

### DIFF
--- a/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
@@ -9,6 +9,8 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\CloningVisitor;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\NodeVisitorAbstract;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
@@ -16,6 +18,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Concerns\ClassifiesFiles;
 
 /**
  * Flags public methods without documentation.
@@ -27,6 +30,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
  */
 class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
 {
+    use ClassifiesFiles;
+
     /**
      * @var array<string>
      */
@@ -56,13 +61,20 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
         $requireTags = true;
 
         foreach ($this->getPhpFiles() as $file) {
+            // Skip Laravel scaffolding/test-support files (migrations, factories,
+            // seeders). Their framework hooks (up/down, configure, definition) and
+            // trivial state methods make docblock enforcement pure noise.
+            if ($this->isDevelopmentFile($file)) {
+                continue;
+            }
+
             $ast = $this->parser->parseFile($file);
 
             if (empty($ast)) {
                 continue;
             }
 
-            $visitor = new DocBlockVisitor($excludePatterns, $requireTags);
+            $visitor = new DocBlockVisitor($excludePatterns, $requireTags, $this->isFilamentClassFromAst($ast));
             $traverser = new NodeTraverser;
             $traverser->addVisitor($visitor);
             $traverser->traverse($ast);
@@ -112,6 +124,72 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
+     * Check if the file's AST represents a Filament Resource/Page/RelationManager/Provider.
+     *
+     * Uses the same CloningVisitor + NameResolver pattern as the other detectors to
+     * resolve parent class names to FQN before checking. A class is treated as a
+     * Filament UI class when it extends a Filament base class OR lives in a Filament
+     * namespace (catches project-local intermediate bases such as App\Filament\BaseResource).
+     *
+     * @param  array<Node>  $ast
+     */
+    private function isFilamentClassFromAst(array $ast): bool
+    {
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor(new CloningVisitor);
+        $traverser->addVisitor(new NameResolver);
+        $resolvedAst = $traverser->traverse($ast);
+
+        foreach ($resolvedAst as $node) {
+            if ($node instanceof Stmt\Namespace_) {
+                $namespace = $node->name?->toString();
+
+                foreach ($node->stmts as $stmt) {
+                    if ($stmt instanceof Stmt\Class_ &&
+                        ($this->extendsFilamentBase($stmt) || $this->isFilamentNamespace($namespace))) {
+                        return true;
+                    }
+                }
+            } elseif ($node instanceof Stmt\Class_ && $this->extendsFilamentBase($node)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a class extends a Filament base class.
+     *
+     * After NameResolver has been applied, the parent class name is FQN, so any parent
+     * in the Filament\ namespace (e.g. Filament\Resources\Resource, Filament\PanelProvider)
+     * marks a Filament UI class.
+     */
+    private function extendsFilamentBase(Stmt\Class_ $class): bool
+    {
+        if ($class->extends === null) {
+            return false;
+        }
+
+        $parent = ltrim($class->extends->toString(), '\\');
+
+        return str_starts_with($parent, 'Filament\\');
+    }
+
+    /**
+     * Check if a namespace is a Filament namespace (e.g. App\Filament\Resources).
+     */
+    private function isFilamentNamespace(?string $namespace): bool
+    {
+        if ($namespace === null) {
+            return false;
+        }
+
+        return str_starts_with($namespace, 'Filament\\')
+            || str_contains($namespace, '\\Filament\\');
+    }
+
+    /**
      * Get recommendation based on issue type.
      */
     private function getRecommendation(string $type, string $method): string
@@ -153,11 +231,26 @@ class DocBlockVisitor extends NodeVisitorAbstract
     private ?string $currentClass = null;
 
     /**
+     * Filament framework override methods whose meaning and signature are fixed by the
+     * framework contract. Documenting them adds only noise, so they are skipped when the
+     * containing class is a Filament UI class. Compared case-insensitively.
+     *
+     * @var array<string>
+     */
+    private array $filamentOverrides = [
+        'form', 'table', 'infolist', 'panel',
+        'canaccess', 'canview', 'canviewany', 'cancreate', 'canedit', 'candelete',
+        'canviewforrecord', 'canforcedelete', 'canforcedeleteany', 'candeleteany',
+        'canrestore', 'canrestoreany', 'canreorder', 'canreplicate',
+    ];
+
+    /**
      * @param  array<string>  $excludePatterns
      */
     public function __construct(
         private array $excludePatterns = [],
-        private bool $requireTags = true
+        private bool $requireTags = true,
+        private bool $isFilamentClass = false
     ) {}
 
     public function enterNode(Node $node)
@@ -180,6 +273,12 @@ class DocBlockVisitor extends NodeVisitorAbstract
 
             // Skip magic methods
             if (str_starts_with($methodName, '__')) {
+                return null;
+            }
+
+            // Skip Filament framework overrides (form, table, infolist, panel, can*)
+            // whose contract and signature are fixed by the framework.
+            if ($this->isFilamentClass && in_array(strtolower($methodName), $this->filamentOverrides, true)) {
                 return null;
             }
 

--- a/tests/Unit/Analyzers/CodeQuality/MissingDocBlockAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/MissingDocBlockAnalyzerTest.php
@@ -1130,4 +1130,364 @@ PHP;
         // Adding @return would conflict with Pint which strips redundant type declarations
         $this->assertPassed($result);
     }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_filament_resource_builder_overrides(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources;
+
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+
+class ClientResource extends Resource
+{
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([]);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return $schema->components([]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/ClientResource.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // form/table/infolist are framework overrides with self-explanatory signatures
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_filament_authorization_overrides(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources;
+
+use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Model;
+
+class AllocationResource extends Resource
+{
+    public static function canAccess(): bool
+    {
+        return auth()->user()->can('access', Allocation::class);
+    }
+
+    public static function canView(Model $record): bool
+    {
+        return auth()->user()->can('view', $record);
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()->can('viewAny', Allocation::class);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/AllocationResource.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // can* authorization overrides should not require docblocks
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_filament_panel_provider_override(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Providers\Filament;
+
+use Filament\Panel;
+use Filament\PanelProvider;
+
+class AppPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel->default()->id('app');
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Providers/Filament/AppPanelProvider.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // panel() is a Filament framework override (class extends Filament\PanelProvider)
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_does_not_exclude_builder_methods_in_non_filament_class(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class ReportBuilder
+{
+    public function form($data)
+    {
+        return $data;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/ReportBuilder.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // form() in a plain service class is NOT a Filament override and stays flagged
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('PHPDoc', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_custom_methods_in_filament_class(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources;
+
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+
+class AllocationResource extends Resource
+{
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([]);
+    }
+
+    public function calculateTotals($rows, $modifier)
+    {
+        return collect($rows)->sum();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/AllocationResource.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Only known framework overrides are skipped; custom methods stay flagged
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('calculateTotals', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_detects_filament_class_via_namespace(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\BaseResource;
+use Filament\Schemas\Schema;
+
+class ProductResource extends BaseResource
+{
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Filament/Resources/ProductResource.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Class extends a project-local base but lives in an App\Filament namespace
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_skips_migration_files(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePermissionTables extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (empty(config('permission.table_names'))) {
+            throw new Exception('config not loaded');
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (empty(config('permission.table_names'))) {
+            throw new Exception('config not found');
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'database/migrations/2022_10_14_000000_create_permission_tables.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['database']);
+
+        $result = $analyzer->analyze();
+
+        // Migrations are scaffolding: no @throws noise on up()/down()
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_skips_factory_files(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ClientFactory extends Factory
+{
+    public function configure()
+    {
+        return $this->afterCreating(fn ($client) => null);
+    }
+
+    public function surveyed(): static
+    {
+        return $this->state(fn () => ['site_survey_requested' => true]);
+    }
+
+    public function forEmployee($employee, $extra): static
+    {
+        return $this->state(fn () => ['employee_id' => $employee->id]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'database/factories/ClientFactory.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['database']);
+
+        $result = $analyzer->analyze();
+
+        // Factory hooks (configure) and arbitrary state methods are test-support noise
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_skips_seeder_files(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run($extra)
+    {
+        return null;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'database/seeders/DatabaseSeeder.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['database']);
+
+        $result = $analyzer->analyze();
+
+        // Seeders are scaffolding/test-support files
+        $this->assertPassed($result);
+    }
 }


### PR DESCRIPTION
## What

`MissingDocBlockAnalyzer` produced documentation noise on framework-fixed methods. This stops two classes of false positives:

- **Filament overrides** — when a class is a Filament UI class (extends `Filament\…` or sits in an `…\Filament\…` namespace), skip `form`, `table`, `infolist`, `panel`, and the `can*` authorization family (`canAccess`, `canView`, `canViewAny`, …). These have framework-fixed contracts and self-explanatory signatures.
- **Scaffolding files** — migrations, factories, and seeders are skipped entirely. Eliminates `@throws` noise on migration `up()/down()`, factory `configure()`, and arbitrary-named state methods like `surveyed()`/`forEmployee()`.

## How

- Reuses the `CloningVisitor` + `NameResolver` Filament-detection pattern already used by `ServiceContainerResolutionAnalyzer` for consistency.
- Reuses the existing `ClassifiesFiles::isDevelopmentFile()` helper for the scaffolding skip.
- Suppression is class-context + method-name based (not signature based), so it survives Filament v3 `Form $form` → v4 `Schema $schema` churn.

## Verification

- `MissingDocBlockAnalyzerTest`: 37 passed (9 new cases covering each scenario plus scoping/precision guards).
- PHPStan Level 9: 0 errors. Pint: passed.
- Validated against a real Filament app (`sekuraerp`): 0 override leaks and 0 scaffolding leaks; legitimate custom methods stay flagged.