### PR TITLE
fix: correct location and recommendation for runtime-injected log channels

### DIFF
--- a/src/Analyzers/Performance/DebugLogAnalyzer.php
+++ b/src/Analyzers/Performance/DebugLogAnalyzer.php
@@ -152,22 +152,67 @@ class DebugLogAnalyzer extends AbstractAnalyzer
                 $configPath = $this->buildPath('config', 'logging.php');
             }
 
-            $lineNumber = ConfigFileHelper::findNestedKeyLine($configPath, 'channels', 'level', $channel);
+            // Determine whether the channel is actually authored in config/logging.php.
+            // Channels injected at runtime by a package/framework (e.g. laravel-cloud-socket)
+            // are not present in the file, so reporting a file/line location and a
+            // "update config/logging.php" recommendation would be misleading.
+            // "Injected" only when the channel is absent AND the file genuinely parsed.
+            // parseConfigArray() returns [] for a missing/unreadable/unparseable file, in
+            // which case we cannot tell — fall back to the legacy behaviour rather than
+            // mislabel. The second parse only runs when the channel was not found (&& short-circuits).
+            $authoredLine = ConfigFileHelper::findNestedArrayKeyLine($configPath, 'channels', $channel);
+            $isInjected = $authoredLine === null
+                && ConfigFileHelper::parseConfigArray($configPath) !== [];
+
+            $lineNumber = $isInjected
+                ? null
+                : ConfigFileHelper::findNestedKeyLine($configPath, 'channels', 'level', $channel);
 
             $issues[] = $this->createIssueWithSnippet(
                 message: "Log channel '{$channel}' is set to debug level in {$environment} environment",
                 filePath: $configPath,
                 lineNumber: $lineNumber,
                 severity: $this->metadata()->severity,
-                recommendation: "Set the log level to 'info' or higher in production by updating your logging configuration or setting the LOG_LEVEL environment variable. Debug logging causes significant performance degradation, generates excessive log files that can exhaust disk space, and exposes sensitive data.",
+                recommendation: $isInjected
+                    ? $this->injectedChannelRecommendation($channel)
+                    : "Set the log level to 'info' or higher in production by updating your logging configuration or setting the LOG_LEVEL environment variable. Debug logging causes significant performance degradation, generates excessive log files that can exhaust disk space, and exposes sensitive data.",
                 metadata: [
                     'environment' => $environment,
                     'channel' => $channel,
                     'level' => $level,
-                    'detection_method' => 'config_repository',
+                    'detection_method' => $isInjected ? 'runtime_injected' : 'config_repository',
+                    'injected' => $isInjected,
                     'code' => 'debug-log-level',
                 ]
             );
         }
+    }
+
+    /**
+     * Build a recommendation for a channel that is injected at runtime rather than
+     * authored in config/logging.php. Such channels cannot be fixed by editing that
+     * file (the framework/package overwrites the entry after config load), so the
+     * guidance must name the real lever per known channel, with a generic fallback.
+     */
+    private function injectedChannelRecommendation(string $channel): string
+    {
+        $known = [
+            'laravel-cloud-socket' => "Channel '{$channel}' is injected at runtime by Laravel "
+                .'(Illuminate\\Foundation\\Cloud::configureCloudLogging) and reads LOG_LEVEL from the '
+                .'process environment, not config/logging.php. Under config:cache a .env value is not '
+                .'enough — set LOG_LEVEL as a real platform environment variable, or re-assert the level '
+                ."in a service provider boot() (e.g. config(['logging.channels.{$channel}.level' => 'info'])). "
+                .'Debug logging causes performance degradation, excessive log volume, and can expose sensitive data.',
+            'nightwatch' => "Channel '{$channel}' is injected at runtime by Laravel Nightwatch. Set "
+                .'NIGHTWATCH_LOG_LEVEL (or nightwatch.filtering.log_level) to info or higher; it inherits '
+                .'LOG_LEVEL by default. Debug logging causes performance degradation, excessive log volume, '
+                .'and can expose sensitive data.',
+        ];
+
+        return $known[$channel] ?? "Channel '{$channel}' is not defined in config/logging.php; it is "
+            .'registered at runtime by a package or the framework. Configure its level via that package\'s '
+            .'documented environment variable/config, or override it to info or higher in a service provider '
+            ."boot() (e.g. config(['logging.channels.{$channel}.level' => 'info'])). Debug logging causes "
+            .'performance degradation, excessive log volume, and can expose sensitive data.';
     }
 }

