### PR TITLE
fix: stop suppressed high/critical issues leaving a result mislabeled "failed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.8.5
+
+### Fixed
+- Suppressed High/Critical issues no longer leave a result mislabeled "failed" — when inline `@shieldci-ignore`, an `ignore_errors` rule, or a baseline match removes the last High/Critical issue and only Low/Medium issues remain, the result now downgrades to "warning" (and "passed" when all issues are suppressed); suppression only removes issues, so status can only improve. Exit codes and score are unchanged
+
 ## v1.8.4
 
 ### Fixed

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 use ShieldCI\AnalyzerManager;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
+use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Enums\Status;
 use ShieldCI\AnalyzersCore\Results\AnalysisResult;
 use ShieldCI\AnalyzersCore\Support\FileParser;
@@ -1385,9 +1386,7 @@ class AnalyzeCommand extends Command
         });
 
         // Create new result with filtered issues
-        $status = $newIssues->isEmpty()
-            ? Status::Passed
-            : $result->getStatus();
+        $status = $this->deriveSuppressedStatus($result->getStatus(), $newIssues->all());
 
         // Update message to reflect filtered count
         $message = $result->getMessage();
@@ -1509,9 +1508,7 @@ class AnalyzeCommand extends Command
             return new FilterResult($result, []); // Nothing was suppressed
         }
 
-        $status = $newIssues === []
-            ? Status::Passed
-            : $result->getStatus();
+        $status = $this->deriveSuppressedStatus($result->getStatus(), $newIssues);
 
         $message = $this->adjustFilteredMessage($result->getMessage(), count($currentIssues), count($newIssues));
 
@@ -1636,9 +1633,7 @@ class AnalyzeCommand extends Command
             $this->accumulateSuppressed($suppressedRecords, $analyzerId);
 
             // Create new result with filtered issues
-            $status = $newIssues->isEmpty()
-                ? Status::Passed
-                : $result->getStatus();
+            $status = $this->deriveSuppressedStatus($result->getStatus(), $newIssues->all());
 
             // Update message to reflect filtered count
             $message = $result->getMessage();
@@ -1712,6 +1707,36 @@ class AnalyzeCommand extends Command
         foreach ($records as $record) {
             $this->suppressedIssues[$analyzerId][] = $record;
         }
