### PR TITLE
fix: detect mass-assignment issues on Pivot/Authenticatable models

### DIFF
--- a/src/Analyzers/Security/MassAssignmentAnalyzer.php
+++ b/src/Analyzers/Security/MassAssignmentAnalyzer.php
@@ -190,11 +190,17 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
      */
     private function isEloquentModel(string $file, Node\Stmt\Class_ $class): bool
     {
-        // First check if extends Model (most reliable)
+        // First check the parent class (most reliable). Covers Model plus the other
+        // Eloquent bases that carry mass-assignment behaviour: Authenticatable (the
+        // User model) and Pivot/MorphPivot (join models), which may live outside the
+        // App\Models namespace.
         if ($class->extends !== null) {
             $parentClass = $class->extends->toString();
-            if ($parentClass === 'Model' || str_ends_with($parentClass, '\\Model')) {
-                return true;
+
+            foreach (['Model', 'Authenticatable', 'Pivot', 'MorphPivot'] as $base) {
+                if ($parentClass === $base || str_ends_with($parentClass, '\\'.$base)) {
+                    return true;
+                }
             }
         }
 

--- a/tests/Unit/Analyzers/Security/MassAssignmentAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/MassAssignmentAnalyzerTest.php
@@ -157,6 +157,70 @@ PHP;
         $this->assertHasIssueContaining('$guarded = []', $result);
     }
 
+    public function test_detects_empty_guarded_on_authenticatable_outside_models_namespace(): void
+    {
+        // Legacy layout: App\User extends Authenticatable, not in App\Models. Detection
+        // must come from the parent class, not the namespace.
+        $code = <<<'PHP'
+<?php
+
+namespace App;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    protected $guarded = [];
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/User.php' => $code,
+            // Presence of app/Models/ satisfies shouldRun(); this model is protected.
+            'app/Models/Placeholder.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Placeholder extends Model { protected \$fillable = ['name']; }",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('$guarded = []', $result);
+    }
+
+    public function test_detects_empty_guarded_on_pivot_outside_models_namespace(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Pivots;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class Membership extends Pivot
+{
+    protected $guarded = [];
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Pivots/Membership.php' => $code,
+            // Presence of app/Models/ satisfies shouldRun(); this model is protected.
+            'app/Models/Placeholder.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Placeholder extends Model { protected \$fillable = ['name']; }",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('$guarded = []', $result);
+    }
+
     public function test_detects_create_with_request_all(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
`MassAssignmentAnalyzer::isEloquentModel` only matched `extends Model` + the `App\Models` namespace, so `Authenticatable` (e.g. legacy `App\User`) and `Pivot`/`MorphPivot` join models outside `App\Models` were never analysed — a `$guarded = []` on them went unreported.

- Broaden the parent-class check to also match `Authenticatable`, `Pivot`, `MorphPivot`.

Closes the coverage gap left when `fillable-foreign-key` stopped duplicating the `$guarded = []` finding (#232). PHPStan L9 + Pint clean, full suite 4153 passing.