--- a/tests/Unit/Analyzers/Performance/DebugLogAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/DebugLogAnalyzerTest.php
@@ -15,6 +15,9 @@ use ShieldCI\Tests\AnalyzerTestCase;
 
 class DebugLogAnalyzerTest extends AnalyzerTestCase
 {
+    /** @var array<int, string> */
+    private array $tempDirs = [];
+
     /**
      * @param  array<string, mixed>  $configValues
      */
@@ -723,8 +726,177 @@ class DebugLogAnalyzerTest extends AnalyzerTestCase
         $this->assertPassed($result);
     }
 
+    /**
+     * Build an analyzer whose base path points at a temp directory, optionally seeded with a
+     * config/logging.php fixture so the authored-vs-injected detection resolves deterministically.
+     *
+     * @param  array<string, mixed>  $configValues
+     */
+    private function createAnalyzerWithLoggingFixture(array $configValues, ?string $loggingContents): AnalyzerInterface
+    {
+        $dir = sys_get_temp_dir().'/shieldci_debuglog_'.uniqid();
+        mkdir($dir.'/config', 0777, true);
+        $this->tempDirs[] = $dir;
+
+        if ($loggingContents !== null) {
+            file_put_contents($dir.'/config/logging.php', $loggingContents);
+        }
+
+        /** @var ConfigRepository&MockInterface $config */
+        $config = Mockery::mock(ConfigRepository::class);
+        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
+        $config->shouldReceive('get')
+            ->andReturnUsing(function ($key, $default = null) use ($configValues) {
+                return $configValues[$key] ?? $default;
+            });
+
+        return new class($config, $dir) extends DebugLogAnalyzer
+        {
+            public function __construct(ConfigRepository $config, private string $testBasePath)
+            {
+                parent::__construct($config);
+            }
+
+            protected function getBasePath(): string
+            {
+                return $this->testBasePath;
+            }
+        };
+    }
+
+    private function authoredLoggingFixture(): string
+    {
+        return <<<'PHP'
+            <?php
+
+            return [
+                'default' => env('LOG_CHANNEL', 'stack'),
+                'channels' => [
+                    'stack' => [
+                        'driver' => 'stack',
+                        'channels' => ['single'],
+                    ],
+                    'single' => [
+                        'driver' => 'single',
+                        'level' => env('LOG_LEVEL', 'debug'),
+                    ],
+                ],
+            ];
+            PHP;
+    }
+
+    public function test_injected_channel_at_debug_drops_location_and_names_real_lever(): void
+    {
+        $analyzer = $this->createAnalyzerWithLoggingFixture([
+            'app.env' => 'production',
+            'logging.default' => 'stack',
+            'logging.channels.stack.channels' => ['laravel-cloud-socket'],
+            'logging.channels.laravel-cloud-socket.level' => 'debug',
+        ], $this->authoredLoggingFixture());
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertNotEmpty($issues);
+
+        $issue = $issues[0];
+        $this->assertStringContainsString('laravel-cloud-socket', $issue->message);
+        // No bogus config/logging.php location for a channel that isn't in the file.
+        $this->assertNull($issue->location?->line);
+        $this->assertNull($issue->codeSnippet);
+        $this->assertTrue($issue->metadata['injected'] ?? false);
+        $this->assertEquals('runtime_injected', $issue->metadata['detection_method'] ?? '');
+        $this->assertStringContainsString('LOG_LEVEL', $issue->recommendation);
+        $this->assertStringContainsString('boot()', $issue->recommendation);
+    }
+
+    public function test_authored_channel_at_debug_keeps_location_and_original_recommendation(): void
+    {
+        $analyzer = $this->createAnalyzerWithLoggingFixture([
+            'app.env' => 'production',
+            'logging.default' => 'single',
+            'logging.channels.single.level' => 'debug',
+        ], $this->authoredLoggingFixture());
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertNotEmpty($issues);
+
+        $issue = $issues[0];
+        $this->assertEquals('single', $issue->metadata['channel'] ?? '');
+        $this->assertFalse($issue->metadata['injected'] ?? true);
+        $this->assertEquals('config_repository', $issue->metadata['detection_method'] ?? '');
+        // 'level' for the 'single' channel is on line 12 of the fixture.
+        $this->assertSame(12, $issue->location?->line);
+        $this->assertStringContainsString('LOG_LEVEL environment variable', $issue->recommendation);
+    }
+
+    public function test_nightwatch_injected_at_debug_names_nightwatch_lever(): void
+    {
+        $analyzer = $this->createAnalyzerWithLoggingFixture([
+            'app.env' => 'production',
+            'logging.default' => 'stack',
+            'logging.channels.stack.channels' => ['nightwatch'],
+            'logging.channels.nightwatch.level' => 'debug',
+        ], $this->authoredLoggingFixture());
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertNotEmpty($issues);
+
+        $issue = $issues[0];
+        $this->assertTrue($issue->metadata['injected'] ?? false);
+        $this->assertStringContainsString('NIGHTWATCH_LOG_LEVEL', $issue->recommendation);
+    }
+
+    public function test_injected_channel_at_info_passes(): void
+    {
+        $analyzer = $this->createAnalyzerWithLoggingFixture([
+            'app.env' => 'production',
+            'logging.default' => 'stack',
+            'logging.channels.stack.channels' => ['laravel-cloud-socket'],
+            'logging.channels.laravel-cloud-socket.level' => 'info',
+        ], $this->authoredLoggingFixture());
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_unparseable_config_falls_back_to_legacy_behaviour(): void
+    {
+        // No logging.php on disk → parseConfigArray() returns [] → cannot tell authored from
+        // injected → fall back to the legacy (authored) path rather than mislabel.
+        $analyzer = $this->createAnalyzerWithLoggingFixture([
+            'app.env' => 'production',
+            'logging.default' => 'single',
+            'logging.channels.single.level' => 'debug',
+        ], null);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertNotEmpty($issues);
+
+        $issue = $issues[0];
+        $this->assertFalse($issue->metadata['injected'] ?? true);
+        $this->assertEquals('config_repository', $issue->metadata['detection_method'] ?? '');
+        $this->assertStringContainsString('LOG_LEVEL environment variable', $issue->recommendation);
+    }
+
     protected function tearDown(): void
     {
+        foreach ($this->tempDirs as $dir) {
+            $this->removeDirectory($dir);
+        }
+        $this->tempDirs = [];
+
         Mockery::close();
         parent::tearDown();
     }


### PR DESCRIPTION
## What

`DebugLogAnalyzer` reported a bogus `config/logging.php` location and an "edit config/logging.php" recommendation for log channels **injected at runtime** (e.g. `laravel-cloud-socket`, `nightwatch`). Those channels aren't authored in that file and can't be fixed there — for `laravel-cloud-socket`, editing `config/logging.php` has no effect at all.

## Change

- Detect non-authored channels via `ConfigFileHelper::findNestedArrayKeyLine` (analyzers-core v1.6.0).
- Injected channel → drop the file location and emit guidance naming the real lever (platform env var / service provider `boot()`), via a per-channel map with a generic fallback.
- Authored channels unchanged; unreadable/unparseable config falls back to the legacy behaviour.
- The finding itself is unchanged — still fires, same severity. This is a location/messaging fix, not a suppression.

5 fixture-based tests added (injected / authored / nightwatch / info / unparseable). Full suite green, PHPStan level 9 clean.