### PR TITLE
fix(analyzer-manager): preserve router middleware state across instance resolution

### DIFF
--- a/src/AnalyzerManager.php
+++ b/src/AnalyzerManager.php
@@ -148,8 +148,9 @@ class AnalyzerManager
         // clobbers any runtime override a service provider applied (e.g. Route::aliasMiddleware()).
         // Snapshot the router's middleware maps and restore them afterwards so running the
         // analyzer suite leaves application state untouched.
-        $aliasSnapshot = $this->router?->getMiddleware();
-        $groupSnapshot = $this->router?->getMiddlewareGroups();
+        $router = $this->router;
+        $aliasSnapshot = $router?->getMiddleware();
+        $groupSnapshot = $router?->getMiddlewareGroups();
 
         /** @var Collection<int, AnalyzerInterface> $instances */
         $instances = collect();
@@ -182,8 +183,8 @@ class AnalyzerManager
                 ->filter()
                 ->values();
         } finally {
-            if (is_array($aliasSnapshot) && is_array($groupSnapshot)) {
-                $this->restoreRouterMiddleware($aliasSnapshot, $groupSnapshot);
+            if ($router !== null && is_array($aliasSnapshot) && is_array($groupSnapshot)) {
+                $this->restoreRouterMiddleware($router, $aliasSnapshot, $groupSnapshot);
             }
         }
 
@@ -203,21 +204,17 @@ class AnalyzerManager
      * @param  array<string, mixed>  $aliases
      * @param  array<string, mixed>  $groups
      */
-    private function restoreRouterMiddleware(array $aliases, array $groups): void
+    private function restoreRouterMiddleware(Router $router, array $aliases, array $groups): void
     {
-        if ($this->router === null) {
-            return;
-        }
-
         foreach ($aliases as $name => $class) {
             if (is_string($name) && is_string($class)) {
-                $this->router->aliasMiddleware($name, $class);
+                $router->aliasMiddleware($name, $class);
             }
         }
 
         foreach ($groups as $name => $middleware) {
             if (is_string($name) && is_array($middleware)) {
-                $this->router->middlewareGroup($name, $middleware);
+                $router->middlewareGroup($name, $middleware);
             }
         }
     }

--- a/src/AnalyzerManager.php
+++ b/src/AnalyzerManager.php
@@ -6,6 +6,7 @@ namespace ShieldCI;
 
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
@@ -24,6 +25,7 @@ class AnalyzerManager
         protected Config $config,
         protected array $analyzerClasses,
         protected Container $container,
+        protected ?Router $router = null,
     ) {}
 
     /** @var Collection<int, AnalyzerInterface>|null */
@@ -141,36 +143,83 @@ class AnalyzerManager
 
         $this->initConfigCache();
 
+        // Resolving kernel-injecting analyzers triggers Laravel's afterResolving(HttpKernel)
+        // callback, which re-syncs the framework-default middleware maps onto the router and
+        // clobbers any runtime override a service provider applied (e.g. Route::aliasMiddleware()).
+        // Snapshot the router's middleware maps and restore them afterwards so running the
+        // analyzer suite leaves application state untouched.
+        $aliasSnapshot = $this->router?->getMiddleware();
+        $groupSnapshot = $this->router?->getMiddlewareGroups();
+
         /** @var Collection<int, AnalyzerInterface> $instances */
