### PR TITLE
fix(chunk-missing): exempt seeded reference catalogues from chunking hint

### DIFF
--- a/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
+++ b/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\BestPractices;
 
+use Illuminate\Support\Str;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
@@ -13,7 +14,10 @@ use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Support\ModelTableResolver;
+use ShieldCI\Support\SeededTableScanner;
 
 /**
  * Detects large dataset queries without chunking.
@@ -42,6 +46,13 @@ class ChunkMissingAnalyzer extends AbstractFileAnalyzer
         $issues = [];
         $phpFiles = $this->getPhpFiles();
 
+        // Tiny seeded reference-catalogue tables (plans, pillars, …) are bounded by
+        // construction, so looping over them is not a chunking problem. Scan once; the
+        // set is empty when there is no database/seeders/ directory.
+        $astParser = new AstParser;
+        $catalogueTables = (new SeededTableScanner($astParser))->catalogueTables($this->getBasePath()) ?? [];
+        $tableResolver = new ModelTableResolver($astParser);
+
         foreach ($phpFiles as $file) {
             try {
                 $ast = $this->parser->parseFile($file);
@@ -49,7 +60,7 @@ class ChunkMissingAnalyzer extends AbstractFileAnalyzer
                     continue;
                 }
 
-                $visitor = new ChunkMissingVisitor;
+                $visitor = new ChunkMissingVisitor($catalogueTables, $tableResolver, $this->getBasePath());
                 $traverser = new NodeTraverser;
                 $traverser->addVisitor($visitor);
                 $traverser->traverse($ast);
@@ -90,6 +101,15 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
     /** @var array<string, Node\Expr> Track variable assignments */
     private array $variableAssignments = [];
 
