### PR TITLE
fix: stop OpcacheAnalyzer pinning unset directives to commented php.ini lines

### DIFF
--- a/src/Analyzers/Performance/OpcacheAnalyzer.php
+++ b/src/Analyzers/Performance/OpcacheAnalyzer.php
@@ -133,7 +133,18 @@ class OpcacheAnalyzer extends AbstractAnalyzer
     public function setPhpIniPath(string $phpIniPath): void
     {
         $this->phpIniPathOverride = $phpIniPath;
-        $this->phpIniLinesCache = null;
+        $this->phpIniLinesCache = [];
+    }
+
+    /**
+     * Override the conf.d drop-in files to scan (testing only).
+     *
+     * @param  array<int, string>  $paths
+     */
+    public function setScannedIniFiles(array $paths): void
+    {
+        $this->scannedIniFilesOverride = $paths;
+        $this->phpIniLinesCache = [];
     }
 
     /**
@@ -153,10 +164,11 @@ class OpcacheAnalyzer extends AbstractAnalyzer
 
     private ?string $deploymentPlatformOverride = null;
 
-    private ?string $cachedPhpIniPath = null;
-
     /** @var array<int, string>|null */
-    private ?array $phpIniLinesCache = null;
+    private ?array $scannedIniFilesOverride = null;
+
+    /** @var array<string, array<int, string>> */
+    private array $phpIniLinesCache = [];
 
     protected function runAnalysis(): ResultInterface
     {
@@ -383,7 +395,10 @@ class OpcacheAnalyzer extends AbstractAnalyzer
             return;
         }
 