-        $instances = collect($this->analyzerClasses)
-            ->map(function (string $class): ?AnalyzerInterface {
-                try {
-                    /** @var AnalyzerInterface $analyzer */
-                    $analyzer = $this->container->make($class);
+        $instances = collect();
 
-                    if (method_exists($analyzer, 'setBasePath')) {
-                        $analyzer->setBasePath(base_path());
+        try {
+            /** @var Collection<int, AnalyzerInterface> $instances */
+            $instances = collect($this->analyzerClasses)
+                ->map(function (string $class): ?AnalyzerInterface {
+                    try {
+                        /** @var AnalyzerInterface $analyzer */
+                        $analyzer = $this->container->make($class);
+
+                        if (method_exists($analyzer, 'setBasePath')) {
+                            $analyzer->setBasePath(base_path());
+                        }
+
+                        if (method_exists($analyzer, 'setPaths') && ! empty($this->cachedPathsToAnalyze)) {
+                            $analyzer->setPaths($this->cachedPathsToAnalyze);
+                        }
+
+                        if (method_exists($analyzer, 'setExcludePatterns')) {
+                            $analyzer->setExcludePatterns($this->cachedExcludedPaths);
+                        }
+
+                        return $analyzer;
+                    } catch (\Throwable $e) {
+                        return null;
                     }
-
-                    if (method_exists($analyzer, 'setPaths') && ! empty($this->cachedPathsToAnalyze)) {
-                        $analyzer->setPaths($this->cachedPathsToAnalyze);
-                    }
-
-                    if (method_exists($analyzer, 'setExcludePatterns')) {
-                        $analyzer->setExcludePatterns($this->cachedExcludedPaths);
-                    }
-
-                    return $analyzer;
-                } catch (\Throwable $e) {
-                    return null;
-                }
-            })
-            ->filter()
-            ->values();
+                })
+                ->filter()
+                ->values();
+        } finally {
+            if (is_array($aliasSnapshot) && is_array($groupSnapshot)) {
+                $this->restoreRouterMiddleware($aliasSnapshot, $groupSnapshot);
+            }
+        }
 
         $this->cachedAllInstances = $instances;
 
         return $this->cachedAllInstances;
+    }
+
+    /**
+     * Restore the router's middleware alias and group maps to a prior snapshot,
+     * undoing the re-sync Laravel performs when the HTTP kernel is first resolved.
+     *
+     * Re-applies each snapshot entry via the public router API (overwrite restore);
+     * this faithfully undoes a provider overriding an existing alias/group, which is
+     * the only mutation that occurs in a booted application.
+     *
+     * @param  array<string, mixed>  $aliases
+     * @param  array<string, mixed>  $groups
+     */
+    private function restoreRouterMiddleware(array $aliases, array $groups): void
+    {
+        if ($this->router === null) {
+            return;
+        }
+
+        foreach ($aliases as $name => $class) {
+            if (is_string($name) && is_string($class)) {
+                $this->router->aliasMiddleware($name, $class);
+            }
+        }
+
+        foreach ($groups as $name => $middleware) {
+            if (is_string($name) && is_array($middleware)) {
+                $this->router->middlewareGroup($name, $middleware);
+            }
+        }
     }
 
     /**

--- a/src/ShieldCIServiceProvider.php
+++ b/src/ShieldCIServiceProvider.php
@@ -7,6 +7,7 @@ namespace ShieldCI;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use Psr\Log\LoggerInterface;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
@@ -101,7 +102,8 @@ class ShieldCIServiceProvider extends ServiceProvider
             return new AnalyzerManager(
                 $app->make('config'),
                 $this->discoverAnalyzers(),
-                $app
+                $app,
+                $app->make(Router::class)
             );
         });
     }

--- a/tests/Unit/AnalyzerManagerTest.php
+++ b/tests/Unit/AnalyzerManagerTest.php
@@ -6,6 +6,9 @@ namespace ShieldCI\Tests\Unit;
 
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Illuminate\Routing\Router;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use ShieldCI\AnalyzerManager;
@@ -24,6 +27,60 @@ class AnalyzerManagerTest extends TestCase
     {
         Mockery::close();
         parent::tearDown();
+    }
+
+    #[Test]
+    public function it_restores_router_middleware_clobbered_during_instance_resolution(): void
+    {
+        $app = $this->app;
+        assert($app !== null);
+
+        $router = $app->make(Router::class);
+
+        // The runtime swap a service provider would apply (e.g. gated on Redis).
+        $router->aliasMiddleware('throttle', ThrottleRequestsWithRedis::class);
+
+        $manager = new AnalyzerManager(
+            $app->make(Config::class),
+            [RouterClobberingTestAnalyzer::class],
+            $app,
+            $router,
+        );
+
+        $manager->getAnalyzers();
+
+        $this->assertSame(
+            ThrottleRequestsWithRedis::class,
+            $router->getMiddleware()['throttle'] ?? null,
+            'Resolving analyzers must not leave the throttle alias clobbered.'
+        );
+    }
+
+    #[Test]
+    public function it_leaves_router_middleware_clobbered_when_no_router_is_injected(): void
+    {
+        $app = $this->app;
+        assert($app !== null);
+
+        $router = $app->make(Router::class);
+        $router->aliasMiddleware('throttle', ThrottleRequestsWithRedis::class);
+
+        // No router passed: the manager cannot snapshot/restore, so the clobber persists.
+        // This negative control proves the test exercises a real clobber and that the
+        // restore is what undoes it.
+        $manager = new AnalyzerManager(
+            $app->make(Config::class),
+            [RouterClobberingTestAnalyzer::class],
+            $app,
+        );
+
+        $manager->getAnalyzers();
+
+        $this->assertSame(
+            ThrottleRequests::class,
+            $router->getMiddleware()['throttle'] ?? null,
+            'Without an injected router the clobber is expected to persist (negative control).'
+        );
     }
 
     /** @test */
@@ -954,6 +1011,52 @@ class AnotherTestAnalyzer implements AnalyzerInterface
     public function getId(): string
     {
         return 'another-test-analyzer';
+    }
+}
+
+/**
+ * Simulates a kernel-injecting analyzer: resolving it mutates the router's middleware
+ * alias map the way Laravel's afterResolving(HttpKernel) re-sync does, clobbering a
+ * provider-applied 'throttle' override. The clobber is reproduced deterministically in
+ * the constructor because the real afterResolving fires only on the first kernel
+ * resolution, which is not deterministic under Testbench.
+ */
+class RouterClobberingTestAnalyzer implements AnalyzerInterface
+{
+    public function __construct(Router $router)
+    {
+        $router->aliasMiddleware('throttle', ThrottleRequests::class);
+    }
+
+    public function analyze(): ResultInterface
+    {
+        return AnalysisResult::passed('router-clobbering-test-analyzer', 'Test passed');
+    }
+
+    public function getMetadata(): AnalyzerMetadata
+    {
+        return new AnalyzerMetadata(
+            id: 'router-clobbering-test-analyzer',
+            name: 'Router Clobbering Test Analyzer',
+            description: 'Test description',
+            category: Category::Security,
+            severity: Severity::Low,
+        );
+    }
+
+    public function shouldRun(): bool
+    {
+        return true;
+    }
+
+    public function getSkipReason(): string
+    {
+        return 'Not applicable';
+    }
+
+    public function getId(): string
+    {
+        return 'router-clobbering-test-analyzer';
     }
 }
 

