### PR TITLE
fix: skip asset-cache-headers analyzer on Laravel Vapor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.8.2
+
+### Fixed
+- `CacheHeaderAnalyzer` no longer false-positives with "missing Cache-Control headers" on Laravel Vapor — Vapor serves compiled assets from a CDN (`ASSET_URL`/CloudFront) with platform-managed cache headers, not from `APP_URL`, so probing `APP_URL/build/...` never reaches the real asset and is additionally intercepted by any auth gateway in front of the app (e.g. CloudFlare Access), whose login/challenge page carries `private`/`no-cache`; with no actionable in-app fix the analyzer now skips on Vapor/serverless via `isVaporOrServerless()`, mirroring the existing Laravel Cloud skip (#231)
+
 ## v1.8.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.8.2
 
 ### Fixed
-- `CacheHeaderAnalyzer` no longer false-positives with "missing Cache-Control headers" on Laravel Vapor — Vapor serves compiled assets from a CDN (`ASSET_URL`/CloudFront) with platform-managed cache headers, not from `APP_URL`, so probing `APP_URL/build/...` never reaches the real asset and is additionally intercepted by any auth gateway in front of the app (e.g. CloudFlare Access), whose login/challenge page carries `private`/`no-cache`; with no actionable in-app fix the analyzer now skips on Vapor/serverless via `isVaporOrServerless()`, mirroring the existing Laravel Cloud skip (#231)
+- `CacheHeaderAnalyzer` no longer false-positives on Laravel Vapor — Vapor serves compiled assets from a CDN with platform-managed cache headers rather than from `APP_URL`, so probing `APP_URL` is unactionable (and is intercepted by auth gateways like CloudFlare Access); the analyzer now skips on Vapor/serverless, mirroring the existing Laravel Cloud skip (#231)
 
 ## v1.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.8.2
 
 ### Fixed
-- `CacheHeaderAnalyzer` no longer false-positives on Laravel Vapor — Vapor serves compiled assets from a CDN with platform-managed cache headers rather than from `APP_URL`, so probing `APP_URL` is unactionable (and is intercepted by auth gateways like CloudFlare Access); the analyzer now skips on Vapor/serverless, mirroring the existing Laravel Cloud skip (#231)
+- `CacheHeaderAnalyzer` no longer false-positives on Laravel Vapor — Vapor serves compiled assets from a CDN with platform-managed cache headers rather than from `APP_URL`, so probing `APP_URL` is unactionable; the analyzer now skips on Vapor/serverless, mirroring the existing Laravel Cloud skip (#231)
 
 ## v1.8.1
 

--- a/src/Analyzers/Performance/CacheHeaderAnalyzer.php
+++ b/src/Analyzers/Performance/CacheHeaderAnalyzer.php
@@ -164,6 +164,14 @@ class CacheHeaderAnalyzer extends AbstractAnalyzer
             return false;
         }
 
+        // On Vapor/serverless, compiled assets are served from a CDN (ASSET_URL /
+        // CloudFront) with platform-managed cache headers, not from APP_URL. Probing
+        // APP_URL yields false positives (and is intercepted by any auth gateway such
+        // as CloudFlare Access), so there is no actionable fix to surface.
+        if ($this->isVaporOrServerless()) {
+            return false;
+        }
+
         // Only run if an asset build system is present
         return $this->hasMixManifest() || $this->hasViteManifest();
     }
@@ -179,6 +187,10 @@ class CacheHeaderAnalyzer extends AbstractAnalyzer
 
         if ($this->isLaravelCloud()) {
             return 'Laravel Cloud manages asset cache headers. No configuration is possible.';
+        }
+
+        if ($this->isVaporOrServerless()) {
+            return 'Laravel Vapor serves compiled assets from a CDN with platform-managed cache headers. No configuration is possible.';
         }
 
         return 'No asset build system detected (Laravel Mix or Vite)';

--- a/tests/Unit/Analyzers/Performance/CacheHeaderAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/CacheHeaderAnalyzerTest.php
@@ -1278,6 +1278,34 @@ class CacheHeaderAnalyzerTest extends AnalyzerTestCase
         $this->assertStringContainsString('Laravel Cloud manages asset cache headers', $analyzer->getSkipReason());
     }
 
+    public function test_skips_on_vapor(): void
+    {
+        $manifest = json_encode(['resources/js/app.js' => ['file' => 'assets/app.abc123.js']]);
+        $tempDir = $this->createTempDirectory(['public/build/manifest.json' => $manifest]);
+
+        /** @var CacheHeaderAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setPublicPath($tempDir.'/public');
+        $analyzer->setDeploymentPlatform('vapor');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('Laravel Vapor serves compiled assets from a CDN', $analyzer->getSkipReason());
+    }
+
+    public function test_skips_on_serverless(): void
+    {
+        $manifest = json_encode(['resources/js/app.js' => ['file' => 'assets/app.abc123.js']]);
+        $tempDir = $this->createTempDirectory(['public/build/manifest.json' => $manifest]);
+
+        /** @var CacheHeaderAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setPublicPath($tempDir.'/public');
+        $analyzer->setDeploymentPlatform('serverless');
+
+        $this->assertFalse($analyzer->shouldRun());
+        $this->assertStringContainsString('platform-managed cache headers', $analyzer->getSkipReason());
+    }
+
     public function test_recommendation_mentions_web_server_config_on_traditional_servers(): void
     {
         $manifest = json_encode([


### PR DESCRIPTION
## Problem

`asset-cache-headers` produces a false positive on Laravel Vapor: "Compiled assets are missing Cache-Control headers or use non-cacheable directives".

The analyzer probes asset URLs built only from `config('app.url')`. On Vapor, compiled assets are served from a CDN (`ASSET_URL`/CloudFront) with platform-managed cache headers, **not** from `APP_URL`. Probing `APP_URL` never reaches the real asset, and behind an auth gateway (e.g. CloudFlare Access) the request is intercepted by the login/challenge page — so every asset gets flagged. There is no actionable in-app fix on Vapor.

## Fix

Skip the analyzer on Vapor/serverless via the already-imported `isVaporOrServerless()` trait method, mirroring the existing Laravel Cloud skip in `shouldRun()`/`getSkipReason()`.

Added `test_skips_on_vapor` and `test_skips_on_serverless`. PHPStan Level 9 clean, Pint passing, full CacheHeaderAnalyzer suite green.