### PR TITLE
fix: stop config-outside-config flagging identifier strings as secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.8.4
+
+### Fixed
+- `ConfigOutsideConfigAnalyzer` no longer false-positives on long descriptive identifiers (e.g. camelCase array keys) reported as "Possible hardcoded API key or secret" — the heuristics now skip strings in identifier positions (array-access keys, array-literal keys, and `compact()` arguments) since these can never hold a credential; array values continue to be scanned (#235)
+
 ## v1.8.3
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,8 @@
         "preferred-install": "dist",
         "audit": {
             "ignore": {
+                "PKSA-m5cs-t1y6-qpcs": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions",
+                "PKSA-3r5d-mb8f-1qw9": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions",
                 "PKSA-8qx3-n5y5-vvnd": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions",
                 "PKSA-w7xr-vk7n-rstm": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions",
                 "PKSA-mdq4-51ck-6kdq": "Dev-only: Laravel framework advisory pulled via orchestra/testbench for testing older Laravel versions",

--- a/src/Analyzers/BestPractices/ConfigOutsideConfigAnalyzer.php
+++ b/src/Analyzers/BestPractices/ConfigOutsideConfigAnalyzer.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Config\Repository as Config;
 use PhpParser\Error as PhpParserError;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\NodeVisitorAbstract;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
@@ -75,6 +76,8 @@ class ConfigOutsideConfigAnalyzer extends AbstractFileAnalyzer
 
                 $visitor = new ConfigHardcodeVisitor($this->excludedDomains, $this->strictUrlDetection);
                 $traverser = new NodeTraverser;
+                // ParentConnectingVisitor MUST be added first to enable parent node tracking
+                $traverser->addVisitor(new ParentConnectingVisitor);
                 $traverser->addVisitor($visitor);
                 $traverser->traverse($ast);
 
@@ -239,6 +242,13 @@ class ConfigHardcodeVisitor extends NodeVisitorAbstract
     public function enterNode(Node $node): ?Node
     {
         if ($node instanceof Node\Scalar\String_) {
+            // Skip strings used as identifiers (array keys, compact() arguments) rather than
+            // values. These are never credentials, so applying the secret/URL heuristics to
+            // them produces false positives (e.g. long descriptive camelCase array keys).
+            if ($this->isIdentifierContext($node)) {
+                return null;
+            }
+
             $value = $node->value;
 
             // Check for hardcoded URLs (including localhost and IP addresses)
@@ -269,6 +279,44 @@ class ConfigHardcodeVisitor extends NodeVisitorAbstract
         }
 
         return null;
+    }
+
+    /**
+     * Check if a string node is used as an identifier rather than a value.
+     *
+     * Identifier positions (array keys, array-access keys, compact() arguments) name things;
+     * they can never hold a credential or configurable URL, so they must not be flagged.
+     */
+    private function isIdentifierContext(Node $node): bool
+    {
+        $parent = $node->getAttribute('parent');
+
+        if (! $parent instanceof Node) {
+            return false;
+        }
+
+        // Array-access key: $metrics['someKey']
+        if ($parent instanceof Node\Expr\ArrayDimFetch && $parent->dim === $node) {
+            return true;
+        }
+
+        // Array-literal key: ['someKey' => $value] (only the key, never the value)
+        if ($parent instanceof Node\Expr\ArrayItem && $parent->key === $node) {
+            return true;
+        }
+
+        // compact('someVar', 'otherVar'): arguments name variables, not values
+        if ($parent instanceof Node\Arg) {
+            $grandparent = $parent->getAttribute('parent');
+
+            if ($grandparent instanceof Node\Expr\FuncCall
+                && $grandparent->name instanceof Node\Name
+                && strtolower($grandparent->name->toString()) === 'compact') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Analyzers/BestPractices/ConfigOutsideConfigAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ConfigOutsideConfigAnalyzerTest.php
@@ -732,6 +732,127 @@ PHP;
         $this->assertPassed($result);
     }
 
+    public function test_excludes_array_access_key_identifiers(): void
+    {
+        // Long descriptive camelCase key used as an array-access key is an identifier,
+        // not a hardcoded secret. Reproduces the reported false positive.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class MetricsService
+{
+    public function value(array $metrics)
+    {
+        return $metrics['monthlyActiveUsersWith2FactorAuthByQACount'];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/MetricsService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_excludes_compact_argument_identifiers(): void
+    {
+        // A long descriptive token passed to compact() is a variable name, not a secret.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class ReportService
+{
+    public function build()
+    {
+        $monthlyActiveUsersWith2FactorAuthByQACount = 0;
+
+        return compact('monthlyActiveUsersWith2FactorAuthByQACount');
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/ReportService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_excludes_array_literal_key_identifiers(): void
+    {
+        // The key of an array literal is an identifier; only the value could be a secret.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class MetricsService
+{
+    public function defaults()
+    {
+        return [
+            'monthlyActiveUsersWith2FactorAuthByQACount' => 0,
+        ];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/MetricsService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_still_detects_secret_as_array_value(): void
+    {
+        // Regression guard: a secret in the VALUE position of an array literal is still flagged,
+        // even though the surrounding key is treated as an identifier.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class PaymentService
+{
+    public function config()
+    {
+        return [
+            'api_key' => 'secret_aBcDeF0123456789aBcDeF0123456789xyz',
+        ];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/PaymentService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('API key', $result);
+    }
+
     public function test_excludes_css_class_combinations(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
Long descriptive camelCase array keys were flagged as "Possible hardcoded API key or secret" by `config-outside-config`.

**Cause:** the secret heuristic scored strings on shape (length + mixed-case + a digit) regardless of syntactic role, so identifier strings got flagged.

**Fix:** skip strings in identifier positions — array-access keys (`$x['key']`), array-literal keys, and `compact()` args — via the existing `ParentConnectingVisitor` pattern. Array *values* (the real secret position) are still scanned, so `['api_key' => '...']` is still caught.

Also adds two missing advisory IDs to `config.audit.ignore` to unblock the Laravel 9 CI matrix.

4 new tests; full suite green, PHPStan L9 + Pint clean.