### PR TITLE
fix: recognize Eloquent attribute config in mass-assignment analyzers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "illuminate/view": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "larastan/larastan": "^2.0|^3.0",
         "phpstan/phpstan": "^1.10|^2.0",
-        "shieldci/analyzers-core": "^1.0"
+        "shieldci/analyzers-core": "^1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0|^10.0|^11.0|^12.0|^13.0",

--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\EloquentModelHelper;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
@@ -102,6 +103,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                     }
 
                     $this->checkFillableProperty($file, $class, $issues);
+                    $this->checkFillableAttribute($file, $class, $issues);
                 }
             }
         }
@@ -146,43 +148,19 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
-     * Check if fillable is declared in an Eloquent model.
+     * Check if fillable is declared locally, via a $fillable property or a #[Fillable] attribute.
      */
     private function hasLocalFillable(Node\Stmt\Class_ $class): bool
     {
-        foreach ($class->stmts as $stmt) {
-            if (! $stmt instanceof Node\Stmt\Property) {
-                continue;
-            }
-
-            foreach ($stmt->props as $prop) {
-                if ($prop->name->toString() === 'fillable') {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return EloquentModelHelper::hasFillable($class);
     }
 
     /**
-     * Check if guarded is declared in an Eloquent model.
+     * Check if guarded is declared locally, via a $guarded property or a #[Guarded]/#[Unguarded] attribute.
      */
     private function hasLocalGuarded(Node\Stmt\Class_ $class): bool
     {
-        foreach ($class->stmts as $stmt) {
-            if (! $stmt instanceof Node\Stmt\Property) {
-                continue;
-            }
-
-            foreach ($stmt->props as $prop) {
-                if ($prop->name->toString() === 'guarded') {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return EloquentModelHelper::hasGuarded($class);
     }
 
     /**
@@ -230,6 +208,45 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                 }
             }
         }
+    }
+
+    /**
+     * Check fields declared via a #[Fillable(...)] attribute for foreign keys.
+     *
+     * Reuses the same curated-pattern detection (checkField) as the property path so an
+     * attribute-based model is analyzed identically to a property-based one.
+     */
+    private function checkFillableAttribute(string $file, Node\Stmt\Class_ $class, array &$issues): void
+    {
+        $fields = EloquentModelHelper::extractFillableFieldsFromAttribute($class);
+        if ($fields === []) {
+            return;
+        }
+
+        $modelName = $class->name ? $class->name->toString() : 'Unknown';
+        $line = $this->fillableAttributeLine($class);
+
+        foreach ($fields as $fieldName) {
+            $this->checkField($file, $line, $modelName, $fieldName, $issues);
+        }
+    }
+
+    /**
+     * Line of the #[Fillable] attribute, falling back to the class line.
+     */
+    private function fillableAttributeLine(Node\Stmt\Class_ $class): int
+    {
+        foreach ($class->attrGroups as $group) {
+            foreach ($group->attrs as $attr) {
+                $name = $attr->name->toString();
+                $short = ($pos = strrpos($name, '\\')) !== false ? substr($name, $pos + 1) : $name;
+                if ($short === 'Fillable') {
+                    return $attr->getLine();
+                }
+            }
+        }
+
+        return $class->getLine();
     }
 
     /**

--- a/src/Analyzers/Security/MassAssignmentAnalyzer.php
+++ b/src/Analyzers/Security/MassAssignmentAnalyzer.php
@@ -10,6 +10,7 @@ use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\EloquentModelHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 
@@ -262,6 +263,10 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
                 }
             }
         }
+
+        // Mass-assignment config can also be declared via #[Fillable]/#[Guarded]/#[Unguarded] attributes.
+        $hasFillable = $hasFillable || EloquentModelHelper::hasFillable($class);
+        $hasGuarded = $hasGuarded || EloquentModelHelper::hasGuarded($class);
 
         $modelName = $class->name ? $class->name->toString() : 'Unknown';
 
@@ -1074,59 +1079,12 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
      */
     private function checkHiddenAttributes(string $file, Node\Stmt\Class_ $class, array &$issues): void
     {
-        $hasHidden = false;
-        $hasFillable = false;
-        $hasGuarded = false;
-        $hiddenFields = [];
-        $guardedFields = [];
-        $fillableFields = [];
-
-        foreach ($class->stmts as $stmt) {
-            if ($stmt instanceof Node\Stmt\Property) {
-                foreach ($stmt->props as $prop) {
-                    $propName = $prop->name->toString();
-
-                    if ($propName === 'hidden') {
-                        $hasHidden = true;
-
-                        // Extract hidden field names
-                        if ($prop->default instanceof Node\Expr\Array_) {
-                            foreach ($prop->default->items as $item) {
-                                if ($item && $item->value instanceof Node\Scalar\String_) {
-                                    $hiddenFields[] = $item->value->value;
-                                }
-                            }
-                        }
-                    }
-
-                    if ($propName === 'fillable') {
-                        $hasFillable = true;
-
-                        // Extract fillable field names
-                        if ($prop->default instanceof Node\Expr\Array_) {
-                            foreach ($prop->default->items as $item) {
-                                if ($item && $item->value instanceof Node\Scalar\String_) {
-                                    $fillableFields[] = $item->value->value;
-                                }
-                            }
-                        }
-                    }
-
-                    if ($propName === 'guarded') {
-                        $hasGuarded = true;
-
-                        // Extract guarded field names
-                        if ($prop->default instanceof Node\Expr\Array_) {
-                            foreach ($prop->default->items as $item) {
-                                if ($item && $item->value instanceof Node\Scalar\String_) {
-                                    $guardedFields[] = $item->value->value;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        // Read configuration from either properties or #[Fillable]/#[Guarded]/#[Hidden] attributes.
+        $hasHidden = EloquentModelHelper::hasHidden($class);
+        $hasFillable = EloquentModelHelper::hasFillable($class);
+        $hiddenFields = EloquentModelHelper::extractHiddenFields($class);
+        $guardedFields = EloquentModelHelper::extractGuardedFields($class);
+        $fillableFields = EloquentModelHelper::extractFillableFields($class);
 
         $modelName = $class->name ? $class->name->toString() : 'Unknown';
 

--- a/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
@@ -860,4 +860,123 @@ PHP;
         // Verify analyzer runs successfully
         $this->assertPassed($result);
     }
+
+    public function test_passes_with_fillable_attribute_no_foreign_key(): void
+    {
+        // Direct regression for the Compass false positive: a #[Fillable] model with
+        // no foreign keys must produce zero issues (no "inherited fillable" notice).
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['first_name', 'last_name', 'phone', 'email', 'password'])]
+class User extends Model
+{
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Models/User.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertIssueCount(0, $result);
+    }
+
+    public function test_detects_company_id_in_fillable_attribute(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'company_id'])]
+class Membership extends Model
+{
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Models/Membership.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('company_id', $result);
+    }
+
+    public function test_detects_user_id_in_fillable_attribute_variadic(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable('title', 'user_id')]
+class Post extends Model
+{
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Models/Post.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('user_id', $result);
+        $this->assertHasIssueContaining('impersonate', $result);
+    }
+
+    public function test_still_notices_when_no_property_and_no_attribute(): void
+    {
+        // True positive preserved: a model with neither $fillable property nor
+        // #[Fillable] attribute still gets the medium "cannot analyze" notice.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Widget extends Model
+{
+    protected $table = 'widgets';
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Models/Widget.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $inheritedIssues = array_filter(
+            $result->getIssues(),
+            fn ($i) => isset($i->metadata['fillable_inherited']) && $i->metadata['fillable_inherited'] === true
+        );
+        $this->assertNotEmpty($inheritedIssues, 'Model with no fillable property or attribute should still get the notice');
+    }
 }

--- a/tests/Unit/Analyzers/Security/MassAssignmentAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/MassAssignmentAnalyzerTest.php
@@ -3018,4 +3018,187 @@ PHP;
         );
         $this->assertNotEmpty($protectionIssues, 'Should still flag model when whole chain lacks protection');
     }
+
+    public function test_passes_with_fillable_attribute(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'email'])]
+class User extends Model
+{
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/User.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $this->assertPassed($analyzer->analyze());
+    }
+
+    public function test_passes_with_fillable_attribute_variadic(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable('name', 'email')]
+class User extends Model
+{
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/User.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $this->assertPassed($analyzer->analyze());
+    }
+
+    public function test_passes_with_guarded_attribute(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Guarded;
+use Illuminate\Database\Eloquent\Model;
+
+#[Guarded(['id'])]
+class User extends Model
+{
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/User.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $this->assertPassed($analyzer->analyze());
+    }
+
+    public function test_passes_with_unguarded_attribute(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Unguarded;
+use Illuminate\Database\Eloquent\Model;
+
+#[Unguarded]
+class User extends Model
+{
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/User.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        // #[Unguarded] counts as explicit mass-assignment configuration, so the
+        // "lacks protection" issue must not fire.
+        $protectionIssues = array_filter(
+            $analyzer->analyze()->getIssues(),
+            fn ($i) => isset($i->metadata['issue_type']) && $i->metadata['issue_type'] === 'missing_model_protection'
+        );
+        $this->assertEmpty($protectionIssues);
+    }
+
+    public function test_recognizes_hidden_attribute_for_sensitive_fillable_field(): void
+    {
+        // #[Fillable] exposes password, #[Hidden] hides it — must NOT warn that
+        // a sensitive field lacks $hidden (both sides read from attributes).
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'password'])]
+#[Hidden(['password'])]
+class User extends Model
+{
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/User.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $hiddenIssues = array_filter(
+            $analyzer->analyze()->getIssues(),
+            fn ($i) => isset($i->metadata['issue_type'])
+                && in_array($i->metadata['issue_type'], ['missing_hidden_attributes', 'fillable_field_not_hidden'], true)
+        );
+        $this->assertEmpty($hiddenIssues, 'Hidden declared via #[Hidden] should satisfy the hidden-field check');
+    }
+
+    public function test_flags_sensitive_fillable_attribute_without_hidden(): void
+    {
+        // #[Fillable] exposes password but nothing hides it — the existing medium
+        // warning should still fire when fillable is declared via an attribute.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'password'])]
+class User extends Model
+{
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/User.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $hiddenIssues = array_filter(
+            $analyzer->analyze()->getIssues(),
+            fn ($i) => isset($i->metadata['issue_type']) && $i->metadata['issue_type'] === 'missing_hidden_attributes'
+        );
+        $this->assertNotEmpty($hiddenIssues, 'Sensitive field in #[Fillable] without $hidden should warn');
+    }
 }


### PR DESCRIPTION
## Summary

`MassAssignmentAnalyzer` and `FillableForeignKeyAnalyzer` read only the `$fillable`/`$guarded` **properties**, so models that declare mass-assignment config via the Laravel 12+ attributes `#[Fillable]` / `#[Guarded]` / `#[Unguarded]` (as shipped by the official starter kits) were wrongly flagged as unprotected.

Both analyzers now use `EloquentModelHelper` (property **or** attribute). `MassAssignmentAnalyzer` also reads `#[Hidden]` so the sensitive-field-in-`$fillable` check stays accurate for attribute-based models. True positives are preserved — a model with neither a property nor an attribute is still flagged.

Requires `shieldci/analyzers-core ^1.5` (the release that adds `EloquentModelHelper`); `composer.json` bumped accordingly.

## Verification

- 122 analyzer tests pass (incl. new attribute fixtures + regression guards)
- PHPStan Level 9 clean, Pint clean