+    /**
+     * @param  array<int, string>  $catalogueTables  Seeded reference tables exempt from the hint
+     */
+    public function __construct(
+        private array $catalogueTables = [],
+        private ?ModelTableResolver $tableResolver = null,
+        private string $basePath = '',
+    ) {}
+
     public function enterNode(Node $node): ?Node
     {
         // Reset variable tracking when entering a new function scope
@@ -117,7 +137,7 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
             $loopIterator = $node->expr;
 
             // Check if iterator is a direct ->all() or ->get() call
-            if ($this->isFetchCollectionCall($loopIterator)) {
+            if ($this->isFetchCollectionCall($loopIterator) && ! $this->isSeededCatalogueChain($loopIterator)) {
                 $this->issues[] = [
                     'message' => 'Looping over ->all() or ->get() without chunk() can cause memory issues on large datasets',
                     'line' => $node->getLine(),
@@ -128,7 +148,8 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
             }
             // Check if iterator is a variable that was assigned with ->all() or ->get()
             elseif ($loopIterator instanceof Node\Expr\Variable && is_string($loopIterator->name)) {
-                if (isset($this->variableAssignments[$loopIterator->name])) {
+                if (isset($this->variableAssignments[$loopIterator->name])
+                    && ! $this->isSeededCatalogueChain($this->variableAssignments[$loopIterator->name])) {
                     $this->issues[] = [
                         'message' => 'Looping over a variable assigned with ->all() or ->get() can cause memory issues on large datasets',
                         'line' => $node->getLine(),
@@ -275,6 +296,63 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
         }
 
         return $current instanceof Node\Expr\StaticCall;
+    }
+
+    /**
+     * Return true when the chain reads from a tiny seeded reference-catalogue table —
+     * bounded by construction, so iterating it is not a chunking problem.
+     */
+    private function isSeededCatalogueChain(Node\Expr $expr): bool
+    {
+        if ($this->catalogueTables === [] || $this->tableResolver === null) {
+            return false;
+        }
+
+        $table = $this->resolveChainRootTable($expr);
+
+        return $table !== null && in_array($table, $this->catalogueTables, true);
+    }
+
+    /**
+     * Resolve the table a query chain targets from its StaticCall root, or null when it
+     * cannot be determined statically. DB::table('x') → 'x'; Model::… → the model's
+     * explicit `protected $table` override else the conventional Eloquent table name.
+     */
+    private function resolveChainRootTable(Node\Expr $expr): ?string
+    {
+        $current = $expr;
+        while ($current instanceof Node\Expr\MethodCall) {
+            $current = $current->var;
+        }
+
+        if (! $current instanceof Node\Expr\StaticCall || ! $current->class instanceof Node\Name) {
+            return null;
+        }
+
+        $class = $current->class->getLast();
+
+        if ($class === 'DB') {
+            return $current->name instanceof Node\Identifier && $current->name->toString() === 'table'
+                ? $this->firstStringArg($current)
+                : null;
+        }
+
+        return $this->tableResolver?->tableFor($this->basePath, $class)
+            ?? Str::snake(Str::pluralStudly($class));
+    }
+
+    /**
+     * Return the string value of a call's first argument, or null when it is not a string literal.
+     */
+    private function firstStringArg(Node\Expr\StaticCall $call): ?string
+    {
+        if (! isset($call->args[0]) || ! $call->args[0] instanceof Node\Arg) {
+            return null;
+        }
+
+        $value = $call->args[0]->value;
+
+        return $value instanceof Node\Scalar\String_ ? $value->value : null;
     }
 
     private function getMethodChain(Node\Expr $expr): array

--- a/src/Support/ModelTableResolver.php
+++ b/src/Support/ModelTableResolver.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+use PhpParser\Node;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ShieldCI\AnalyzersCore\Support\AstParser;
+use SplFileInfo;
+
+/**
+ * Resolves the database table behind an Eloquent model class by reading explicit
+ * `protected $table = '...'` overrides from app/Models.
+ *
+ * The conventional Eloquent name (Str::snake(Str::pluralStudly($class))) is wrong
+ * whenever a model sets $table by hand — e.g. GitHubInstallation lives in
+ * github_installations, not git_hub_installations. Callers consult this resolver
+ * before falling back to the naming convention so per-table index reasoning attributes
+ * queries to the right table.
+ *
+ * Keyed by short class name. Two models sharing a short name in different namespaces
+ * are ambiguous (last-wins); that is acceptable for the FP-reduction this serves.
+ */
+final class ModelTableResolver
+{
+    /**
+     * Per-basePath cache of short class name => explicit table name.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private array $cache = [];
+
+    public function __construct(private readonly AstParser $parser) {}
+
+    /**
+     * The explicit `protected $table` for $shortClassName, or null when the model
+     * declares no override (caller keeps the conventional table name).
+     */
+    public function tableFor(string $basePath, string $shortClassName): ?string
+    {
+        return $this->scan($basePath)[$shortClassName] ?? null;
+    }
+
+    /**
+     * Scan (and cache) app/Models under $basePath for explicit $table overrides.
+     *
+     * @return array<string, string>
+     */
+    private function scan(string $basePath): array
+    {
+        if (array_key_exists($basePath, $this->cache)) {
+            return $this->cache[$basePath];
+        }
+
+        $modelsPath = rtrim($basePath, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'Models';
+
+        if (! is_dir($modelsPath)) {
+            return $this->cache[$basePath] = [];
+        }
+
+        /** @var array<string, string> $map */
+        $map = [];
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($modelsPath, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (! $file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $ast = $this->parser->parseFile($file->getPathname());
+            if ($ast === []) {
+                continue;
+            }
+
+            foreach ($this->parser->findClasses($ast) as $class) {
+                if ($class->name === null) {
+                    continue;
+                }
+
+                $table = $this->extractTableOverride($class);
+                if ($table !== null) {
+                    $map[$class->name->toString()] = $table;
+                }
+            }
+        }
+
+        return $this->cache[$basePath] = $map;
+    }
+
+    /**
+     * Return the string value of a class's `protected $table = '...'` property, or
+     * null when the class declares no such literal override.
+     */
+    private function extractTableOverride(Node\Stmt\Class_ $class): ?string
+    {
+        foreach ($class->stmts as $stmt) {
+            if (! $stmt instanceof Node\Stmt\Property) {
+                continue;
+            }
+
+            foreach ($stmt->props as $prop) {
+                if ($prop->name->toString() === 'table' && $prop->default instanceof Node\Scalar\String_) {
+                    return $prop->default->value;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Support/SeededTableScanner.php
+++ b/src/Support/SeededTableScanner.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+use Illuminate\Support\Str;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\NodeFinder;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ShieldCI\AnalyzersCore\Support\AstParser;
+use SplFileInfo;
+
+/**
+ * Scans database/seeders/ to identify "reference catalogue" tables — small, fixed lookup
+ * tables populated by literal seeding (plans, pillars, business_stages …) that never grow
+ * with real usage. A full scan of such a table beats an index, so per-column index hints
+ * on them are noise.
+ *
+ * A table qualifies as a catalogue when it is written by literal seeding and never via a
+ * factory:
+ * - literal: DB::table('x')->insert(...), or Model::create()/updateOrCreate()/
+ *   firstOrCreate()/insert()/forceCreate() resolved to its table.
+ * - factory usage (Model::factory()->create()) disqualifies the table — factories generate
+ *   volume, the opposite of a fixed catalogue.
+ *
+ * Returns null when database/seeders/ does not exist, so callers skip the catalogue check
+ * rather than treat "no seeders" as "no catalogues."
+ *
+ * Tradeoff (accepted): a seeded-but-growing table could lose a legitimate low-severity
+ * index hint. Given the Low severity and the false-positive volume these catalogues
+ * generate, that is the right trade.
+ */
+final class SeededTableScanner
+{
+    /**
+     * Eloquent persistence methods that write literal catalogue rows.
+     *
+     * @var array<int, string>
+     */
+    private const LITERAL_WRITE_METHODS = [
+        'create', 'updateOrCreate', 'firstOrCreate', 'insert', 'forceCreate',
+    ];
+
+    /**
+     * Query-builder write terminals used against DB::table('x') in seeders.
+     *
+     * @var array<int, string>
+     */
+    private const BUILDER_WRITE_METHODS = [
+        'insert', 'insertOrIgnore', 'updateOrInsert', 'upsert',
+    ];
+
+    private readonly NodeFinder $nodeFinder;
+
+    private readonly ModelTableResolver $modelTableResolver;
+
+    /**
+     * Per-basePath cache of catalogue table names (null when no seeders directory).
+     *
+     * @var array<string, array<int, string>|null>
+     */
+    private array $cache = [];
+
+    public function __construct(private readonly AstParser $parser)
+    {
+        $this->nodeFinder = new NodeFinder;
+        $this->modelTableResolver = new ModelTableResolver($parser);
+    }
+
+    /**
+     * Tables populated only by literal seeding (catalogues), or null when there is no
+     * database/seeders/ directory.
+     *
+     * @return array<int, string>|null
+     */
+    public function catalogueTables(string $basePath): ?array
+    {
+        return $this->scan($basePath);
+    }
+
+    /**
+     * Scan (and cache) database/seeders/ for catalogue tables.
+     *
+     * @return array<int, string>|null
+     */
+    private function scan(string $basePath): ?array
+    {
+        if (array_key_exists($basePath, $this->cache)) {
+            return $this->cache[$basePath];
+        }
+
+        $seedersPath = rtrim($basePath, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'database'.DIRECTORY_SEPARATOR.'seeders';
+
+        if (! is_dir($seedersPath)) {
+            return $this->cache[$basePath] = null;
+        }
+
+        /** @var array<string, true> $literal */
+        $literal = [];
+        /** @var array<string, true> $factory */
+        $factory = [];
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($seedersPath, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (! $file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $ast = $this->parser->parseFile($file->getPathname());
+            if ($ast === []) {
+                continue;
+            }
+
+            $this->collectLiteralModelWrites($ast, $basePath, $literal);
+            $this->collectBuilderWrites($ast, $literal);
+            $this->collectFactoryUses($ast, $basePath, $factory);
+        }
+
+        // array_keys can narrow numeric-looking table names to int; normalise to string.
+        $catalogue = array_values(array_map(
+            'strval',
+            array_diff(array_keys($literal), array_keys($factory))
+        ));
+
+        return $this->cache[$basePath] = $catalogue;
+    }
+
+    /**
+     * Record tables written via Model::create()/updateOrCreate()/firstOrCreate()/insert().
+     *
+     * @param  array<Node>  $ast
+     * @param  array<string, true>  $literal
+     */
+    private function collectLiteralModelWrites(array $ast, string $basePath, array &$literal): void
+    {
+        /** @var array<int, StaticCall> $staticCalls */
+        $staticCalls = $this->nodeFinder->findInstanceOf($ast, StaticCall::class);
+
+        foreach ($staticCalls as $call) {
+            if (! $call->name instanceof Identifier
+                || ! in_array($call->name->name, self::LITERAL_WRITE_METHODS, true)
+                || ! $call->class instanceof Node\Name
+            ) {
+                continue;
+            }
+
+            $table = $this->tableForModel($basePath, $call->class->getLast());
+            $literal[$table] = true;
+        }
+    }
+
+    /**
+     * Record tables written via DB::table('x')->insert()/upsert()/updateOrInsert().
+     *
+     * @param  array<Node>  $ast
+     * @param  array<string, true>  $literal
+     */
+    private function collectBuilderWrites(array $ast, array &$literal): void
+    {
+        /** @var array<int, MethodCall> $methodCalls */
+        $methodCalls = $this->nodeFinder->findInstanceOf($ast, MethodCall::class);
+
+        foreach ($methodCalls as $call) {
+            if (! $call->name instanceof Identifier
+                || ! in_array($call->name->name, self::BUILDER_WRITE_METHODS, true)
+            ) {
+                continue;
+            }
+
+            $table = $this->dbTableLiteral($call->var);
+            if ($table !== null) {
+                $literal[$table] = true;
+            }
+        }
+    }
+
+    /**
+     * Record tables seeded via Model::factory(), which disqualifies them as catalogues.
+     *
+     * @param  array<Node>  $ast
+     * @param  array<string, true>  $factory
+     */
+    private function collectFactoryUses(array $ast, string $basePath, array &$factory): void
+    {
+        /** @var array<int, StaticCall> $staticCalls */
+        $staticCalls = $this->nodeFinder->findInstanceOf($ast, StaticCall::class);
+
+        foreach ($staticCalls as $call) {
+            if (! $call->name instanceof Identifier
+                || $call->name->name !== 'factory'
+                || ! $call->class instanceof Node\Name
+            ) {
+                continue;
+            }
+
+            $table = $this->tableForModel($basePath, $call->class->getLast());
+            $factory[$table] = true;
+        }
+    }
+
+    /**
+     * Walk a method-call chain to a DB::table('x') root and return 'x', or null.
+     */
+    private function dbTableLiteral(Node $node): ?string
+    {
+        $current = $node;
+        while ($current instanceof MethodCall) {
+            $current = $current->var;
+        }
+
+        if ($current instanceof StaticCall
+            && $current->class instanceof Node\Name
+            && $current->class->getLast() === 'DB'
+            && $current->name instanceof Identifier
+            && $current->name->name === 'table'
+            && count($current->args) >= 1
+            && $current->args[0] instanceof Node\Arg
+            && $current->args[0]->value instanceof Node\Scalar\String_
+        ) {
+            return $current->args[0]->value->value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve a model short name to its table — explicit $table override else convention.
+     */
+    private function tableForModel(string $basePath, string $shortClass): string
+    {
+        return $this->modelTableResolver->tableFor($basePath, $shortClass)
+            ?? Str::snake(Str::pluralStudly($shortClass));
+    }
+}

--- a/tests/Unit/Analyzers/BestPractices/ChunkMissingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ChunkMissingAnalyzerTest.php
@@ -1037,4 +1037,162 @@ PHP;
 
         $this->assertStringContainsString('2 queries', $result2->getMessage());
     }
+
+    public function test_passes_when_looping_over_seeded_catalogue_table(): void
+    {
+        // Pillar is a fixed seeded reference catalogue (literal seeding, no factory), so
+        // iterating Pillar::...->get() is bounded by construction — not a chunking problem.
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Pillar;
+
+class PillarSeeder
+{
+    public function run(): void
+    {
+        Pillar::create(['slug' => 'governance']);
+        Pillar::create(['slug' => 'risk']);
+    }
+}
+PHP;
+
+        $service = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Pillar;
+
+class AssessmentService
+{
+    public function codes(): void
+    {
+        foreach (Pillar::with('questions')->orderBy('display_order')->get() as $pillar) {
+            // map each pillar's questions
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'Services/AssessmentService.php' => $service,
+            'database/seeders/PillarSeeder.php' => $seeder,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_flags_non_catalogue_table_even_when_a_catalogue_exists(): void
+    {
+        // Pillar is a seeded catalogue, but the loop reads users (not seeded). The guard is
+        // table-specific, so the unbounded users loop is still flagged.
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Pillar;
+
+class PillarSeeder
+{
+    public function run(): void
+    {
+        Pillar::create(['slug' => 'governance']);
+    }
+}
+PHP;
+
+        $service = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+class UserService
+{
+    public function process(): void
+    {
+        foreach (User::where('active', true)->get() as $user) {
+            // process user
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'Services/UserService.php' => $service,
+            'database/seeders/PillarSeeder.php' => $seeder,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('get()', $result);
+    }
+
+    public function test_flags_factory_seeded_table_loop(): void
+    {
+        // A table seeded via factory grows with volume — not a fixed catalogue, still flagged.
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+
+class UserSeeder
+{
+    public function run(): void
+    {
+        User::factory()->count(50)->create();
+    }
+}
+PHP;
+
+        $service = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+class UserService
+{
+    public function process(): void
+    {
+        foreach (User::where('active', true)->get() as $user) {
+            // process user
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'Services/UserService.php' => $service,
+            'database/seeders/UserSeeder.php' => $seeder,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('get()', $result);
+    }
 }

--- a/tests/Unit/Support/ModelTableResolverTest.php
+++ b/tests/Unit/Support/ModelTableResolverTest.php
@@ -72,4 +72,91 @@ PHP;
         // No override declared → caller falls back to the naming convention.
         $this->assertNull($this->resolver()->tableFor($basePath, 'User'));
     }
+
+    public function test_skips_non_php_files_in_models_directory(): void
+    {
+        $model = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Widget extends Model
+{
+    protected $table = 'widgets_custom';
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'app/Models/Widget.php' => $model,
+            'app/Models/notes.txt' => 'not php',
+        ]);
+
+        // The .txt file is skipped; the real model override still resolves.
+        $this->assertSame('widgets_custom', $this->resolver()->tableFor($basePath, 'Widget'));
+    }
+
+    public function test_skips_files_with_empty_ast(): void
+    {
+        $basePath = $this->createTempDirectory([
+            'app/Models/Empty.php' => '<?php',
+        ]);
+
+        // A file that parses to an empty AST registers no override.
+        $this->assertNull($this->resolver()->tableFor($basePath, 'Empty'));
+    }
+
+    public function test_skips_anonymous_classes(): void
+    {
+        $model = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+return new class extends Model
+{
+    protected $table = 'anon';
+};
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'app/Models/Anon.php' => $model,
+        ]);
+
+        // An anonymous class has no name, so no override is registered under any short name.
+        $this->assertNull($this->resolver()->tableFor($basePath, 'Anon'));
+    }
+
+    public function test_resolves_override_alongside_other_class_members(): void
+    {
+        $model = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Invoice extends Model
+{
+    public const STATUS = 'open';
+
+    public function customer()
+    {
+        return $this->belongsTo(Customer::class);
+    }
+
+    protected $table = 'invoices_custom';
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'app/Models/Invoice.php' => $model,
+        ]);
+
+        // Non-property statements (const, method) are skipped before the $table property.
+        $this->assertSame('invoices_custom', $this->resolver()->tableFor($basePath, 'Invoice'));
+    }
 }

--- a/tests/Unit/Support/ModelTableResolverTest.php
+++ b/tests/Unit/Support/ModelTableResolverTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
+use ShieldCI\AnalyzersCore\Support\AstParser;
+use ShieldCI\Support\ModelTableResolver;
+use ShieldCI\Tests\AnalyzerTestCase;
+
+class ModelTableResolverTest extends AnalyzerTestCase
+{
+    protected function createAnalyzer(): AnalyzerInterface
+    {
+        throw new \LogicException('No analyzer under test.');
+    }
+
+    private function resolver(): ModelTableResolver
+    {
+        return new ModelTableResolver(new AstParser);
+    }
+
+    public function test_returns_null_when_no_models_directory(): void
+    {
+        $basePath = $this->createTempDirectory(['composer.json' => '{}']);
+
+        $this->assertNull($this->resolver()->tableFor($basePath, 'GitHubInstallation'));
+    }
+
+    public function test_resolves_explicit_table_override(): void
+    {
+        // Conventional name would be git_hub_installations; the override wins.
+        $model = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class GitHubInstallation extends Model
+{
+    protected $table = 'github_installations';
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'app/Models/GitHubInstallation.php' => $model,
+        ]);
+
+        $this->assertSame('github_installations', $this->resolver()->tableFor($basePath, 'GitHubInstallation'));
+    }
+
+    public function test_returns_null_for_model_without_table_override(): void
+    {
+        $model = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'app/Models/User.php' => $model,
+        ]);
+
+        // No override declared → caller falls back to the naming convention.
+        $this->assertNull($this->resolver()->tableFor($basePath, 'User'));
+    }
+}

--- a/tests/Unit/Support/SeededTableScannerTest.php
+++ b/tests/Unit/Support/SeededTableScannerTest.php
@@ -188,4 +188,130 @@ PHP;
 
         $this->assertContains('business_stages', $this->scanner()->catalogueTables($basePath) ?? []);
     }
+
+    public function test_caches_catalogue_per_base_path(): void
+    {
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Plan;
+
+class PlanSeeder
+{
+    public function run(): void
+    {
+        Plan::create(['tier' => 'free']);
+    }
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'database/seeders/PlanSeeder.php' => $seeder,
+        ]);
+
+        $scanner = $this->scanner();
+        $first = $scanner->catalogueTables($basePath);
+
+        // A second call for the same base path returns the cached result.
+        $this->assertSame($first, $scanner->catalogueTables($basePath));
+    }
+
+    public function test_skips_non_php_files_in_seeders_directory(): void
+    {
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Plan;
+
+class PlanSeeder
+{
+    public function run(): void
+    {
+        Plan::create(['tier' => 'free']);
+    }
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'database/seeders/PlanSeeder.php' => $seeder,
+            'database/seeders/notes.txt' => 'not php',
+        ]);
+
+        // The .txt file is skipped; the real seeder is still scanned.
+        $this->assertContains('plans', $this->scanner()->catalogueTables($basePath) ?? []);
+    }
+
+    public function test_empty_seeder_file_is_skipped(): void
+    {
+        $basePath = $this->createTempDirectory([
+            'database/seeders/EmptySeeder.php' => '<?php',
+        ]);
+
+        // A file that parses to an empty AST contributes nothing; the directory still
+        // exists, so the result is an empty catalogue rather than null.
+        $this->assertSame([], $this->scanner()->catalogueTables($basePath));
+    }
+
+    public function test_resolves_db_table_through_a_chained_builder_write(): void
+    {
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Support\Facades\DB;
+
+class WidgetSeeder
+{
+    public function run(): void
+    {
+        DB::table('widgets')->where('active', true)->insert([
+            ['name' => 'A'],
+        ]);
+    }
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'database/seeders/WidgetSeeder.php' => $seeder,
+        ]);
+
+        // The DB::table root is reached by walking past the intermediate ->where() call.
+        $this->assertContains('widgets', $this->scanner()->catalogueTables($basePath) ?? []);
+    }
+
+    public function test_builder_write_not_rooted_in_db_table_is_ignored(): void
+    {
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+class CustomSeeder
+{
+    public function run(): void
+    {
+        $builder = $this->builder();
+        $builder->insert([['name' => 'A']]);
+    }
+
+    private function builder()
+    {
+        return null;
+    }
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'database/seeders/CustomSeeder.php' => $seeder,
+        ]);
+
+        // $builder->insert(...) has no statically-resolvable DB::table('x') root, so it
+        // registers no catalogue table.
+        $this->assertSame([], $this->scanner()->catalogueTables($basePath));
+    }
 }

--- a/tests/Unit/Support/SeededTableScannerTest.php
+++ b/tests/Unit/Support/SeededTableScannerTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
+use ShieldCI\AnalyzersCore\Support\AstParser;
+use ShieldCI\Support\SeededTableScanner;
+use ShieldCI\Tests\AnalyzerTestCase;
+
+class SeededTableScannerTest extends AnalyzerTestCase
+{
+    protected function createAnalyzer(): AnalyzerInterface
+    {
+        throw new \LogicException('No analyzer under test.');
+    }
+
+    private function scanner(): SeededTableScanner
+    {
+        return new SeededTableScanner(new AstParser);
+    }
+
+    public function test_returns_null_when_no_seeders_directory(): void
+    {
+        $basePath = $this->createTempDirectory(['composer.json' => '{}']);
+
+        $this->assertNull($this->scanner()->catalogueTables($basePath));
+    }
+
+    public function test_detects_table_seeded_via_model_update_or_create(): void
+    {
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Plan;
+
+class PlanSeeder
+{
+    public function run(): void
+    {
+        Plan::updateOrCreate(['tier' => 'free'], ['amount' => 0]);
+    }
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'database/seeders/PlanSeeder.php' => $seeder,
+        ]);
+
+        $this->assertContains('plans', $this->scanner()->catalogueTables($basePath) ?? []);
+    }
+
+    public function test_detects_table_seeded_via_db_table_insert(): void
+    {
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Support\Facades\DB;
+
+class PillarSeeder
+{
+    public function run(): void
+    {
+        DB::table('pillars')->insert([
+            ['name' => 'Strategy'],
+            ['name' => 'Finance'],
+        ]);
+    }
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'database/seeders/PillarSeeder.php' => $seeder,
+        ]);
+
+        $this->assertContains('pillars', $this->scanner()->catalogueTables($basePath) ?? []);
+    }
+
+    public function test_factory_seeded_table_is_not_a_catalogue(): void
+    {
+        // Factories generate volume, not a fixed catalogue — must not be treated as one.
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+
+class UserSeeder
+{
+    public function run(): void
+    {
+        User::factory()->count(50)->create();
+    }
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'database/seeders/UserSeeder.php' => $seeder,
+        ]);
+
+        $this->assertNotContains('users', $this->scanner()->catalogueTables($basePath) ?? []);
+    }
+
+    public function test_table_seeded_both_literally_and_via_factory_is_excluded(): void
+    {
+        // A table that is also factory-seeded somewhere grows with volume → not a catalogue.
+        $literal = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Tag;
+
+class TagSeeder
+{
+    public function run(): void
+    {
+        Tag::create(['name' => 'urgent']);
+    }
+}
+PHP;
+
+        $factory = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Tag;
+
+class TagVolumeSeeder
+{
+    public function run(): void
+    {
+        Tag::factory()->count(1000)->create();
+    }
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'database/seeders/TagSeeder.php' => $literal,
+            'database/seeders/TagVolumeSeeder.php' => $factory,
+        ]);
+
+        $this->assertNotContains('tags', $this->scanner()->catalogueTables($basePath) ?? []);
+    }
+
+    public function test_respects_explicit_table_override_when_resolving_model(): void
+    {
+        $model = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BusinessStage extends Model
+{
+    protected $table = 'business_stages';
+}
+PHP;
+
+        $seeder = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\BusinessStage;
+
+class BusinessStageSeeder
+{
+    public function run(): void
+    {
+        BusinessStage::firstOrCreate(['name' => 'Seed']);
+    }
+}
+PHP;
+
+        $basePath = $this->createTempDirectory([
+            'app/Models/BusinessStage.php' => $model,
+            'database/seeders/BusinessStageSeeder.php' => $seeder,
+        ]);
+
+        $this->assertContains('business_stages', $this->scanner()->catalogueTables($basePath) ?? []);
+    }
+}


### PR DESCRIPTION
## Problem

`ChunkMissingAnalyzer` (High) flagged `foreach` loops over tiny, seeder-only reference catalogues — e.g. `foreach (Pillar::with('questions')->orderBy('display_order')->get() as $pillar)` where `pillars` is a fixed catalogue populated only by a seeder. Such bounded tables cannot cause the memory blow-up chunking guards against, so the hint is a false positive.

## Fix

Add `SeededTableScanner` + `ModelTableResolver` under `ShieldCI\Support` — shared helpers that identify seeder-only (non-factory) reference tables and resolve a model's table (honouring explicit `$table` overrides). These are Laravel-specific, so they live in this package rather than the framework-agnostic `analyzers-core`.

`ChunkMissingAnalyzer` scans seeders once, resolves each looped query chain's root table, and skips the hint when it targets a catalogue table. The guard is inert when there is no `database/seeders/` directory.

## Tests

- loop over a seeded catalogue table → passes
- catalogue exists but a different table is looped → still flagged (table-specific)
- factory-grown table → still flagged (factories disqualify catalogues)
- unit tests for both new helpers

Pint, PHPStan Level 9, and the full suite (4202 tests) pass.

## Note

`SeededTableScanner`/`ModelTableResolver` are the same helpers currently in the Pro package; a follow-up will remove the Pro copies and re-point its analyzers here once this is released.