### PR TITLE
ci: add concurrency and markdown paths-ignore to tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,20 @@ on:
     branches:
       - master
       - '*.x'
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
   schedule:
     - cron: '0 0 * * *'
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
Brings the free package's tests workflow in line with `laravel-pro`:

- **`concurrency`** — newer pushes to the same ref cancel in-progress runs, saving CI minutes.
- **`paths-ignore: ['**.md']`** on `push` and `pull_request` — markdown-only changes skip the matrix.

Daily `schedule` is unchanged.