--- a/tests/Unit/AnalyzerManagerTest.php
+++ b/tests/Unit/AnalyzerManagerTest.php
@@ -83,6 +83,33 @@ class AnalyzerManagerTest extends TestCase
         );
     }
 
+    #[Test]
+    public function it_restores_router_middleware_groups_clobbered_during_instance_resolution(): void
+    {
+        $app = $this->app;
+        assert($app !== null);
+
+        $router = $app->make(Router::class);
+
+        // A provider-applied middleware group override.
+        $router->middlewareGroup('web', [ThrottleRequestsWithRedis::class]);
+
+        $manager = new AnalyzerManager(
+            $app->make(Config::class),
+            [GroupClobberingTestAnalyzer::class],
+            $app,
+            $router,
+        );
+
+        $manager->getAnalyzers();
+
+        $this->assertSame(
+            [ThrottleRequestsWithRedis::class],
+            $router->getMiddlewareGroups()['web'] ?? null,
+            'Resolving analyzers must not leave a middleware group clobbered.'
+        );
+    }
+
     /** @test */
     #[Test]
     public function it_can_get_all_analyzers(): void
@@ -1057,6 +1084,49 @@ class RouterClobberingTestAnalyzer implements AnalyzerInterface
     public function getId(): string
     {
         return 'router-clobbering-test-analyzer';
+    }
+}
+
+/**
+ * Like RouterClobberingTestAnalyzer but mutates a middleware GROUP, exercising the
+ * group branch of the snapshot/restore in AnalyzerManager.
+ */
+class GroupClobberingTestAnalyzer implements AnalyzerInterface
+{
+    public function __construct(Router $router)
+    {
+        $router->middlewareGroup('web', [ThrottleRequests::class]);
+    }
+
+    public function analyze(): ResultInterface
+    {
+        return AnalysisResult::passed('group-clobbering-test-analyzer', 'Test passed');
+    }
+
+    public function getMetadata(): AnalyzerMetadata
+    {
+        return new AnalyzerMetadata(
+            id: 'group-clobbering-test-analyzer',
+            name: 'Group Clobbering Test Analyzer',
+            description: 'Test description',
+            category: Category::Security,
+            severity: Severity::Low,
+        );
+    }
+
+    public function shouldRun(): bool
+    {
+        return true;
+    }
+
+    public function getSkipReason(): string
+    {
+        return 'Not applicable';
+    }
+
+    public function getId(): string
+    {
+        return 'group-clobbering-test-analyzer';
     }
 }
 


### PR DESCRIPTION
## Problem

Running the analyzer suite mutates live application state. Six analyzers (`CookieSecurityAnalyzer`, `XssAnalyzer`, `DirectoryWritePermissionsAnalyzer`, `CustomErrorPageAnalyzer`, `SessionDriverAnalyzer`, `UnusedGlobalMiddlewareAnalyzer`) constructor-inject the HTTP `Kernel` via `AnalyzesMiddleware`. `AnalyzerManager::getAllInstances()` resolves every analyzer up front via `container->make()`, and the first kernel injection fires Laravel's `afterResolving(HttpKernel)` → `syncMiddlewareToRouter()`, which re-stamps the framework-default middleware alias/group maps onto the router — clobbering any runtime override a service provider applied via `Route::aliasMiddleware()` / `Route::middlewareGroup()`.

In a real HTTP request the kernel resolves before providers boot, so the override wins; the clobber is a **console/CI-only artifact** of the suite resolving the kernel after boot. It was the root mechanism behind the `redis-throttling` false positive (laravel-pro #292, which worked around it with static source detection).

## Fix

Snapshot the router's middleware alias and group maps before the resolution loop and restore them afterwards, centralized at the single choke point (`getAllInstances()`) so it covers all kernel-injecting analyzers — current and future — without touching the shared trait or the six analyzers.

- `AnalyzerManager`: optional `?Router` constructor param (kept optional so existing Mockery-based tests are unaffected); snapshot/restore around the make-loop via `restoreRouterMiddleware()` using the public router API (no reflection).
- Service provider passes the router into the manager.

Resolving the router is side-effect-free w.r.t. the kernel, and the clobber fires only on the first kernel resolution, so a single snapshot/restore fully undoes it.

## Tests

A router-clobbering fixture analyzer plus a restore test and a **no-router negative control** (proves the test exercises a real clobber and that the restore is what undoes it). Full suite green: 4213 tests, PHPStan Level 9 clean, Pint clean.