### PR TITLE
fix: stop fillable-foreign-key false positives (generic *_id + $guarded dedup)

### DIFF
--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -15,13 +15,16 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
 /**
- * Detects foreign keys in fillable arrays.
+ * Detects ownership/impersonation foreign keys exposed to mass assignment.
  *
  * Checks for:
- * - Fields ending in _id in $fillable arrays
- * - Foreign key columns exposed to mass assignment
- * - Potential relationship manipulation attacks
- * - Critical patterns like user_id, owner_id that allow impersonation
+ * - Curated ownership/impersonation keys in $fillable (user_id, owner_id, tenant_id, ...)
+ *   that allow users to reassign records to other principals
+ * - $guarded = [], which disables mass assignment protection entirely
+ *
+ * Generic *_id fields are deliberately not flagged: whether a fillable foreign key is
+ * exploitable depends on data flow (an untrusted create()/update()/fill() sink), which
+ * is detected by MassAssignmentAnalyzer, not on the field name.
  */
 class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 {
@@ -40,7 +43,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
         return new AnalyzerMetadata(
             id: 'fillable-foreign-key',
             name: 'Fillable Foreign Key Analyzer',
-            description: 'Detects foreign keys in fillable arrays that may allow unauthorized relationship manipulation',
+            description: 'Detects ownership/impersonation foreign keys in fillable arrays, and unrestricted mass assignment, in Eloquent models',
             category: Category::Security,
             severity: Severity::High,
             tags: ['mass-assignment', 'foreign-keys', 'eloquent', 'security', 'relationships'],
@@ -283,7 +286,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
      */
     private function checkField(string $file, int $itemLine, string $modelName, string $fieldName, array &$issues): void
     {
-        // Check dangerous patterns FIRST (prevents duplicates)
+        // Report only curated impersonation/ownership keys (user_id, owner_id, ...).
         if (array_key_exists($fieldName, $this->dangerousPatterns)) {
             $relationship = $this->dangerousPatterns[$fieldName];
 
@@ -310,36 +313,14 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                     'line' => $itemLine,
                 ]
             );
-
-            return; // Early return - don't create second issue
         }
 
-        // Check for generic _id pattern (only if not a dangerous pattern)
-        if (str_ends_with($fieldName, '_id')) {
-            $issues[] = $this->createIssueWithSnippet(
-                message: sprintf(
-                    'Potential foreign key "%s" is fillable in model "%s"',
-                    $fieldName,
-                    $modelName
-                ),
-                filePath: $file,
-                lineNumber: $itemLine,
-                severity: Severity::High,
-                recommendation: sprintf(
-                    'Remove "%s" from $fillable or validate that users should be able to set this relationship. '.
-                    'Consider using $guarded or manual assignment for foreign keys.',
-                    $fieldName
-                ),
-                metadata: [
-                    'field_name' => $fieldName,
-                    'model_name' => $modelName,
-                    'model_file' => $this->getRelativePath($file),
-                    'is_dangerous_pattern' => false,
-                    'pattern_type' => 'foreign_key',
-                    'line' => $itemLine,
-                ]
-            );
-        }
+        // Generic *_id foreign keys are intentionally NOT reported here. Whether a
+        // fillable foreign key is exploitable depends on data flow (an untrusted
+        // create()/update()/fill() sink with no allowlist), not on the field name —
+        // and that is already detected by MassAssignmentAnalyzer. Flagging every *_id
+        // field lexically produces evidence-free noise, so this analyzer reports only
+        // the curated impersonation/ownership patterns above.
     }
 
     /**

--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -17,14 +17,12 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
 /**
  * Detects ownership/impersonation foreign keys exposed to mass assignment.
  *
- * Checks for:
- * - Curated ownership/impersonation keys in $fillable (user_id, owner_id, tenant_id, ...)
- *   that allow users to reassign records to other principals
- * - $guarded = [], which disables mass assignment protection entirely
+ * Flags curated ownership/impersonation keys in $fillable (user_id, owner_id, tenant_id,
+ * ...) that allow users to reassign records to other principals.
  *
- * Generic *_id fields are deliberately not flagged: whether a fillable foreign key is
- * exploitable depends on data flow (an untrusted create()/update()/fill() sink), which
- * is detected by MassAssignmentAnalyzer, not on the field name.
+ * Out of scope by design (owned by MassAssignmentAnalyzer): $guarded = [] and untrusted
+ * create()/update()/fill() sinks. Generic *_id fields are likewise not flagged — whether
+ * a fillable foreign key is exploitable is a data-flow property, not a field-name one.
  */
 class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 {
@@ -43,7 +41,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
         return new AnalyzerMetadata(
             id: 'fillable-foreign-key',
             name: 'Fillable Foreign Key Analyzer',
-            description: 'Detects ownership/impersonation foreign keys in fillable arrays, and unrestricted mass assignment, in Eloquent models',
+            description: 'Detects ownership/impersonation foreign keys exposed to mass assignment in Eloquent model $fillable arrays',
             category: Category::Security,
             severity: Severity::High,
             tags: ['mass-assignment', 'foreign-keys', 'eloquent', 'security', 'relationships'],
@@ -104,7 +102,6 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                     }
 
                     $this->checkFillableProperty($file, $class, $issues);
-                    $this->checkGuardedProperty($file, $class, $issues);
                 }
             }
         }
