### PR TITLE
fix: skip composer-validation when composer binary is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.8.6
+
+### Fixed
+- `ComposerValidationAnalyzer` no longer reports a false Critical "composer.json validation failed" finding when the `composer` binary is absent — slimmed CI containers and pipeline steps that restore `vendor/` without installing composer made the `composer validate` subprocess exit 127, which was indistinguishable from a real schema error; the existing serverless guard is generalised to skip the subprocess (returning a skipped result) whenever composer cannot be run, and `composer.json` JSON syntax is still validated independently beforehand; also fixes a latent mismatch where the `composer.phar` lookup probed `getcwd()` while the process ran in the working directory (#238)
+
 ## v1.8.5
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.8.6
 
 ### Fixed
-- `ComposerValidationAnalyzer` no longer reports a false Critical "composer.json validation failed" finding when the `composer` binary is absent — slimmed CI containers and pipeline steps that restore `vendor/` without installing composer made the `composer validate` subprocess exit 127, which was indistinguishable from a real schema error; the existing serverless guard is generalised to skip the subprocess (returning a skipped result) whenever composer cannot be run, and `composer.json` JSON syntax is still validated independently beforehand; also fixes a latent mismatch where the `composer.phar` lookup probed `getcwd()` while the process ran in the working directory (#238)
+- `ComposerValidationAnalyzer` no longer reports a false Critical "composer.json validation failed" finding when the `composer` binary is absent (slimmed CI containers, or steps that restore `vendor/` without installing composer) — a missing binary made `composer validate` exit 127, indistinguishable from a real schema error; the subprocess is now skipped when composer cannot be run, while JSON syntax is still validated independently (#238)
 
 ## v1.8.5
 

--- a/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
+++ b/src/Analyzers/Reliability/ComposerValidationAnalyzer.php
@@ -63,13 +63,16 @@ class ComposerValidationAnalyzer extends AbstractFileAnalyzer
             return $jsonValidationResult;
         }
 
-        // Skip `composer validate` subprocess on serverless runtimes — composer binary
-        // is not installed on Lambda/Cloud Functions/etc. JSON syntax already validated above.
-        if (PlatformDetector::isServerless()) {
-            return $this->passed('composer.json is valid');
+        $basePath = $this->getBasePath();
+
+        // Skip the `composer validate` subprocess when composer cannot be run — serverless
+        // runtimes (Lambda/Cloud Functions) don't ship the binary, and slimmed CI containers
+        // may restore vendor/ without installing composer itself. JSON syntax is already
+        // validated above, so a missing binary is a skip, not a failure.
+        if (PlatformDetector::isServerless() || ! $this->composerValidator->isAvailable($basePath)) {
+            return $this->skipped('Skipped composer validate: composer binary not available. composer.json JSON syntax is valid.');
         }
 
-        $basePath = $this->getBasePath();
         $result = $this->composerValidator->validate($basePath);
 
         if (! $result->successful) {

--- a/src/Support/ComposerValidator.php
+++ b/src/Support/ComposerValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ShieldCI\Support;
 
+use RuntimeException;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 class ComposerValidator
@@ -13,7 +15,12 @@ class ComposerValidator
      */
     public function validate(string $workingDirectory): ComposerValidatorResult
     {
-        $composer = $this->findComposerBinary();
+        $composer = $this->findComposerBinary($workingDirectory);
+
+        if ($composer === null) {
+            throw new RuntimeException('No composer binary could be located.');
+        }
+
         $process = new Process(array_merge($composer, ['validate', '--no-check-publish']), $workingDirectory);
         $process->run();
 
@@ -21,14 +28,26 @@ class ComposerValidator
     }
 
     /**
-     * Determine the composer binary to execute.
+     * Determine whether a composer binary can be located for the given working directory.
      */
-    private function findComposerBinary(): array
+    public function isAvailable(string $workingDirectory): bool
     {
-        if (file_exists(getcwd().'/composer.phar')) {
-            return [PHP_BINARY, getcwd().'/composer.phar'];
+        return $this->findComposerBinary($workingDirectory) !== null;
+    }
+
+    /**
+     * Determine the composer binary to execute.
+     *
+     * @return list<string>|null Null when no composer binary can be located.
+     */
+    private function findComposerBinary(string $workingDirectory): ?array
+    {
+        if (file_exists($workingDirectory.'/composer.phar')) {
+            return [PHP_BINARY, $workingDirectory.'/composer.phar'];
         }
 
-        return ['composer'];
+        $binary = (new ExecutableFinder)->find('composer');
+
+        return $binary !== null ? [$binary] : null;
     }
 }

--- a/tests/Unit/Analyzers/Reliability/ComposerValidationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/ComposerValidationAnalyzerTest.php
@@ -60,6 +60,7 @@ class ComposerValidationAnalyzerTest extends AnalyzerTestCase
 
         /** @var ComposerValidator&MockInterface $validator */
         $validator = Mockery::mock(ComposerValidator::class);
+        $validator->shouldReceive('isAvailable')->andReturn(true);
         $validator->shouldReceive('validate')
             ->andReturn(new ComposerValidatorResult(true, 'composer.json is valid'));
 
@@ -71,6 +72,25 @@ class ComposerValidationAnalyzerTest extends AnalyzerTestCase
         $this->assertPassed($result);
     }
 
+    public function test_skips_when_composer_binary_unavailable(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            'composer.json' => '{"name":"shieldci/demo"}',
+        ]);
+
+        /** @var ComposerValidator&MockInterface $validator */
+        $validator = Mockery::mock(ComposerValidator::class);
+        $validator->shouldReceive('isAvailable')->andReturn(false);
+        $validator->shouldNotReceive('validate');
+
+        $analyzer = $this->createAnalyzer($validator);
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertSkipped($result);
+    }
+
     public function test_fails_when_composer_validate_reports_errors(): void
     {
         $tempDir = $this->createTempDirectory([
@@ -79,6 +99,7 @@ class ComposerValidationAnalyzerTest extends AnalyzerTestCase
 
         /** @var ComposerValidator&MockInterface $validator */
         $validator = Mockery::mock(ComposerValidator::class);
+        $validator->shouldReceive('isAvailable')->andReturn(true);
         $validator->shouldReceive('validate')
             ->andReturn(new ComposerValidatorResult(false, 'composer.json is invalid'));
 
@@ -212,6 +233,7 @@ class ComposerValidationAnalyzerTest extends AnalyzerTestCase
 
         /** @var ComposerValidator&MockInterface $validator */
         $validator = Mockery::mock(ComposerValidator::class);
+        $validator->shouldReceive('isAvailable')->andReturn(true);
         $validator->shouldReceive('validate')
             ->andReturn(new ComposerValidatorResult(true, 'composer.json is valid'));
 
@@ -262,6 +284,7 @@ class ComposerValidationAnalyzerTest extends AnalyzerTestCase
 
         /** @var ComposerValidator&MockInterface $validator */
         $validator = Mockery::mock(ComposerValidator::class);
+        $validator->shouldReceive('isAvailable')->andReturn(true);
         $validator->shouldReceive('validate')
             ->andReturn(new ComposerValidatorResult(true, 'composer.json is valid'));
 
@@ -281,6 +304,7 @@ class ComposerValidationAnalyzerTest extends AnalyzerTestCase
 
         /** @var ComposerValidator&MockInterface $validator */
         $validator = Mockery::mock(ComposerValidator::class);
+        $validator->shouldReceive('isAvailable')->andReturn(true);
         $validator->shouldReceive('validate')
             ->andReturn(new ComposerValidatorResult(false, 'name is required'));
 
@@ -338,7 +362,7 @@ class ComposerValidationAnalyzerTest extends AnalyzerTestCase
 
         putenv('VAPOR_SSM_PATH');
 
-        $this->assertPassed($result);
+        $this->assertSkipped($result);
     }
 
     public function test_location_points_to_composer_json(): void

--- a/tests/Unit/Support/ComposerValidatorTest.php
+++ b/tests/Unit/Support/ComposerValidatorTest.php
@@ -148,6 +148,31 @@ class ComposerValidatorTest extends TestCase
 
     /** @test */
     #[Test]
+    public function it_throws_when_validating_without_a_composer_binary(): void
+    {
+        $validator = new ComposerValidator;
+
+        // Temp dir with no composer.phar, and an empty PATH so ExecutableFinder finds nothing.
+        $tempDir = sys_get_temp_dir().'/shieldci-novalidate-test-'.uniqid();
+        mkdir($tempDir);
+
+        $originalPath = getenv('PATH');
+
+        try {
+            putenv('PATH=');
+
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('No composer binary could be located.');
+
+            $validator->validate($tempDir);
+        } finally {
+            putenv($originalPath === false ? 'PATH' : 'PATH='.$originalPath);
+            rmdir($tempDir);
+        }
+    }
+
+    /** @test */
+    #[Test]
     public function it_validates_composer_json_with_missing_fields(): void
     {
         $validator = new ComposerValidator;

--- a/tests/Unit/Support/ComposerValidatorTest.php
+++ b/tests/Unit/Support/ComposerValidatorTest.php
@@ -92,19 +92,56 @@ class ComposerValidatorTest extends TestCase
         mkdir($tempDir);
         file_put_contents($tempDir.'/composer.phar', '<?php echo "fake composer";');
 
-        $originalDir = (string) getcwd();
-
         try {
-            chdir($tempDir);
-            /** @var array<int, string> $binary */
-            $binary = $reflection->invoke($validator);
+            // The phar lookup must use the passed working directory, not getcwd().
+            /** @var array<int, string>|null $binary */
+            $binary = $reflection->invoke($validator, $tempDir);
 
+            $this->assertNotNull($binary);
             $this->assertCount(2, $binary);
             $this->assertEquals(PHP_BINARY, $binary[0]);
-            $this->assertStringContainsString('composer.phar', $binary[1]);
+            $this->assertEquals($tempDir.'/composer.phar', $binary[1]);
         } finally {
-            chdir($originalDir);
             unlink($tempDir.'/composer.phar');
+            rmdir($tempDir);
+        }
+    }
+
+    /** @test */
+    #[Test]
+    public function it_reports_available_when_composer_phar_present(): void
+    {
+        $validator = new ComposerValidator;
+
+        $tempDir = sys_get_temp_dir().'/shieldci-avail-test-'.uniqid();
+        mkdir($tempDir);
+        file_put_contents($tempDir.'/composer.phar', '<?php echo "fake composer";');
+
+        try {
+            $this->assertTrue($validator->isAvailable($tempDir));
+        } finally {
+            unlink($tempDir.'/composer.phar');
+            rmdir($tempDir);
+        }
+    }
+
+    /** @test */
+    #[Test]
+    public function it_reports_unavailable_when_no_binary_can_be_found(): void
+    {
+        $validator = new ComposerValidator;
+
+        // Temp dir with no composer.phar, and an empty PATH so ExecutableFinder finds nothing.
+        $tempDir = sys_get_temp_dir().'/shieldci-noavail-test-'.uniqid();
+        mkdir($tempDir);
+
+        $originalPath = getenv('PATH');
+
+        try {
+            putenv('PATH=');
+            $this->assertFalse($validator->isAvailable($tempDir));
+        } finally {
+            putenv($originalPath === false ? 'PATH' : 'PATH='.$originalPath);
             rmdir($tempDir);
         }
     }


### PR DESCRIPTION
## Problem

`shield:analyze` raised a **Critical** "composer.json validation failed" finding even when `composer.json` was perfectly valid — whenever the `composer` binary was not on `PATH` (slimmed CI containers, or pipeline steps that restore `vendor/` without installing composer). A missing binary makes `Process` exit 127, which `isSuccessful()` reports as a failure, indistinguishable from a genuine schema error.

## Fix

- Generalize the existing serverless guard to "can we run composer?": skip the `composer validate` subprocess (returning `skipped()`, which does not fail CI) when no binary is available. JSON syntax is already validated independently beforehand.
- `ComposerValidator` gains `isAvailable()` and uses Symfony's `ExecutableFinder` instead of a blind `['composer']` fallback.
- Fix a latent bug: `findComposerBinary()` probed `getcwd()` for `composer.phar` while the process ran in the working directory; the working directory is now threaded through so the two match.

## Verification

- Full suite: 4164 tests pass.
- PHPStan Level 9: no errors; Pint: passed.