-        $memoryConsumption = (int) $directives['opcache.memory_consumption'];
+        // opcache_get_configuration() reports memory_consumption in bytes
+        // (e.g. 134217728 for 128MB), unlike interned_strings_buffer which is
+        // reported in MB. Convert to MB before comparing against the thresholds.
+        $memoryConsumption = (int) round(((int) $directives['opcache.memory_consumption']) / 1048576);
 
         if ($memoryConsumption >= 0 && $memoryConsumption < self::MIN_MEMORY_CONSUMPTION) {
             $issues[] = $this->createOpcacheIssue(
@@ -517,7 +532,13 @@ class OpcacheAnalyzer extends AbstractAnalyzer
         string $recommendation,
         array $metadata = []
     ): Issue {
-        $line = $this->getSettingLine($phpIniPath, $setting);
+        // Point at the file/line where the directive is actively set (the loaded
+        // php.ini or a conf.d drop-in). When it isn't set anywhere we can see,
+        // fall back to the loaded php.ini with no line — the runtime value is a
+        // PHP default, so there's no line to highlight.
+        $location = $this->findSettingLocation($setting);
+        $filePath = $location['file'] ?? $phpIniPath;
+        $line = $location['line'] ?? null;
 
         if ($this->isVaporOrServerless()) {
             $recommendation = $this->buildVaporRecommendation($setting, $recommendation);
@@ -527,7 +548,7 @@ class OpcacheAnalyzer extends AbstractAnalyzer
         // Try to get code snippet, but handle open_basedir restrictions gracefully
         return $this->createIssueWithSnippet(
             message: $message,
-            filePath: $phpIniPath,
+            filePath: $filePath,
             lineNumber: $line,
             severity: $severity,
             recommendation: $recommendation,
@@ -536,9 +557,76 @@ class OpcacheAnalyzer extends AbstractAnalyzer
     }
 
     /**
-     * Get the line number where a setting is defined in php.ini.
+     * Find the file and line where a setting is actively defined.
+     *
+     * Searches the loaded php.ini followed by any conf.d drop-ins, returning the
+     * first active (uncommented) match. Returns null when the directive isn't
+     * explicitly set anywhere we scan — its runtime value is then a PHP default.
+     *
+     * @return array{file: string, line: int}|null
      */
-    private function getSettingLine(string $phpIniPath, string $setting): int
+    private function findSettingLocation(string $setting): ?array
+    {
+        foreach ($this->getIniFilesToScan() as $file) {
+            $line = $this->getSettingLine($file, $setting);
+
+            if ($line !== null) {
+                return ['file' => $file, 'line' => $line];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the ini files that may define directives, in precedence order: the
+     * loaded php.ini followed by any conf.d drop-ins (the "Additional .ini files
+     * parsed" list). On the common Debian/Ubuntu layout OPcache is loaded and
+     * tuned from a drop-in (e.g. conf.d/10-opcache.ini), not the main php.ini.
+     *
+     * @return array<int, string>
+     */
+    private function getIniFilesToScan(): array
+    {
+        $files = [$this->getPhpIniPath()];
+
+        // Explicit override (testing): scan exactly what was provided.
+        if ($this->scannedIniFilesOverride !== null) {
+            return array_merge($files, $this->scannedIniFilesOverride);
+        }
+
+        // When the php.ini path is overridden (testing) without drop-ins, don't
+        // reach into the real system's scanned directory.
+        if ($this->phpIniPathOverride !== null) {
+            return $files;
+        }
+
+        $scanned = php_ini_scanned_files();
+
+        if (is_string($scanned) && $scanned !== '') {
+            foreach (explode(',', $scanned) as $scannedFile) {
+                $scannedFile = trim($scannedFile);
+
+                if ($scannedFile !== '') {
+                    $files[] = $scannedFile;
+                }
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * Get the line number where a setting is actively defined in php.ini.
+     *
+     * Returns null when the setting has no active (uncommented) line. The
+     * runtime value still comes from opcache_get_configuration(), so a missing
+     * line just means the directive isn't explicitly set in this file (it may
+     * be a PHP default or set in a conf.d drop-in). Returning null avoids
+     * pinning the issue to an unrelated line (e.g. a comment), which previously
+     * made commented directives look active.
+     */
+    private function getSettingLine(string $phpIniPath, string $setting): ?int
     {
         $lines = $this->getPhpIniLines($phpIniPath);
 
@@ -557,7 +645,7 @@ class OpcacheAnalyzer extends AbstractAnalyzer
             }
         }
 
-        return 1;
+        return null;
     }
 
     /**
@@ -567,22 +655,17 @@ class OpcacheAnalyzer extends AbstractAnalyzer
      */
     private function getPhpIniLines(string $phpIniPath): array
     {
-        if ($this->cachedPhpIniPath !== $phpIniPath) {
-            $this->phpIniLinesCache = null;
-            $this->cachedPhpIniPath = $phpIniPath;
-        }
-
-        if ($this->phpIniLinesCache === null) {
+        if (! array_key_exists($phpIniPath, $this->phpIniLinesCache)) {
             // Try to read the file, but handle open_basedir restrictions gracefully
             try {
-                $this->phpIniLinesCache = FileParser::getLines($phpIniPath);
+                $this->phpIniLinesCache[$phpIniPath] = FileParser::getLines($phpIniPath);
             } catch (\Throwable $e) {
-                // If we can't read the file (e.g., due to open_basedir restrictions), return empty array
-                $this->phpIniLinesCache = [];
+                // If we can't read the file (e.g., due to open_basedir restrictions), cache empty
+                $this->phpIniLinesCache[$phpIniPath] = [];
             }
         }
 
-        return $this->phpIniLinesCache ?? [];
+        return $this->phpIniLinesCache[$phpIniPath];
     }
 
     /**

--- a/tests/Unit/Analyzers/Performance/OpcacheAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/OpcacheAnalyzerTest.php
@@ -12,6 +12,12 @@ use ShieldCI\Tests\AnalyzerTestCase;
 
 class OpcacheAnalyzerTest extends AnalyzerTestCase
 {
+    /**
+     * Bytes per megabyte. opcache_get_configuration() reports
+     * opcache.memory_consumption in bytes, so overrides use byte values.
+     */
+    private const MB = 1048576;
+
     protected function createAnalyzer(): AnalyzerInterface
     {
         $analyzer = new class extends OpcacheAnalyzer
@@ -68,7 +74,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
             'directives' => [
                 'opcache.enable' => true,
                 'opcache.validate_timestamps' => false,
-                'opcache.memory_consumption' => 64,
+                'opcache.memory_consumption' => 64 * self::MB,
                 'opcache.interned_strings_buffer' => 8,
                 'opcache.max_accelerated_files' => 5000,
                 'opcache.revalidate_freq' => 0,
@@ -90,7 +96,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
             'directives' => [
                 'opcache.enable' => true,
                 'opcache.validate_timestamps' => false,
-                'opcache.memory_consumption' => 256,
+                'opcache.memory_consumption' => 256 * self::MB,
                 'opcache.interned_strings_buffer' => 16,
                 'opcache.max_accelerated_files' => 20000,
                 'opcache.revalidate_freq' => 0,
@@ -249,7 +255,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $analyzer->setScenario(true, [
             'directives' => [
                 'opcache.enable' => true,
-                'opcache.memory_consumption' => 64, // Below MIN (128)
+                'opcache.memory_consumption' => 64 * self::MB, // Below MIN (128)
             ],
         ]);
 
@@ -270,7 +276,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $analyzer->setScenario(true, [
             'directives' => [
                 'opcache.enable' => true,
-                'opcache.memory_consumption' => 128, // Exactly at MIN
+                'opcache.memory_consumption' => 128 * self::MB, // Exactly at MIN
             ],
         ]);
 
@@ -324,7 +330,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $analyzer->setScenario(true, [
             'directives' => [
                 'opcache.enable' => true,
-                'opcache.memory_consumption' => '64', // String number
+                'opcache.memory_consumption' => (string) (64 * self::MB), // String number (bytes)
             ],
         ]);
 
@@ -593,7 +599,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
             'directives' => [
                 'opcache.enable' => true,
                 'opcache.validate_timestamps' => true, // Issue 1
-                'opcache.memory_consumption' => 64, // Issue 2
+                'opcache.memory_consumption' => 64 * self::MB, // Issue 2
                 'opcache.interned_strings_buffer' => 8, // Issue 3
                 'opcache.max_accelerated_files' => 5000, // Issue 4
             ],
@@ -615,7 +621,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
             'directives' => [
                 'opcache.enable' => true,
                 'opcache.validate_timestamps' => false,
-                'opcache.memory_consumption' => 64, // Only this is suboptimal
+                'opcache.memory_consumption' => 64 * self::MB, // Only this is suboptimal
                 'opcache.interned_strings_buffer' => 16,
                 'opcache.max_accelerated_files' => 20000,
                 'opcache.revalidate_freq' => 0,
@@ -670,7 +676,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $analyzer->setScenario(true, [
             'directives' => [
                 'opcache.enable' => true,
-                'opcache.memory_consumption' => 64,
+                'opcache.memory_consumption' => 64 * self::MB,
             ],
         ]);
 
@@ -717,7 +723,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $analyzer->setScenario(true, [
             'directives' => [
                 'opcache.enable' => true,
-                'opcache.memory_consumption' => 64,
+                'opcache.memory_consumption' => 64 * self::MB,
             ],
         ]);
 
@@ -779,9 +785,12 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $this->assertWarning($result);
         $issues = $result->getIssues();
         $this->assertCount(1, $issues);
-        // Should report line 1 (generic), NOT line 2 (the commented line)
+        // No active (uncommented) line exists, so the issue must NOT be pinned to
+        // a line — the commented line is not "active" and line 1 would be misleading.
         $this->assertNotNull($issues[0]->location);
-        $this->assertEquals(1, $issues[0]->location->line);
+        $this->assertNull($issues[0]->location->line);
+        // And no code snippet should be attached when there's no line to point at.
+        $this->assertNull($issues[0]->codeSnippet);
     }
 
     public function test_active_setting_reports_correct_line_number(): void
@@ -803,7 +812,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
             'directives' => [
                 'opcache.enable' => true,
                 'opcache.validate_timestamps' => true,
-                'opcache.memory_consumption' => 64,
+                'opcache.memory_consumption' => 64 * self::MB,
             ],
         ]);
         $analyzer->setPhpIniPath($tempDir.'/php.ini');
@@ -833,7 +842,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $analyzer->setScenario(true, [
             'directives' => [
                 'opcache.enable' => true,
-                'opcache.memory_consumption' => 64,
+                'opcache.memory_consumption' => 64 * self::MB,
             ],
         ]);
         $analyzer->setDeploymentPlatform('vapor');
@@ -870,7 +879,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $analyzer->setScenario(true, [
             'directives' => [
                 'opcache.enable' => true,
-                'opcache.memory_consumption' => 32,          // below MIN — would normally flag
+                'opcache.memory_consumption' => 32 * self::MB,          // below MIN — would normally flag
                 'opcache.interned_strings_buffer' => 4,       // below MIN — would normally flag
                 'opcache.max_accelerated_files' => 1000,      // below MIN — would normally flag
                 'opcache.validate_timestamps' => true,        // enabled — would normally flag
@@ -893,7 +902,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $analyzer->setScenario(true, [
             'directives' => [
                 'opcache.enable' => true,
-                'opcache.memory_consumption' => 32,          // PHP_INI_SYSTEM — should be suppressed
+                'opcache.memory_consumption' => 32 * self::MB,          // PHP_INI_SYSTEM — should be suppressed
                 'opcache.interned_strings_buffer' => 4,       // PHP_INI_SYSTEM — should be suppressed
                 'opcache.max_accelerated_files' => 1000,      // PHP_INI_SYSTEM — should be suppressed
                 'opcache.validate_timestamps' => true,        // PHP_INI_ALL — should still flag
@@ -932,7 +941,7 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $analyzer->setScenario(true, [
             'directives' => [
                 'opcache.enable' => true,
-                'opcache.memory_consumption' => 64,
+                'opcache.memory_consumption' => 64 * self::MB,
             ],
         ]);
         // No setDeploymentPlatform() call — traditional server
@@ -949,5 +958,86 @@ class OpcacheAnalyzerTest extends AnalyzerTestCase
         $this->assertStringNotContainsString('php/conf.d', $recommendation);
 
         $this->assertArrayNotHasKey('deployment_platform', $issues[0]->metadata);
+    }
+
+    // Category 14: conf.d Drop-in Scanning
+
+    public function test_reports_directive_set_in_conf_d_drop_in(): void
+    {
+        // Common Debian/Ubuntu layout: OPcache is loaded and tuned from a
+        // conf.d drop-in, not the main php.ini.
+        $tempDir = $this->createTempDirectory([
+            'php.ini' => implode("\n", [
+                '[opcache]',
+                '; opcache is tuned in conf.d',
+            ]),
+            '10-opcache.ini' => implode("\n", [
+                '; configuration for php opcache module',
+                'zend_extension=opcache.so',
+                'opcache.interned_strings_buffer=8',
+            ]),
+        ]);
+
+        /** @var OpcacheAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        // @phpstan-ignore-next-line
+        $analyzer->setScenario(true, [
+            'directives' => [
+                'opcache.enable' => true,
+                'opcache.interned_strings_buffer' => 8,
+            ],
+        ]);
+        $analyzer->setPhpIniPath($tempDir.'/php.ini');
+        $analyzer->setScannedIniFiles([$tempDir.'/10-opcache.ini']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        // The issue must point at the conf.d drop-in (line 3), not the main php.ini.
+        $this->assertNotNull($issues[0]->location);
+        $this->assertEquals(3, $issues[0]->location->line);
+        $this->assertStringContainsString('10-opcache.ini', $issues[0]->location->file);
+    }
+
+    public function test_falls_back_to_php_ini_when_directive_not_in_any_scanned_file(): void
+    {
+        // OPcache loaded via a drop-in that only loads the extension — no tuning
+        // anywhere, so the runtime value is a PHP default with no line to point at.
+        $tempDir = $this->createTempDirectory([
+            'php.ini' => implode("\n", [
+                '[opcache]',
+                ';opcache.interned_strings_buffer=8',
+            ]),
+            '10-opcache.ini' => implode("\n", [
+                '; configuration for php opcache module',
+                'zend_extension=opcache.so',
+                'opcache.jit=off',
+            ]),
+        ]);
+
+        /** @var OpcacheAnalyzer $analyzer */
+        $analyzer = $this->createAnalyzer();
+        // @phpstan-ignore-next-line
+        $analyzer->setScenario(true, [
+            'directives' => [
+                'opcache.enable' => true,
+                'opcache.interned_strings_buffer' => 8,
+            ],
+        ]);
+        $analyzer->setPhpIniPath($tempDir.'/php.ini');
+        $analyzer->setScannedIniFiles([$tempDir.'/10-opcache.ini']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        // No active line anywhere → fall back to php.ini with no line / snippet.
+        $this->assertNotNull($issues[0]->location);
+        $this->assertNull($issues[0]->location->line);
+        $this->assertStringContainsString('php.ini', $issues[0]->location->file);
+        $this->assertNull($issues[0]->codeSnippet);
     }
 }


### PR DESCRIPTION
## Problem

`OpcacheAnalyzer` appeared to flag **commented** `php.ini` lines (e.g. `;opcache.validate_timestamps=1`, `;opcache.interned_strings_buffer=8`) as if they were active settings. Root cause: values come from `opcache_get_configuration()` (runtime), but when a directive had no active line in the loaded `php.ini`, `getSettingLine()` fell back to line `1`, pinning the issue + code snippet to an unrelated comment. The flagged values are the real PHP defaults — sub-optimal, but presented as if they lived on a commented line.

## Changes

- `getSettingLine()` returns `?int` and now yields `null` (no line, no snippet) when there's no active match, instead of falling back to line 1.
- New `findSettingLocation()` / `getIniFilesToScan()` scan the loaded `php.ini` **and** conf.d drop-ins (`php_ini_scanned_files()`), so a directive tuned in e.g. `conf.d/10-opcache.ini` is pinned to the correct file and line — matching the common Debian/Ubuntu layout where OPcache is loaded/tuned from a drop-in.
- Fix `memory_consumption` units: `opcache_get_configuration()` reports it in **bytes** (unlike `interned_strings_buffer` in MB), so the check compared bytes against an MB threshold and never fired. Now converts to MB before comparing.
- Per-path line cache so scanning multiple ini files doesn't thrash.

## Tests

- Comment-detection test now asserts `location->line === null` and no code snippet.
- Added tests for a directive set in a conf.d drop-in (pins to that file/line) and for the not-set-anywhere fallback.
- `memory_consumption` overrides converted to byte values via an `MB` constant.