### PR TITLE
fix: stop flagging missing password rehash on Laravel 11+

### DIFF
--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -15,6 +15,7 @@ use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\DetectsLaravelVersion;
 
 /**
  * Validates password security: hashing configuration AND password policies.
@@ -36,6 +37,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
 {
+    use DetectsLaravelVersion;
+
     /**
      * Hashing configuration is environment-specific, not applicable in CI.
      */
@@ -1845,7 +1848,13 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
             }
         }
 
-        if ($rehashOnLogin === true) {
+        // On Laravel 11+, rehash_on_login defaults to true and Auth::attempt() rehashes the
+        // stored password automatically via EloquentUserProvider::rehashPasswordIfRequired().
+        // So an unset/unpublished config (null) means rehashing is already active there.
+        $rehashEffectivelyEnabled = $rehashOnLogin === true
+            || ($rehashOnLogin === null && $this->isLaravel11OrNewer());
+
+        if ($rehashEffectivelyEnabled) {
             return;
         }
 
@@ -1921,7 +1930,7 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
                     $this->getRelativePath($loginFlowFile)
                 ),
                 severity: Severity::Medium,
-                recommendation: 'Check whether the stored password hash needs rehashing after a successful authentication and update it if so. On Laravel 11 or higher, this can be enabled automatically via the rehash_on_login option in config/hashing.php.',
+                recommendation: 'Check whether the stored password hash needs rehashing after a successful authentication and update it if so.',
                 metadata: ['issue_type' => 'missing_password_rehash']
             );
         }

--- a/tests/Unit/Analyzers/Security/PasswordSecurityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/PasswordSecurityAnalyzerTest.php
@@ -3120,7 +3120,52 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertHasIssueContaining('never rehashes passwords', $result);
+        // On Laravel 11+, rehash_on_login defaults to true and Auth::attempt() rehashes
+        // automatically, so an unset config should not be flagged. On Laravel 9/10 there is
+        // no auto-rehash, so the missing-rehash issue remains legitimate.
+        if (version_compare(app()->version(), '11.0.0', '>=')) {
+            $this->assertNoRehashIssue($result);
+        } else {
+            $this->assertHasIssueContaining('never rehashes passwords', $result);
+        }
+    }
+
+    public function test_no_missing_rehash_when_hashing_config_unpublished_on_laravel_11(): void
+    {
+        if (version_compare(app()->version(), '11.0.0', '<')) {
+            $this->markTestSkipped('Running on Laravel '.app()->version().' — rehash-on-login is not automatic before Laravel 11.');
+        }
+
+        // Reproduces the real-world false positive: a Laravel 11+ app with an Auth::attempt()
+        // login flow and no published config/hashing.php. rehash_on_login defaults to true, so
+        // Auth::attempt() rehashes automatically and the analyzer must not flag it.
+        $loginController = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Auth;
+
+class LoginController
+{
+    public function login($request)
+    {
+        Auth::attempt($request->only('email', 'password'));
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/LoginController.php' => $loginController,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertNoRehashIssue($result);
     }
 
     public function test_passes_when_hash_needs_rehash_is_present(): void
@@ -3313,7 +3358,11 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertHasIssueContaining('never rehashes passwords', $result);
+        if (version_compare(app()->version(), '11.0.0', '>=')) {
+            $this->assertNoRehashIssue($result);
+        } else {
+            $this->assertHasIssueContaining('never rehashes passwords', $result);
+        }
     }
 
     public function test_no_rehash_issue_when_only_auth_login(): void
@@ -3477,7 +3526,11 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertHasIssueContaining('never rehashes passwords', $result);
+        if (version_compare(app()->version(), '11.0.0', '>=')) {
+            $this->assertNoRehashIssue($result);
+        } else {
+            $this->assertHasIssueContaining('never rehashes passwords', $result);
+        }
     }
 
     public function test_no_rehash_issue_when_auth_login_with_hash_needs_rehash(): void
@@ -3620,7 +3673,13 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertHasIssueContaining('never rehashes passwords', $result);
+        // $cache->needsRehash() is not a recognized hasher, so on Laravel 9/10 the missing-rehash
+        // issue is still flagged. On Laravel 11+, the unset config is treated as default-enabled.
+        if (version_compare(app()->version(), '11.0.0', '>=')) {
+            $this->assertNoRehashIssue($result);
+        } else {
+            $this->assertHasIssueContaining('never rehashes passwords', $result);
+        }
     }
 
     // ==================== Validated Array Password Detection (Bug 1 Verification) ====================
@@ -4641,7 +4700,13 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertHasIssueContaining('never rehashes passwords', $result);
+        // $hashmap is not a recognized hasher name, so on Laravel 9/10 the missing-rehash issue
+        // is still flagged. On Laravel 11+, the unset config is treated as default-enabled.
+        if (version_compare(app()->version(), '11.0.0', '>=')) {
+            $this->assertNoRehashIssue($result);
+        } else {
+            $this->assertHasIssueContaining('never rehashes passwords', $result);
+        }
     }
 
     public function test_hasher_variable_needs_rehash_is_valid(): void


### PR DESCRIPTION
## Problem

`PasswordSecurityAnalyzer` flagged `LoginRequest.php` with `missing_password_rehash` ("Login flow detected but never rehashes passwords when hash parameters change") on a Laravel 13.17.0 app using the standard `Auth::attempt()` login path.

This is a false positive on Laravel 11+. `Auth::attempt()` automatically rehashes the stored password on successful login via `EloquentUserProvider::rehashPasswordIfRequired()`, governed by `config('hashing.rehash_on_login')`, which **defaults to `true`**. Since `config/hashing.php` is usually unpublished, the analyzer read the config as absent (`null`) and wrongly assumed rehashing was off.

## Fix

- Reuse the existing `DetectsLaravelVersion` trait (`isLaravel11OrNewer()`).
- Treat an unset/unpublished `rehash_on_login` as default-enabled on Laravel 11+, so no issue is flagged. Unchanged elsewhere:
  - explicit `rehash_on_login = false` → still flags `rehash_on_login_disabled` (all versions)
  - unset config on Laravel 9/10 → still flags `missing_password_rehash` (no auto-rehash there)
- Dropped the now-unreachable "On Laravel 11 or higher…" note from the recommendation.

Tests made version-aware (assert no issue on 11+, still flagged on 9/10), plus a new test reproducing the unpublished-config scenario.

## Verification

- PHPStan level 9: 0 errors
- Full suite: 4190 passed, 0 failures
- End-to-end on the affected app (Laravel 13.17.0): analyzer now passes, no false positive