### PR TITLE
fix: skip view-caching analyzer on Laravel Vapor

### DIFF
--- a/src/Analyzers/Performance/ViewCachingAnalyzer.php
+++ b/src/Analyzers/Performance/ViewCachingAnalyzer.php
@@ -13,6 +13,7 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\PlatformDetector;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use Symfony\Component\Finder\Finder;
 
@@ -48,6 +49,8 @@ class ViewCachingAnalyzer extends AbstractAnalyzer
      */
     protected ?array $relevantEnvironments = ['production', 'staging'];
 
+    private ?string $deploymentPlatformOverride = null;
+
     public function __construct(
         private Filesystem $files,
         private Config $config
@@ -70,7 +73,19 @@ class ViewCachingAnalyzer extends AbstractAnalyzer
 
     public function shouldRun(): bool
     {
-        return $this->isRelevantForCurrentEnvironment();
+        if (! $this->isRelevantForCurrentEnvironment()) {
+            return false;
+        }
+
+        // Timestamp-based freshness is meaningless on Vapor: the build copies every
+        // file (resetting blade mtimes) and the artifact is unzipped onto a read-only
+        // Lambda FS, so mtime ordering does not reflect real staleness. View caching
+        // there is a build-time concern (vapor.yml), not fixable at runtime.
+        if ($this->isVapor()) {
+            return false;
+        }
+
+        return true;
     }
 
     public function getSkipReason(): string
@@ -82,7 +97,31 @@ class ViewCachingAnalyzer extends AbstractAnalyzer
             return "Not relevant in '{$currentEnv}' environment (only relevant in: {$relevantEnvs})";
         }
 
+        if ($this->isVapor()) {
+            return 'Not applicable on Laravel Vapor - view caching is handled at build time and the read-only Lambda filesystem makes timestamp-based freshness checks unreliable';
+        }
+
         return 'Analyzer is not applicable in current context';
+    }
+
+    /**
+     * Override deployment platform detection (testing only).
+     */
+    public function setDeploymentPlatform(string $platform): void
+    {
+        $this->deploymentPlatformOverride = $platform;
+    }
+
+    /**
+     * Check if the application is deployed on Laravel Vapor.
+     */
+    private function isVapor(): bool
+    {
+        if ($this->deploymentPlatformOverride !== null) {
+            return $this->deploymentPlatformOverride === 'vapor';
+        }
+
+        return PlatformDetector::isLaravelVapor($this->getBasePath());
     }
 
     protected function runAnalysis(): ResultInterface

--- a/tests/Unit/Analyzers/Performance/ViewCachingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/ViewCachingAnalyzerTest.php
@@ -11,7 +11,6 @@ use Illuminate\View\FileViewFinder;
 use Mockery;
 use Mockery\MockInterface;
 use ShieldCI\Analyzers\Performance\ViewCachingAnalyzer;
-use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\Tests\AnalyzerTestCase;
@@ -55,7 +54,7 @@ class ViewCachingAnalyzerTest extends AnalyzerTestCase
         array $viewPaths = [],
         array $viewHints = [],
         array|false|null $globReturn = null,
-    ): AnalyzerInterface {
+    ): ViewCachingAnalyzer {
         /** @var Filesystem&MockInterface $files */
         $files = Mockery::mock(Filesystem::class);
 
@@ -602,6 +601,42 @@ class ViewCachingAnalyzerTest extends AnalyzerTestCase
         $this->assertStringContainsString('local', $reason);
         $this->assertStringContainsString('production', $reason);
         $this->assertStringContainsString('staging', $reason);
+    }
+
+    public function test_skips_on_laravel_vapor(): void
+    {
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Vapor', $analyzer->getSkipReason());
+
+        $result = $analyzer->analyze();
+
+        $this->assertSkipped($result);
+    }
+
+    public function test_runs_on_traditional_platform(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            'resources/views/welcome.blade.php' => '<html></html>',
+        ]);
+
+        // No setDeploymentPlatform() call - traditional (non-Vapor) deployment.
+        $compiledFiles = $this->createCompiledViews(1, time());
+
+        $analyzer = $this->createAnalyzer(
+            configValues: [],
+            viewPaths: [$tempDir.'/resources/views'],
+            viewHints: [],
+            globReturn: $compiledFiles
+        );
+
+        $this->assertTrue($analyzer->shouldRun());
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
     }
 
     public function test_handles_empty_view_hints(): void


### PR DESCRIPTION
## Summary

`ViewCachingAnalyzer` compares the newest Blade file mtime against the newest compiled-view mtime to detect a stale view cache. This is unreliable on **Laravel Vapor** and produces false "stale cache" findings.

The Vapor build pipeline confirms why:
- `CopyApplicationToBuildPath` copies every file individually, resetting all blade mtimes to build time; the artifact is then zipped and unzipped onto a read-only Lambda filesystem, resetting them again — so compiled-vs-blade ordering reflects packaging order, not real staleness.
- `view:cache` isn't a default build step, and `clear-compiled`/`optimize:clear` are in Vapor's unsupported commands.
- The recommendation (`php artisan view:cache`) isn't actionable at runtime — the FS is read-only; caching is a build-time/`vapor.yml` concern.

## Changes

- Detect Vapor via `PlatformDetector::isLaravelVapor()` and skip in `shouldRun()`, with a clear `getSkipReason()`. Mirrors the `setDeploymentPlatform()` test-hook convention from `PHPIniAnalyzer`. No behavior change off Vapor.
- Tests: `test_skips_on_laravel_vapor` and `test_runs_on_traditional_platform`.

33/33 tests pass · Pint clean · PHPStan Level 9 → 0 errors.