### PR TITLE
fix: guard mass-assignment AST walkers against null nodes and first-class callables

### DIFF
--- a/src/Analyzers/Security/MassAssignmentAnalyzer.php
+++ b/src/Analyzers/Security/MassAssignmentAnalyzer.php
@@ -511,6 +511,12 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
 
         $traverse = function (array $nodes) use (&$traverse, &$calls, $methodName): void {
             foreach ($nodes as $node) {
+                // Sub-node arrays can hold null slots (e.g. skipped destructuring
+                // targets: [, , $x] = ...), which must not reach getSubNodeNames().
+                if (! $node instanceof Node) {
+                    continue;
+                }
+
                 if ($node instanceof Node\Expr\StaticCall) {
                     if ($node->name instanceof Node\Identifier && $node->name->toString() === $methodName) {
                         $calls[] = $node;
@@ -703,6 +709,12 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
         }
 
         foreach ($call->args as $arg) {
+            // First-class callable syntax (foo(...)) yields a VariadicPlaceholder
+            // rather than an Arg, which has no ->value to inspect.
+            if (! $arg instanceof Node\Arg) {
+                continue;
+            }
+
             // Recursively check for blacklist filtering first (except)
             if ($this->containsBlacklistRequestData($arg->value)) {
                 $callTypeLabel = match ($callType) {
@@ -1169,6 +1181,10 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
 
                 // Check if any argument contains request data
                 foreach ($call->args as $arg) {
+                    if (! $arg instanceof Node\Arg) {
+                        continue;
+                    }
+
                     if ($this->containsRequestData($arg->value)) {
                         $issues[] = $this->createIssueWithSnippet(
                             message: "Relationship {$method}() with unfiltered request data",
@@ -1210,6 +1226,12 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
                 }
 
                 if (empty($call->args)) {
+                    continue;
+                }
+
+                // First-class callable syntax (foo(...)) puts a VariadicPlaceholder
+                // here instead of an Arg, which has no ->value.
+                if (! $call->args[0] instanceof Node\Arg) {
                     continue;
                 }
 

--- a/tests/Unit/Analyzers/Security/MassAssignmentAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/MassAssignmentAnalyzerTest.php
@@ -3201,4 +3201,64 @@ PHP;
         );
         $this->assertNotEmpty($hiddenIssues, 'Sensitive field in #[Fillable] without $hidden should warn');
     }
+
+    public function test_does_not_crash_on_skipped_destructuring_and_first_class_callables(): void
+    {
+        // Two AST shapes used to crash the analyzer's walkers:
+        //  - skipped destructuring slots ([, , $x] = ...) produce a List_ with null
+        //    items, which reached getSubNodeNames() on null.
+        //  - first-class callables (Thing::create(...)) put a VariadicPlaceholder where
+        //    an Arg is expected, so $arg->value fed null into a Node-typed parameter.
+        // Neither pattern is a vulnerability, so analysis must complete (not error).
+        $controller = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Thing;
+
+class ThingController
+{
+    public function store()
+    {
+        [, , $next] = $this->steps();
+
+        $factory = Thing::create(...);
+
+        return $next;
+    }
+
+    private function steps(): array
+    {
+        return ['a', 'b', 'c'];
+    }
+}
+PHP;
+
+        $model = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Thing extends Model
+{
+    protected $fillable = ['name'];
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/Thing.php' => $model,
+            'app/Http/Controllers/ThingController.php' => $controller,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        // Before the fix this returned Status::Error with a getSubNodeNames()/TypeError
+        // message; the guarded walkers now let analysis finish cleanly.
+        $this->assertPassed($analyzer->analyze());
+    }
 }


### PR DESCRIPTION
`MassAssignmentAnalyzer` crashed with `Call to a member function getSubNodeNames() on null`, which `analyze()` turned into an error result that wiped out all of its findings.

**Root cause:** skipped destructuring slots — `[, , $x] = ...` — parse to a `Node\Expr\List_` whose `items` array contains literal `null`s. The `findStaticMethodCalls` walker recursed into that array and called `getSubNodeNames()` on a null element.

**Also fixed:** first-class callables on dangerous methods (`Model::create(...)`) put a `VariadicPlaceholder` where an `Arg` was assumed, so `$arg->value` fed null into `containsRequestData(Node)` → `TypeError`.

Adds a null guard to the walker (matching the existing pattern in `LoginThrottlingAnalyzer`) and skips non-`Arg` args in the three `->value` sites. Audited all 14 walker call sites — this was the only unguarded one. Verified the fix clears 0→1 crashes across the project that surfaced the bug.