@@ -231,52 +228,6 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                         $this->checkField($file, $item->getLine(), $modelName, $fieldName, $issues);
                     }
                 }
-            }
-        }
-    }
-
-    /**
-     * Check guarded property for full mass assignment.
-     */
-    private function checkGuardedProperty(string $file, Node\Stmt\Class_ $class, array &$issues): void
-    {
-        $modelName = $class->name ? $class->name->toString() : 'Unknown';
-
-        foreach ($class->stmts as $stmt) {
-            if (! $stmt instanceof Node\Stmt\Property) {
-                continue;
-            }
-
-            foreach ($stmt->props as $prop) {
-                if ($prop->name->toString() !== 'guarded') {
-                    continue;
-                }
-
-                if (! $prop->default instanceof Node\Expr\Array_) {
-                    continue;
-                }
-
-                if (count($prop->default->items) !== 0) {
-                    continue;
-                }
-
-                // guarded = []
-                $issues[] = $this->createIssueWithSnippet(
-                    message: sprintf(
-                        'Model "%s" uses $guarded = [] which allows unrestricted mass assignment',
-                        $modelName
-                    ),
-                    filePath: $file,
-                    lineNumber: $stmt->getLine(),
-                    severity: Severity::Critical,
-                    recommendation: 'Define an explicit fillable property listing only the fields you expect from user input, and avoid using an empty guarded array which disables mass assignment protection entirely.',
-                    metadata: [
-                        'model_name' => $modelName,
-                        'model_file' => $this->getRelativePath($file),
-                        'guarded_empty' => true,
-                        'line' => $stmt->getLine(),
-                    ]
-                );
             }
         }
     }

--- a/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
@@ -487,8 +487,11 @@ PHP;
         $this->assertPassed($result);
     }
 
-    public function test_handles_model_without_fillable_property(): void
+    public function test_empty_guarded_is_not_reported_here(): void
     {
+        // $guarded = [] is a mass-assignment-protection concern owned by
+        // MassAssignmentAnalyzer (which reports it Critical). This analyzer no longer
+        // duplicates it, so a model whose only signal is $guarded = [] passes here.
         $code = <<<'PHP'
 <?php
 
@@ -510,7 +513,8 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
+        $this->assertPassed($result);
+        $this->assertIssueCount(0, $result);
     }
 
     public function test_only_checks_eloquent_models(): void

--- a/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
@@ -92,8 +92,11 @@ PHP;
         $this->assertPassed($result);
     }
 
-    public function test_detects_foreign_key_in_fillable(): void
+    public function test_generic_foreign_key_is_not_flagged(): void
     {
+        // A generic *_id key (not a curated ownership/impersonation pattern) is no
+        // longer reported: fillable-FK exploitability is a data-flow concern handled
+        // by MassAssignmentAnalyzer, not a lexical field-name check.
         $code = <<<'PHP'
 <?php
 
@@ -115,8 +118,38 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
-        $this->assertHasIssueContaining('post_id', $result);
+        $this->assertPassed($result);
+        $this->assertIssueCount(0, $result);
+    }
+
+    public function test_generic_foreign_keys_are_not_reported(): void
+    {
+        // Regression guard for the SIMS24 case: a model full of reference/catalog
+        // foreign keys (none of them curated ownership/impersonation patterns) must
+        // produce zero findings rather than a wall of high-severity false positives.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Quotation extends Model
+{
+    protected $fillable = ['client_id', 'product_id', 'employee_id', 'deployment_id'];
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Models/Quotation.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertIssueCount(0, $result);
     }
 
     // ==================== Dangerous Pattern Tests ====================
@@ -389,11 +422,12 @@ PHP;
         $result = $analyzer->analyze();
 
         $this->assertFailed($result);
-        // Should detect: user_id (Critical), parent_id (Critical), post_id (High)
-        $this->assertCount(3, $result->getIssues());
+        // Should detect: user_id (Critical), parent_id (Critical). post_id is a generic
+        // foreign key and is no longer reported.
+        $this->assertCount(2, $result->getIssues());
     }
 
