### PR TITLE
ci: bump actions to Node 24 runtimes (checkout/cache/codecov v5)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -91,7 +91,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php${{ matrix.php }}-laravel${{ matrix.laravel }}-${{ hashFiles('**/composer.json') }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ !matrix.phpunit-config }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -133,7 +133,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-phpstan-${{ hashFiles('**/composer.json') }}
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -165,7 +165,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-pint-${{ hashFiles('**/composer.json') }}


### PR DESCRIPTION
## What

GitHub is deprecating the Node 20 runtime for JavaScript actions. The pinned actions in `tests.yml` run on outdated Node runtimes:

| Action | Was | Runtime | Now |
|---|---|---|---|
| `actions/checkout` | `@v4` | node20 | `@v5` (node24) |
| `actions/cache` | `@v4` | node20 | `@v5` (node24) |
| `codecov/codecov-action` | `@v3` | node16 | `@v5` (composite) |

`shivammathur/setup-php@v2` is left as-is — that major already ships a Node 24 runtime.

## Notes

- Drop-in for how these actions are used here (basic checkout; composer cache by key). The Codecov step's args (`files`/`token`/`flags`/`name`/`fail_ci_if_error`) are already v5-compatible, so only the version tag changed.
- GitHub-hosted `ubuntu-latest` ships Node 24, so the v5 actions run cleanly.
- CI-only change — no changelog entry.