### PR TITLE
fix: detect login throttling defined in a FormRequest

### DIFF
--- a/src/Analyzers/Security/LoginThrottlingAnalyzer.php
+++ b/src/Analyzers/Security/LoginThrottlingAnalyzer.php
@@ -132,10 +132,14 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
         $basePath = $this->getBasePath();
         $authFiles = [];
 
-        // Check auth controllers
+        // Check auth controllers and form requests. The official starter kits throttle
+        // login from App\Http\Requests\Auth\LoginRequest (ensureIsNotRateLimited()), so
+        // app/Http/Requests must be scanned too. The filename filter below keeps this to
+        // auth/login/session-named files.
         $authPaths = [
             $basePath.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'Http'.DIRECTORY_SEPARATOR.'Controllers'.DIRECTORY_SEPARATOR.'Auth',
             $basePath.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'Http'.DIRECTORY_SEPARATOR.'Controllers',
+            $basePath.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'Http'.DIRECTORY_SEPARATOR.'Requests',
         ];
 
         foreach ($authPaths as $path) {
@@ -242,7 +246,9 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
                     // Check if this is an auth-related method
                     // Note: __invoke is included for single-action controllers (Laravel best practice)
                     // e.g., class LoginController { public function __invoke() {...} }
-                    $authMethods = ['login', 'authenticate', 'attempt', 'postLogin', 'handleLogin', 'store', '__invoke'];
+                    // 'ensureIsNotRateLimited' is the canonical throttling guard in the
+                    // official starter-kit LoginRequest.
+                    $authMethods = ['login', 'authenticate', 'attempt', 'postLogin', 'handleLogin', 'store', '__invoke', 'ensureIsNotRateLimited'];
                     if (! in_array(strtolower($methodName), array_map('strtolower', $authMethods), true)) {
                         continue;
                     }

--- a/tests/Unit/Analyzers/Security/LoginThrottlingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/LoginThrottlingAnalyzerTest.php
@@ -1403,4 +1403,143 @@ PHP;
             $this->assertStringNotContainsString('RateLimiter::for(', $issue->recommendation);
         }
     }
+
+    public function test_passes_when_login_request_throttles_via_form_request(): void
+    {
+        // Compass repro: the login route delegates throttling to a LoginRequest in
+        // app/Http/Requests, which the analyzer previously never scanned.
+        $route = <<<'PHP'
+<?php
+
+use App\Http\Controllers\Auth\AuthenticatedSessionController;
+
+Route::post('/login', [AuthenticatedSessionController::class, 'store']);
+PHP;
+
+        $loginRequest = <<<'PHP'
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Validation\ValidationException;
+
+class LoginRequest extends FormRequest
+{
+    public function ensureIsNotRateLimited(): void
+    {
+        if (! RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+            return;
+        }
+
+        throw ValidationException::withMessages(['email' => 'Too many attempts.']);
+    }
+
+    protected function throttleKey(): string
+    {
+        return 'login';
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $route,
+            'app/Http/Requests/Auth/LoginRequest.php' => $loginRequest,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app', 'routes']);
+
+        $this->assertPassed($analyzer->analyze());
+    }
+
+    public function test_passes_when_form_request_uses_rate_limiter_only_in_ensure_method(): void
+    {
+        // Isolates the AST gate: the only throttling signal is RateLimiter::hit/clear
+        // inside ensureIsNotRateLimited() — no tooManyAttempts text, no 'login' literal —
+        // so detection relies on ensureIsNotRateLimited being a recognized auth method.
+        $route = <<<'PHP'
+<?php
+
+use App\Http\Controllers\Auth\AuthenticatedSessionController;
+
+Route::post('/login', [AuthenticatedSessionController::class, 'store']);
+PHP;
+
+        $loginRequest = <<<'PHP'
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\RateLimiter;
+
+class LoginRequest extends FormRequest
+{
+    public function ensureIsNotRateLimited(): void
+    {
+        RateLimiter::hit($this->key());
+        RateLimiter::clear($this->key());
+    }
+
+    protected function key(): string
+    {
+        return 'auth-key';
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $route,
+            'app/Http/Requests/Auth/LoginRequest.php' => $loginRequest,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app', 'routes']);
+
+        $this->assertPassed($analyzer->analyze());
+    }
+
+    public function test_fails_when_login_request_does_not_throttle(): void
+    {
+        // True positive preserved: a login route whose FormRequest performs no rate
+        // limiting (and no route-level throttle) must still be flagged.
+        $route = <<<'PHP'
+<?php
+
+use App\Http\Controllers\Auth\AuthenticatedSessionController;
+
+Route::post('/login', [AuthenticatedSessionController::class, 'store']);
+PHP;
+
+        $loginRequest = <<<'PHP'
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['email' => ['required'], 'password' => ['required']];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $route,
+            'app/Http/Requests/Auth/LoginRequest.php' => $loginRequest,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app', 'routes']);
+
+        $this->assertFailed($analyzer->analyze());
+    }
 }


### PR DESCRIPTION
## Summary

`LoginThrottlingAnalyzer` never scanned `app/Http/Requests`, so the official starter-kit pattern — `App\Http\Requests\Auth\LoginRequest::ensureIsNotRateLimited()` (which throttles via `RateLimiter`) — was missed, producing false "login route lacks rate limiting" reports.

The analyzer now scans `app/Http/Requests` and recognizes `ensureIsNotRateLimited` as an authentication method in its AST check. True positives are preserved — a login route whose FormRequest performs no rate limiting (and has no route-level `throttle`) is still flagged.

## Verification

- 48 tests pass (new FormRequest fixtures: canonical `ensureIsNotRateLimited`, the AST-gate-only `RateLimiter::hit` case, and the no-throttling regression)
- PHPStan Level 9 clean, Pint clean