### PR TITLE
fix: detect web middleware on route files required inside group closures

### DIFF
--- a/src/Support/BootstrapRouteParser.php
+++ b/src/Support/BootstrapRouteParser.php
@@ -379,15 +379,54 @@ class BootstrapRouteParser
                 continue;
             }
 
-            // Arg must be base_path('routes/X.php')
-            $routeFile = $this->extractBasePathArgument($firstArg->value);
-            if ($routeFile === null) {
+            // The group must actually carry the middleware we're looking for.
+            if (! $this->chainContainsMiddleware($call->var, $middlewareName)) {
                 continue;
             }
 
-            // Walk the chain to check the specified middleware is present
-            if ($this->chainContainsMiddleware($call->var, $middlewareName)) {
+            // Form 1: ->group(base_path('routes/X.php'))
+            $routeFile = $this->extractBasePathArgument($firstArg->value);
+            if ($routeFile !== null) {
                 $normalized = $this->normalizePath($routeFile);
+                if ($normalized !== null) {
+                    $found[] = $normalized;
+                }
+
+                continue;
+            }
+
+            // Form 2: ->group(function () { require __DIR__.'/auth.php'; })
+            // Files require'd inside the closure inherit the group's middleware.
+            foreach ($this->extractIncludesFromClosure($firstArg->value, dirname($filePath)) as $included) {
+                $found[] = $included;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * Resolves the absolute paths of files require'd/include'd inside a ->group(Closure) body.
+     *
+     * @return array<string>
+     */
+    private function extractIncludesFromClosure(Node $closure, string $dir): array
+    {
+        if (! ($closure instanceof Node\Expr\Closure) && ! ($closure instanceof Node\Expr\ArrowFunction)) {
+            return [];
+        }
+
+        $found = [];
+        $includes = $this->parser->findNodes([$closure], Include_::class);
+
+        foreach ($includes as $include) {
+            if (! ($include instanceof Include_)) {
+                continue;
+            }
+
+            $path = $this->resolveIncludePath($include->expr, $dir);
+            if ($path !== null && file_exists($path)) {
+                $normalized = $this->normalizePath($path);
                 if ($normalized !== null) {
                     $found[] = $normalized;
                 }

--- a/src/Support/BootstrapRouteParser.php
+++ b/src/Support/BootstrapRouteParser.php
@@ -420,15 +420,15 @@ class BootstrapRouteParser
         $includes = $this->parser->findNodes([$closure], Include_::class);
 
         foreach ($includes as $include) {
-            if (! ($include instanceof Include_)) {
-                continue;
-            }
-
-            $path = $this->resolveIncludePath($include->expr, $dir);
-            if ($path !== null && file_exists($path)) {
-                $normalized = $this->normalizePath($path);
-                if ($normalized !== null) {
-                    $found[] = $normalized;
+            // findNodes() only ever yields Include_ nodes; the instanceof narrows the
+            // type for static analysis without an unreachable skip branch.
+            if ($include instanceof Include_) {
+                $path = $this->resolveIncludePath($include->expr, $dir);
+                if ($path !== null && file_exists($path)) {
+                    $normalized = $this->normalizePath($path);
+                    if ($normalized !== null) {
+                        $found[] = $normalized;
+                    }
                 }
             }
         }

--- a/tests/Unit/Analyzers/Security/CsrfAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/CsrfAnalyzerTest.php
@@ -2096,6 +2096,50 @@ PHP;
         $this->assertPassed($result);
     }
 
+    public function test_skips_route_file_required_inside_web_group_closure_in_bootstrap(): void
+    {
+        // Compass pattern: auth.php is require'd inside a ->group(Closure) on a
+        // Route::domain()->middleware('web') chain (not via ->group(base_path())).
+        $bootstrapApp = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Route;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        then: function () {
+            Route::domain(config('app.domain'))
+                ->middleware('web')
+                ->group(function () {
+                    require __DIR__.'/../routes/auth.php';
+                });
+        },
+    )
+    ->create();
+PHP;
+
+        $authPhp = <<<'PHP'
+<?php
+Route::post('/login', [LoginController::class, 'store']);
+Route::post('/register', [RegisterController::class, 'store']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/web.php' => '<?php // main web routes',
+            'routes/auth.php' => $authPhp,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        // Should pass — auth.php inherits 'web' middleware from the enclosing closure group.
+        $this->assertPassed($analyzer->analyze());
+    }
+
     public function test_passes_api_route_file_registered_with_api_middleware_array(): void
     {
         // Platform's exact pattern: ->middleware(['api', 'throttle:api.rest'])->group(base_path('routes/api-v1.php'))

--- a/tests/Unit/Support/BootstrapRouteParserTest.php
+++ b/tests/Unit/Support/BootstrapRouteParserTest.php
@@ -1038,4 +1038,97 @@ PHP;
             $this->removeDir($tempDir);
         }
     }
+
+    public function test_detects_files_required_inside_web_middleware_group_closure(): void
+    {
+        // Compass pattern: route files are require'd inside a ->group(Closure) on a
+        // Route::domain()->middleware('web') chain, rather than via ->group(base_path()).
+        $bootstrapApp = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Route;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        then: function () {
+            Route::domain(config('app.domain'))
+                ->middleware('web')
+                ->group(function () {
+                    require __DIR__.'/../routes/auth.php';
+                    require __DIR__.'/../routes/settings.php';
+                });
+        },
+    )
+    ->create();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/auth.php' => '<?php // auth routes',
+            'routes/settings.php' => '<?php // settings routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $result = $parser->getWebProtectedRouteFiles();
+
+            $this->assertCount(2, $result);
+            $this->assertTrue($this->endsWithMatch($result, '/routes/auth.php'));
+            $this->assertTrue($this->endsWithMatch($result, '/routes/settings.php'));
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_ignores_files_required_inside_group_closure_without_web_middleware(): void
+    {
+        // True positive preserved: a closure group with no 'web' middleware must NOT
+        // mark the required file as web-protected.
+        $bootstrapApp = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Route;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        then: function () {
+            Route::prefix('legacy')
+                ->group(function () {
+                    require __DIR__.'/../routes/legacy.php';
+                });
+        },
+    )
+    ->create();
+PHP;
+
+        $tempDir = $this->createTempDir([
+            'bootstrap/app.php' => $bootstrapApp,
+            'routes/legacy.php' => '<?php // legacy routes',
+        ]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+
+            $this->assertSame([], $parser->getWebProtectedRouteFiles());
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    /**
+     * @param  array<string>  $paths
+     */
+    private function endsWithMatch(array $paths, string $suffix): bool
+    {
+        foreach ($paths as $path) {
+            if (str_ends_with($path, $suffix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary

`BootstrapRouteParser` only linked `web` middleware to route files registered via `->group(base_path('...'))`. Files `require`d inside a `->group(Closure)` — e.g. `Route::domain()->middleware('web')->group(fn () => require ...)`, the form the Laravel 11+ skeleton uses — were treated as unprotected, producing false "missing CSRF protection" reports.

The parser now walks the closure body for `include`/`require` nodes and links them when the enclosing chain carries the target middleware. This also covers the `withRouting(then:)` form via the existing whole-file AST traversal. True positives are preserved — a file required in a closure with no `web` middleware is still flagged.

## Verification

- 126 tests pass (new closure-group fixtures in `BootstrapRouteParserTest` + end-to-end `CsrfAnalyzerTest`, incl. the no-web-middleware regression)
- PHPStan Level 9 clean, Pint clean