### PR TITLE
fix(eloquent-n-plus-one): stop flagging write-upsert loops and seeders as N+1

### DIFF
--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -53,6 +53,12 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
         $scanResult = $scanner->scan($allFiles);
 
         foreach ($allFiles as $file) {
+            // N+1 is a request-path concern. One-time DB scaffolding (seeders, migrations,
+            // factories) idiomatically loops upserts/lookups where query count is irrelevant.
+            if ($this->shouldSkipFile($file)) {
+                continue;
+            }
+
             try {
                 $ast = $this->parser->parseFile($file);
 
@@ -112,6 +118,25 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
             "Found {$totalIssues} potential N+1 query issue(s)",
             $issues
         );
+    }
+
+    /**
+     * Skip one-time database scaffolding directories.
+     *
+     * Seeders, migrations, and factories run off the request path, so query count
+     * inside their loops is irrelevant — looping upserts/lookups there is idiomatic.
+     */
+    private function shouldSkipFile(string $file): bool
+    {
+        $normalized = strtolower(str_replace('\\', '/', $file));
+
+        foreach (['/database/migrations/', '/database/seeders/', '/database/factories/'] as $dir) {
+            if (str_contains($normalized, $dir)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -1375,15 +1400,17 @@ class NPlusOneVisitor extends NodeVisitorAbstract
             return false;
         }
 
+        // Note: write-upserts (updateOrCreate, firstOrCreate, upsert) are deliberately
+        // excluded. A per-row write inside a loop must reference the loop variable, so the
+        // loop-dependency guard would always fire — but persisting N items inherently needs
+        // N writes; there is no eager-load to add. Reserve N+1 for read-per-iteration.
         $executionMethods = [
             // Retrieval methods
             'get', 'first', 'find', 'findorfail', 'findormany', 'findornew',
-            'firstor', 'firstorfail', 'firstornew', 'firstorcreate', 'firstwhere',
+            'firstor', 'firstorfail', 'firstornew', 'firstwhere',
             'sole', 'all', 'value', 'pluck',
             // Aggregates
             'count', 'sum', 'avg', 'average', 'min', 'max', 'exists', 'doesntexist',
-            // Modification methods that also query
-            'updateorcreate', 'upsert',
         ];
 
         return in_array($lowerMethodName, $executionMethods, true);

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
@@ -1068,6 +1068,135 @@ PHP;
         $this->assertHasIssueContaining('User::find', $result);
     }
 
+    public function test_does_not_flag_update_or_create_inside_loop(): void
+    {
+        // updateOrCreate() is a deliberate per-row write, not an accidental read N+1.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class CatalogueImporter
+{
+    public function import(array $pillars)
+    {
+        foreach ($pillars as $data) {
+            Pillar::updateOrCreate(['slug' => $data['slug']], $data);
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/CatalogueImporter.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_does_not_flag_first_or_create_inside_loop(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class TagSyncer
+{
+    public function sync(array $tags)
+    {
+        foreach ($tags as $name) {
+            Tag::firstOrCreate(['name' => $name]);
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/TagSyncer.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_does_not_flag_upsert_inside_loop(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class PriceWriter
+{
+    public function write(array $batches)
+    {
+        foreach ($batches as $batch) {
+            Price::upsert($batch, ['sku'], ['amount']);
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/PriceWriter.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_skips_seeder_files_for_query_in_loop(): void
+    {
+        // A read-per-iteration that WOULD flag under app/ — proves the directory skip
+        // works independently of the write-upsert exclusion.
+        $code = <<<'PHP'
+<?php
+
+namespace Database\Seeders;
+
+class CatalogueSeeder
+{
+    public function run()
+    {
+        $rows = [['code' => 'a'], ['code' => 'b']];
+
+        foreach ($rows as $row) {
+            $lookup = Lookup::where('code', $row['code'])->first();
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'database/seeders/CatalogueSeeder.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['database']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
     public function test_detects_first_inside_loop(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary
- `updateOrCreate()`/`firstOrCreate()`/`upsert()` in a loop are deliberate per-row writes, not accidental read N+1 — removed from the query-execution set, so they're no longer flagged High. A per-row upsert *must* reference the loop variable, so the loop-dependency guard (sound for reads) was a guaranteed false positive for writes.
- `EloquentNPlusOneAnalyzer` now skips `database/seeders`, `database/migrations`, and `database/factories`, matching the dev-dir exclusions sibling analyzers already apply — looping upserts there is idiomatic and query count off the request path is irrelevant.

Fixes 11 false positives reported from a real Laravel app (9 in seeders, 2 in a request-path upsert service); zero were genuine lazy-load N+1. Read-per-iteration N+1 (`Model::find()`/`where()->get()` keyed on a loop var, lazy-loaded relations) still flags.