+    }
+
+    /**
+     * Derive a result's status after suppression has removed some issues.
+     *
+     * Suppression only ever removes issues, so a result's status can only
+     * improve or stay the same — never worsen:
+     *   - no issues remain                              → Passed
+     *   - issues remain, none High/Critical, was Failed → Warning (downgrade)
+     *   - otherwise                                     → unchanged
+     *
+     * @param  array<Issue>  $remainingIssues
+     */
+    private function deriveSuppressedStatus(Status $original, array $remainingIssues): Status
+    {
+        if ($remainingIssues === []) {
+            return Status::Passed;
+        }
+
+        if ($original !== Status::Failed) {
+            return $original;
+        }
+
+        foreach ($remainingIssues as $issue) {
+            if ($issue->severity->level() >= Severity::High->level()) {
+                return Status::Failed; // a High/Critical issue survived
+            }
+        }
+
+        return Status::Warning; // only Low/Medium remain → downgrade
     }
 
     /**

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -2135,6 +2135,94 @@ PHP);
         $this->assertSame('All issues are suppressed via @shieldci-ignore', $result);
     }
 
+    // ==========================================
+    // deriveSuppressedStatus tests (via reflection)
+    // ==========================================
+
+    /** @test */
+    #[Test]
+    public function derive_suppressed_status_returns_passed_when_no_issues_remain(): void
+    {
+        $command = new AnalyzeCommand;
+        $method = new \ReflectionMethod($command, 'deriveSuppressedStatus');
+        $method->setAccessible(true);
+
+        $this->assertSame(Status::Passed, $method->invoke($command, Status::Failed, []));
+        $this->assertSame(Status::Passed, $method->invoke($command, Status::Warning, []));
+    }
+
+    /** @test */
+    #[Test]
+    public function derive_suppressed_status_downgrades_failed_to_warning_when_only_low_medium_remain(): void
+    {
+        $command = new AnalyzeCommand;
+        $method = new \ReflectionMethod($command, 'deriveSuppressedStatus');
+        $method->setAccessible(true);
+
+        // Mirrors the production case: a High issue was suppressed, leaving 25 Low issues.
+        $remaining = array_map(
+            fn () => $this->makeIssue(Severity::Low),
+            range(1, 25)
+        );
+
+        $this->assertSame(Status::Warning, $method->invoke($command, Status::Failed, $remaining));
+
+        // Medium-only also downgrades.
+        $this->assertSame(
+            Status::Warning,
+            $method->invoke($command, Status::Failed, [$this->makeIssue(Severity::Medium)])
+        );
+    }
+
+    /** @test */
+    #[Test]
+    public function derive_suppressed_status_keeps_failed_when_high_or_critical_survives(): void
+    {
+        $command = new AnalyzeCommand;
+        $method = new \ReflectionMethod($command, 'deriveSuppressedStatus');
+        $method->setAccessible(true);
+
+        $this->assertSame(
+            Status::Failed,
+            $method->invoke($command, Status::Failed, [$this->makeIssue(Severity::Low), $this->makeIssue(Severity::High)])
+        );
+        $this->assertSame(
+            Status::Failed,
+            $method->invoke($command, Status::Failed, [$this->makeIssue(Severity::Critical)])
+        );
+    }
+
+    /** @test */
+    #[Test]
+    public function derive_suppressed_status_never_upgrades_non_failed_status(): void
+    {
+        $command = new AnalyzeCommand;
+        $method = new \ReflectionMethod($command, 'deriveSuppressedStatus');
+        $method->setAccessible(true);
+
+        // A Warning stays a Warning even if a High issue is present — suppression never worsens status.
+        $this->assertSame(
+            Status::Warning,
+            $method->invoke($command, Status::Warning, [$this->makeIssue(Severity::High)])
+        );
+
+        // Error is left untouched when issues remain.
+        $this->assertSame(
+            Status::Error,
+            $method->invoke($command, Status::Error, [$this->makeIssue(Severity::Low)])
+        );
+    }
+
+    private function makeIssue(Severity $severity): Issue
+    {
+        return new Issue(
+            message: 'Issue',
+            location: new Location('app/Example.php', 1),
+            severity: $severity,
+            recommendation: 'Fix it',
+        );
+    }
+
     // ─── API Integration Tests ────────────────────────────────────────────
 
     /** @test */


### PR DESCRIPTION
## What

When a suppression (inline `@shieldci-ignore`, an `ignore_errors` config rule, or a `--baseline` match) removed the last High/Critical issue from a result, the result stayed labeled **failed** as long as any Low/Medium issue survived. Observed in production: an analyzer shown as *failed* with 25 Low issues + 1 suppressed High.

Suppression only ever *removes* issues, so a result's status can only improve or stay the same — never worsen.

## How

Adds a private `deriveSuppressedStatus()` helper shared by all three suppression filter paths (`filterSingleResultAgainstIgnoreErrors`, `filterSingleResultAgainstInlineSuppressions`, `filterAgainstBaseline`):

- no issues remain → `Passed`
- `Failed` with only Low/Medium surviving → `Warning` (downgrade)
- otherwise → unchanged (never upgrades a deliberate `warning()`, never touches `Error`)

It reuses the exact `severity->level() >= Severity::High->level()` threshold from `AbstractAnalyzer::resultBySeverity`, so the two can't drift. This is downgrade-only by design: 14 analyzers set status directly via `warning()`/`failed()` (decoupled from severity), and a full `resultBySeverity` re-derivation could corrupt that intent.

Exit codes and score are unchanged — `determineExitCode` already re-derives from the surviving issues' severities, and `score()` excludes both Failed and Warning from the numerator. This corrects the displayed status, report-card counts, and the platform API payload.

4 reflection-based tests cover every branch, including a 25-Low-issue case mirroring the production report. Full suite: 4161 tests, 0 failures; PHPStan Level 9 clean; Pint clean.