### PR TITLE
docs: add v1.8.3 changelog entry for PRs #232-233

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.8.3
+
+### Changed
+- `FillableForeignKeyAnalyzer` now reports only curated ownership/impersonation keys (`user_id`, `owner_id`, … extensible via `dangerous_patterns`) — the generic `*_id` branch produced evidence-free false positives and is removed, and the duplicate `$guarded = []` finding is dropped in favour of `MassAssignmentAnalyzer` (#232)
+
+### Fixed
+- `MassAssignmentAnalyzer` now also analyses `Authenticatable`, `Pivot`, and `MorphPivot` models, not just `extends Model` / `App\Models` — so `$guarded = []` on a legacy `App\User` or a pivot outside `App\Models` is no longer missed (#233)
+
 ## v1.8.2
 
 ### Fixed


### PR DESCRIPTION
Adds the `v1.8.3` changelog entry covering the two merged fillable-foreign-key / mass-assignment changes:

- #232 — `FillableForeignKeyAnalyzer` reports only curated ownership keys; generic `*_id` branch removed, `$guarded = []` dedup
- #233 — `MassAssignmentAnalyzer` now covers `Authenticatable`/`Pivot`/`MorphPivot` models