-    public function test_detects_mix_of_dangerous_and_normal_foreign_keys(): void
+    public function test_reports_only_dangerous_foreign_keys(): void
     {
         $code = <<<'PHP'
 <?php
@@ -417,19 +451,12 @@ PHP;
         $result = $analyzer->analyze();
 
         $this->assertFailed($result);
-        $this->assertCount(2, $result->getIssues());
+        // Only user_id (Critical) is reported; product_id is a generic foreign key.
+        $this->assertCount(1, $result->getIssues());
 
-        // user_id should be Critical
-        $criticalIssue = collect($result->getIssues())
-            ->first(fn ($issue) => str_contains($issue->message, 'user_id'));
-        $this->assertNotNull($criticalIssue);
+        $criticalIssue = $result->getIssues()[0];
+        $this->assertStringContainsString('user_id', $criticalIssue->message);
         $this->assertEquals(Severity::Critical, $criticalIssue->severity);
-
-        // product_id should be High
-        $highIssue = collect($result->getIssues())
-            ->first(fn ($issue) => str_contains($issue->message, 'product_id'));
-        $this->assertNotNull($highIssue);
-        $this->assertEquals(Severity::High, $highIssue->severity);
     }
 
     // ==================== Edge Cases ====================
@@ -616,8 +643,11 @@ PHP;
         $result = $analyzer->analyze();
 
         $this->assertFailed($result);
-        // Both are critical dangerous patterns
-        $this->assertCount(2, $result->getIssues());
+        // user_id is a curated dangerous pattern (Critical); role_id is a generic
+        // foreign key and is no longer reported.
+        $this->assertCount(1, $result->getIssues());
+        $this->assertEquals(Severity::Critical, $result->getIssues()[0]->severity);
+        $this->assertHasIssueContaining('user_id', $result);
     }
 
     // ==================== shouldRun() Tests ====================
@@ -693,41 +723,6 @@ PHP;
 
     // ==================== Metadata Tests ====================
 
-    public function test_metadata_includes_field_information(): void
-    {
-        $code = <<<'PHP'
-<?php
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-
-class Comment extends Model
-{
-    protected $fillable = ['content', 'post_id'];
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory(['Models/Comment.php' => $code]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['.']);
-
-        $result = $analyzer->analyze();
-
-        $issue = $result->getIssues()[0];
-
-        $this->assertArrayHasKey('field_name', $issue->metadata);
-        $this->assertEquals('post_id', $issue->metadata['field_name']);
-        $this->assertArrayHasKey('model_name', $issue->metadata);
-        $this->assertEquals('Comment', $issue->metadata['model_name']);
-        $this->assertArrayHasKey('is_dangerous_pattern', $issue->metadata);
-        $this->assertFalse($issue->metadata['is_dangerous_pattern']);
-        $this->assertArrayHasKey('pattern_type', $issue->metadata);
-        $this->assertEquals('foreign_key', $issue->metadata['pattern_type']);
-    }
-
     public function test_metadata_includes_dangerous_pattern_info(): void
     {
         $code = <<<'PHP'
@@ -763,35 +758,6 @@ PHP;
 
     // ==================== Message Format Tests ====================
 
-    public function test_high_severity_message_format(): void
-    {
-        $code = <<<'PHP'
-<?php
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-
-class Comment extends Model
-{
-    protected $fillable = ['post_id'];
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory(['Models/Comment.php' => $code]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['.']);
-
-        $result = $analyzer->analyze();
-
-        $issue = $result->getIssues()[0];
-        $this->assertStringContainsString('Potential foreign key', $issue->message);
-        $this->assertStringContainsString('post_id', $issue->message);
-        $this->assertStringContainsString('Comment', $issue->message);
-    }
-
     public function test_critical_severity_message_format(): void
     {
         $code = <<<'PHP'
@@ -824,42 +790,6 @@ PHP;
     // Note: @shieldci-ignore suppression is applied by AnalyzeCommand, not the analyzer.
     // These tests verify that issues are reported at the array item line (not the property
     // declaration line), which is what allows per-item inline suppression to work correctly.
-
-    public function test_issue_is_reported_at_array_item_line_not_property_line(): void
-    {
-        // 'post_id' is on line 11, 'protected $fillable' is on line 9
-        $code = <<<'PHP'
-<?php
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-
-class Post extends Model
-{
-    protected $fillable = [
-        'title',
-        'post_id',
-    ];
-}
-PHP;
-
-        $tempDir = $this->createTempDirectory(['Models/Post.php' => $code]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['.']);
-
-        $result = $analyzer->analyze();
-
-        $this->assertFailed($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-
-        // Issue must report at line 11 ('post_id'), not line 9 ('protected $fillable = [')
-        $this->assertNotNull($issues[0]->location);
-        $this->assertEquals(11, $issues[0]->location->line);
-    }
 
     public function test_dangerous_pattern_issue_is_reported_at_array_item_line(): void
     {


### PR DESCRIPTION
`fillable-foreign-key` flagged every `_id` field in `$fillable` at High, failing CI on evidence-free findings (58/58 FP on a real Filament app). Whether a fillable FK is exploitable is a data-flow concern already handled by `MassAssignmentAnalyzer`, not a field-name one.

- Remove the generic `*_id` branch — keep only curated ownership/impersonation keys (`user_id`, `owner_id`, … extensible via `dangerous_patterns`) at Critical.
- Drop the duplicate `$guarded = []` check (also reported by `MassAssignmentAnalyzer`).

No config changes. PHPStan L9 + Pint clean, full suite 4151 passing.