### PR TITLE
fix(missing-docblock): stop flagging framework-contract, self-documenting, and controller methods

### DIFF
--- a/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
+++ b/src/Analyzers/CodeQuality/MissingDocBlockAnalyzer.php
@@ -8,6 +8,7 @@ use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\NameResolver;
@@ -37,6 +38,94 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
      */
     private array $excludedPatterns = ['get*', 'set*', 'is*', 'has*'];
 
+    /**
+     * Mailable framework-contract methods (Illuminate\Mail\Mailable). Lowercased.
+     *
+     * @var array<string>
+     */
+    private const MAILABLE_METHODS = ['envelope', 'content', 'attachments', 'headers', 'build'];
+
+    /**
+     * FormRequest framework-contract methods (Illuminate\Foundation\Http\FormRequest). Lowercased.
+     *
+     * @var array<string>
+     */
+    private const FORM_REQUEST_METHODS = ['authorize', 'rules', 'messages', 'attributes', 'prepareforvalidation', 'withvalidator'];
+
+    /**
+     * Queued-job / listener framework-contract methods. Lowercased.
+     *
+     * @var array<string>
+     */
+    private const QUEUE_METHODS = ['handle', 'failed'];
+
+    /**
+     * HTTP middleware framework-contract methods. Lowercased.
+     *
+     * @var array<string>
+     */
+    private const MIDDLEWARE_METHODS = ['handle', 'terminate'];
+
+    /**
+     * Eloquent global-scope framework-contract methods (Illuminate\Database\Eloquent\Scope). Lowercased.
+     *
+     * @var array<string>
+     */
+    private const SCOPE_METHODS = ['apply'];
+
+    /**
+     * Validation rule object contract methods (modern ValidationRule + legacy Rule). Lowercased.
+     *
+     * @var array<string>
+     */
+    private const VALIDATION_RULE_METHODS = ['validate'];
+
+    /**
+     * @var array<string>
+     */
+    private const LEGACY_RULE_METHODS = ['passes', 'message'];
+
+    /**
+     * Responsable contract method (Illuminate\Contracts\Support\Responsable). Lowercased.
+     *
+     * @var array<string>
+     */
+    private const RESPONSABLE_METHODS = ['toresponse'];
+
+    /**
+     * Console command framework-contract method (Illuminate\Console\Command). Lowercased.
+     *
+     * @var array<string>
+     */
+    private const CONSOLE_METHODS = ['handle'];
+
+    /**
+     * Notification channel framework-contract methods (Illuminate\Notifications\Notification). Lowercased.
+     *
+     * @var array<string>
+     */
+    private const NOTIFICATION_METHODS = ['via', 'tomail', 'todatabase', 'toarray', 'tobroadcast', 'tovonage', 'toslack'];
+
+    /**
+     * API resource framework-contract methods (Illuminate\Http\Resources\Json\JsonResource). Lowercased.
+     *
+     * @var array<string>
+     */
+    private const JSON_RESOURCE_METHODS = ['toarray', 'with', 'withresponse'];
+
+    /**
+     * Filament framework override methods whose meaning and signature are fixed by the
+     * framework contract. Documenting them adds only noise. Lowercased.
+     *
+     * @var array<string>
+     */
+    private const FILAMENT_OVERRIDES = [
+        'form', 'table', 'infolist', 'panel',
+        'canaccess', 'canview', 'canviewany', 'cancreate', 'canedit', 'candelete',
+        'canviewforrecord', 'canforcedelete', 'canforcedeleteany', 'candeleteany',
+        'canrestore', 'canrestoreany', 'canreorder', 'canreplicate',
+    ];
+
     public function __construct(
         private ParserInterface $parser
     ) {}
@@ -64,7 +153,12 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
             // Skip Laravel scaffolding/test-support files (migrations, factories,
             // seeders). Their framework hooks (up/down, configure, definition) and
             // trivial state methods make docblock enforcement pure noise.
-            if ($this->isDevelopmentFile($file)) {
+            //
+            // Controllers are skipped wholesale too: their public methods are all route
+            // actions (HTTP glue with framework-invoked, typed signatures), so a docblock
+            // only restates the action — the same noise whether the name is a REST
+            // convention (store) or app-specific (switch).
+            if ($this->isDevelopmentFile($file) || $this->isControllerFile($file)) {
                 continue;
             }
 
@@ -74,7 +168,7 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
                 continue;
             }
 
-            $visitor = new DocBlockVisitor($excludePatterns, $requireTags, $this->isFilamentClassFromAst($ast));
+            $visitor = new DocBlockVisitor($excludePatterns, $requireTags, $this->getContractMethodsToSkip($ast, $file));
             $traverser = new NodeTraverser;
             $traverser->addVisitor($visitor);
             $traverser->traverse($ast);
@@ -85,7 +179,13 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
                     filePath: $file,
                     lineNumber: $issue['line'],
                     severity: $this->metadata()->severity,
-                    recommendation: $this->getRecommendation($issue['type'], $issue['method']),
+                    recommendation: $this->getRecommendation(
+                        $issue['type'],
+                        $issue['method'],
+                        $issue['needsParam'] ?? false,
+                        $issue['needsReturn'] ?? false,
+                        $issue['needsThrows'] ?? false,
+                    ),
                     column: null,
                     contextLines: null,
                     metadata: [
@@ -124,17 +224,44 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
-     * Check if the file's AST represents a Filament Resource/Page/RelationManager/Provider.
+     * Build the set of framework-contract method names to skip for this file.
      *
-     * Uses the same CloningVisitor + NameResolver pattern as the other detectors to
-     * resolve parent class names to FQN before checking. A class is treated as a
-     * Filament UI class when it extends a Filament base class OR lives in a Filament
-     * namespace (catches project-local intermediate bases such as App\Filament\BaseResource).
+     * These are methods whose meaning and signature are fixed by a Laravel framework
+     * contract (Mailable, FormRequest, queued Job/Listener, Filament UI, …), so a docblock
+     * only restates the obvious — the same "framework hook = noise" principle already
+     * applied to Filament classes and dev files. (Controllers are handled separately, as a
+     * whole-file skip in runAnalysis.)
+     *
+     * Detection is gated by class type (base class, interface, namespace, or path) so
+     * identically-named methods in plain classes — a repository's store()/update(), a
+     * service's handle() — are NOT skipped. Like the previous Filament detection, this
+     * is file-level: the union across all classes in the file. Laravel is one class per
+     * file under PSR-4, so this matches existing behaviour.
+     *
+     * Uses one CloningVisitor + NameResolver traversal to resolve parent/interface names
+     * to FQN before checking, mirroring the detector pattern used across the analyzers.
      *
      * @param  array<Node>  $ast
+     * @return array<string> lowercased contract-method names to skip
      */
-    private function isFilamentClassFromAst(array $ast): bool
+    private function getContractMethodsToSkip(array $ast, string $file): array
     {
+        $methods = [];
+
+        // Path-based gating (independent of AST): many jobs/listeners are detectable by
+        // location even when they extend no base class.
+        if (str_contains($file, '/Jobs/') || str_contains($file, '/Listeners/')) {
+            $methods = array_merge($methods, self::QUEUE_METHODS);
+        }
+
+        if (str_contains($file, '/Http/Middleware/')) {
+            $methods = array_merge($methods, self::MIDDLEWARE_METHODS);
+        }
+
+        if ($this->isConsoleCommand($file)) {
+            $methods = array_merge($methods, self::CONSOLE_METHODS);
+        }
+
         $traverser = new NodeTraverser;
         $traverser->addVisitor(new CloningVisitor);
         $traverser->addVisitor(new NameResolver);
@@ -145,17 +272,210 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
                 $namespace = $node->name?->toString();
 
                 foreach ($node->stmts as $stmt) {
-                    if ($stmt instanceof Stmt\Class_ &&
-                        ($this->extendsFilamentBase($stmt) || $this->isFilamentNamespace($namespace))) {
-                        return true;
+                    if ($stmt instanceof Stmt\Class_) {
+                        $methods = array_merge($methods, $this->contractMethodsForClass($stmt, $namespace));
                     }
                 }
-            } elseif ($node instanceof Stmt\Class_ && $this->extendsFilamentBase($node)) {
+            } elseif ($node instanceof Stmt\Class_) {
+                $methods = array_merge($methods, $this->contractMethodsForClass($node, null));
+            }
+        }
+
+        return array_values(array_unique($methods));
+    }
+
+    /**
+     * Determine which framework-contract method names apply to a single class, based on
+     * its base class, implemented interfaces, and namespace.
+     *
+     * @return array<string> lowercased contract-method names
+     */
+    private function contractMethodsForClass(Stmt\Class_ $class, ?string $namespace): array
+    {
+        $methods = [];
+
+        if ($this->extendsMailable($class)) {
+            $methods = array_merge($methods, self::MAILABLE_METHODS);
+        }
+
+        if ($this->extendsFormRequest($class)) {
+            $methods = array_merge($methods, self::FORM_REQUEST_METHODS);
+        }
+
+        if ($this->implementsShouldQueue($class) || $this->isJobOrListenerNamespace($namespace)) {
+            $methods = array_merge($methods, self::QUEUE_METHODS);
+        }
+
+        if ($this->isMiddlewareNamespace($namespace)) {
+            $methods = array_merge($methods, self::MIDDLEWARE_METHODS);
+        }
+
+        if ($this->implementsScope($class)) {
+            $methods = array_merge($methods, self::SCOPE_METHODS);
+        }
+
+        if ($this->classImplements($class, 'Illuminate\\Contracts\\Validation\\ValidationRule')) {
+            $methods = array_merge($methods, self::VALIDATION_RULE_METHODS);
+        }
+
+        // Legacy Rule contract matched by exact FQN only — '\Rule' is too common a short
+        // name to suffix-match without risking false exemptions in unrelated classes.
+        if ($this->classImplements($class, 'Illuminate\\Contracts\\Validation\\Rule', false)) {
+            $methods = array_merge($methods, self::LEGACY_RULE_METHODS);
+        }
+
+        if ($this->classImplements($class, 'Illuminate\\Contracts\\Support\\Responsable')) {
+            $methods = array_merge($methods, self::RESPONSABLE_METHODS);
+        }
+
+        // Console commands matched by exact base FQN ('\Command' is too common to suffix-match);
+        // the path check in getContractMethodsToSkip() covers project-local base commands.
+        if ($this->classExtends($class, 'Illuminate\\Console\\Command', false)) {
+            $methods = array_merge($methods, self::CONSOLE_METHODS);
+        }
+
+        if ($this->classExtends($class, 'Illuminate\\Notifications\\Notification')) {
+            $methods = array_merge($methods, self::NOTIFICATION_METHODS);
+        }
+
+        if ($this->classExtends($class, 'Illuminate\\Http\\Resources\\Json\\JsonResource')
+            || $this->classExtends($class, 'Illuminate\\Http\\Resources\\Json\\ResourceCollection')) {
+            $methods = array_merge($methods, self::JSON_RESOURCE_METHODS);
+        }
+
+        if ($this->extendsFilamentBase($class) || $this->isFilamentNamespace($namespace)) {
+            $methods = array_merge($methods, self::FILAMENT_OVERRIDES);
+        }
+
+        return $methods;
+    }
+
+    /**
+     * Check if a class extends Illuminate\Mail\Mailable (or a project-local Mailable base).
+     */
+    private function extendsMailable(Stmt\Class_ $class): bool
+    {
+        if ($class->extends === null) {
+            return false;
+        }
+
+        $parent = ltrim($class->extends->toString(), '\\');
+
+        return $parent === 'Illuminate\\Mail\\Mailable' || str_ends_with($parent, '\\Mailable');
+    }
+
+    /**
+     * Check if a class extends Illuminate\Foundation\Http\FormRequest (or a local FormRequest base).
+     */
+    private function extendsFormRequest(Stmt\Class_ $class): bool
+    {
+        if ($class->extends === null) {
+            return false;
+        }
+
+        $parent = ltrim($class->extends->toString(), '\\');
+
+        return $parent === 'Illuminate\\Foundation\\Http\\FormRequest' || str_ends_with($parent, '\\FormRequest');
+    }
+
+    /**
+     * Check if a class implements the ShouldQueue contract (queued job).
+     */
+    private function implementsShouldQueue(Stmt\Class_ $class): bool
+    {
+        foreach ($class->implements as $interface) {
+            $name = ltrim($interface->toString(), '\\');
+            if ($name === 'Illuminate\\Contracts\\Queue\\ShouldQueue' || str_ends_with($name, '\\ShouldQueue')) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Check if a class implements the Eloquent Scope contract (global scope).
+     */
+    private function implementsScope(Stmt\Class_ $class): bool
+    {
+        foreach ($class->implements as $interface) {
+            $name = ltrim($interface->toString(), '\\');
+            if ($name === 'Illuminate\\Database\\Eloquent\\Scope' || str_ends_with($name, '\\Scope')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a class implements the given interface — by exact FQN, and (when allowed)
+     * by matching short name to catch project-local re-exports / aliased imports.
+     */
+    private function classImplements(Stmt\Class_ $class, string $interface, bool $allowSuffix = true): bool
+    {
+        $suffix = strrchr($interface, '\\');
+
+        foreach ($class->implements as $impl) {
+            $name = ltrim($impl->toString(), '\\');
+            if ($name === $interface || ($allowSuffix && $suffix !== false && str_ends_with($name, $suffix))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a class extends the given base class — by exact FQN, and (when allowed)
+     * by matching short name to catch project-local intermediate base classes.
+     */
+    private function classExtends(Stmt\Class_ $class, string $parent, bool $allowSuffix = true): bool
+    {
+        if ($class->extends === null) {
+            return false;
+        }
+
+        $name = ltrim($class->extends->toString(), '\\');
+        $suffix = strrchr($parent, '\\');
+
+        return $name === $parent || ($allowSuffix && $suffix !== false && str_ends_with($name, $suffix));
+    }
+
+    /**
+     * Check if a file is an HTTP controller (by location or filename). Controllers are
+     * exempt wholesale — every public method is a route action whose typed signature is
+     * the documentation, so a docblock would only restate it.
+     */
+    private function isControllerFile(string $file): bool
+    {
+        return str_contains($file, '/Http/Controllers/') || str_ends_with($file, 'Controller.php');
+    }
+
+    /**
+     * Check if a namespace places a class under Jobs or Listeners.
+     */
+    private function isJobOrListenerNamespace(?string $namespace): bool
+    {
+        if ($namespace === null) {
+            return false;
+        }
+
+        return str_contains($namespace, '\\Jobs') || str_starts_with($namespace, 'Jobs')
+            || str_contains($namespace, '\\Listeners') || str_starts_with($namespace, 'Listeners');
+    }
+
+    /**
+     * Check if a namespace places a class under Http\Middleware (catches HTTP middleware,
+     * which — like Laravel 11+ controllers — extend no base class).
+     */
+    private function isMiddlewareNamespace(?string $namespace): bool
+    {
+        if ($namespace === null) {
+            return false;
+        }
+
+        return str_contains($namespace, '\\Http\\Middleware') || str_starts_with($namespace, 'Http\\Middleware');
     }
 
     /**
@@ -190,10 +510,29 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
-     * Get recommendation based on issue type.
+     * Build a recommendation tailored to what the method actually needs.
+     *
+     * The guidance only mentions the tags the method genuinely requires: @param when a
+     * parameter is untyped or generic, @return when the return type is ambiguous, @throws
+     * when the body throws. A fully-typed method with no throws is simply asked for a
+     * one-line summary, rather than the old blanket "@param/@return/@throws" checklist
+     * that contradicted the analyzer's own self-documenting-type rules.
      */
-    private function getRecommendation(string $type, string $method): string
+    private function getRecommendation(string $type, string $method, bool $needsParam, bool $needsReturn, bool $needsThrows): string
     {
+        $guidelines = match ($type) {
+            'missing_param' => [
+                "Add @param tags documenting each parameter of '{$method}' and its type",
+            ],
+            'missing_return' => [
+                "Add a @return tag describing what '{$method}' returns",
+            ],
+            'missing_throws' => [
+                "Add @throws tags for the exceptions '{$method}' may throw",
+            ],
+            default => $this->missingDocBlockGuidelines($method, $needsParam, $needsReturn, $needsThrows),
+        };
+
         $base = match ($type) {
             'missing' => "The method '{$method}' has no PHPDoc comment. ",
             'missing_param' => "The method '{$method}' is missing @param tags. ",
@@ -202,16 +541,31 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
             default => "The method '{$method}' has incomplete documentation. ",
         };
 
-        $guidelines = [
-            'Add a complete PHPDoc block above the method',
-            'Include a description of what the method does',
-            'Document all parameters with @param tags and types',
-            'Document the return value with @return tag',
-            'Document any exceptions thrown with @throws tags',
-            'Use descriptive parameter and return descriptions',
-        ];
-
         return $base.'Documentation guidelines: '.implode('; ', $guidelines);
+    }
+
+    /**
+     * Guidelines for a method with no DocBlock at all — tailored to its signature.
+     *
+     * @return array<string>
+     */
+    private function missingDocBlockGuidelines(string $method, bool $needsParam, bool $needsReturn, bool $needsThrows): array
+    {
+        $guidelines = ['Add a PHPDoc block with a short description of what the method does'];
+
+        if ($needsParam) {
+            $guidelines[] = 'Document each parameter with a @param tag and its type';
+        }
+
+        if ($needsReturn) {
+            $guidelines[] = 'Document the return value with a @return tag';
+        }
+
+        if ($needsThrows) {
+            $guidelines[] = 'Document thrown exceptions with @throws tags';
+        }
+
+        return $guidelines;
     }
 }
 
@@ -221,7 +575,7 @@ class MissingDocBlockAnalyzer extends AbstractFileAnalyzer
 class DocBlockVisitor extends NodeVisitorAbstract
 {
     /**
-     * @var array<int, array{message: string, line: int, type: string, method: string, class: string}>
+     * @var array<int, array{message: string, line: int, type: string, method: string, class: string, needsParam?: bool, needsReturn?: bool, needsThrows?: bool}>
      */
     private array $issues = [];
 
@@ -231,32 +585,19 @@ class DocBlockVisitor extends NodeVisitorAbstract
     private ?string $currentClass = null;
 
     /**
-     * Filament framework override methods whose meaning and signature are fixed by the
-     * framework contract. Documenting them adds only noise, so they are skipped when the
-     * containing class is a Filament UI class. Compared case-insensitively.
-     *
-     * @var array<string>
-     */
-    private array $filamentOverrides = [
-        'form', 'table', 'infolist', 'panel',
-        'canaccess', 'canview', 'canviewany', 'cancreate', 'canedit', 'candelete',
-        'canviewforrecord', 'canforcedelete', 'canforcedeleteany', 'candeleteany',
-        'canrestore', 'canrestoreany', 'canreorder', 'canreplicate',
-    ];
-
-    /**
      * @param  array<string>  $excludePatterns
+     * @param  array<string>  $contractMethods  lowercased framework-contract method names to skip
      */
     public function __construct(
         private array $excludePatterns = [],
         private bool $requireTags = true,
-        private bool $isFilamentClass = false
+        private array $contractMethods = []
     ) {}
 
     public function enterNode(Node $node)
     {
-        // Track current class
-        if ($node instanceof Stmt\Class_ || $node instanceof Stmt\Trait_ || $node instanceof Stmt\Interface_) {
+        // Track current class context (classes, traits, interfaces, and enums)
+        if ($node instanceof Stmt\Class_ || $node instanceof Stmt\Trait_ || $node instanceof Stmt\Interface_ || $node instanceof Stmt\Enum_) {
             $this->currentClass = $node->name ? $node->name->toString() : 'Anonymous';
 
             return null;
@@ -276,9 +617,19 @@ class DocBlockVisitor extends NodeVisitorAbstract
                 return null;
             }
 
-            // Skip Filament framework overrides (form, table, infolist, panel, can*)
-            // whose contract and signature are fixed by the framework.
-            if ($this->isFilamentClass && in_array(strtolower($methodName), $this->filamentOverrides, true)) {
+            // Skip framework-contract methods (Mailable/FormRequest/Controller/Job/Listener/Filament)
+            // whose signature and meaning are fixed by the framework. Gated by class type in the
+            // analyzer so identically-named methods in plain classes stay flagged.
+            if (in_array(strtolower($methodName), $this->contractMethods, true)) {
+                return null;
+            }
+
+            // Skip trivially self-documenting methods: a trivial body (a single statement,
+            // or assignments feeding a single return) whose typed signature already carries
+            // everything a docblock would — no params needing docs, a self-documenting return
+            // type, and no throws. Forcing a docblock here only invites a summary that
+            // restates the signature — e.g. `label(): string` or `id(): ?int`.
+            if ($this->isTriviallySelfDocumenting($node)) {
                 return null;
             }
 
@@ -292,6 +643,9 @@ class DocBlockVisitor extends NodeVisitorAbstract
                     'type' => 'missing',
                     'method' => $methodName,
                     'class' => $this->currentClass ?? 'Unknown',
+                    'needsParam' => $this->hasParamsRequiringDocs($node),
+                    'needsReturn' => $this->returnRequiresDocs($node),
+                    'needsThrows' => $this->mightThrowException($node),
                 ];
 
                 return null;
@@ -309,7 +663,7 @@ class DocBlockVisitor extends NodeVisitorAbstract
     public function leaveNode(Node $node)
     {
         // Clear class context on exit
-        if ($node instanceof Stmt\Class_ || $node instanceof Stmt\Trait_ || $node instanceof Stmt\Interface_) {
+        if ($node instanceof Stmt\Class_ || $node instanceof Stmt\Trait_ || $node instanceof Stmt\Interface_ || $node instanceof Stmt\Enum_) {
             $this->currentClass = null;
         }
 
@@ -369,20 +723,15 @@ class DocBlockVisitor extends NodeVisitorAbstract
             }
         }
 
-        // Check for @return tag
-        if (! str_contains($docText, '@return')) {
-            // Require @return if:
-            // - No return type declared (needs documentation)
-            // - Return type is generic/ambiguous (array, mixed, union, etc.)
-            if ($node->returnType === null || $this->requiresReturnDocumentation($node->returnType)) {
-                $this->issues[] = [
-                    'message' => "Public method '{$methodName}' is missing @return documentation",
-                    'line' => $node->getStartLine(),
-                    'type' => 'missing_return',
-                    'method' => $methodName,
-                    'class' => $this->currentClass ?? 'Unknown',
-                ];
-            }
+        // Check for @return tag (no docs needed for self-documenting return types)
+        if (! str_contains($docText, '@return') && $this->returnRequiresDocs($node)) {
+            $this->issues[] = [
+                'message' => "Public method '{$methodName}' is missing @return documentation",
+                'line' => $node->getStartLine(),
+                'type' => 'missing_return',
+                'method' => $methodName,
+                'class' => $this->currentClass ?? 'Unknown',
+            ];
         }
 
         // Check for @throws tag if method might throw exceptions
@@ -395,6 +744,127 @@ class DocBlockVisitor extends NodeVisitorAbstract
                 'class' => $this->currentClass ?? 'Unknown',
             ];
         }
+    }
+
+    /**
+     * A method is trivially self-documenting when a complete docblock would carry no
+     * required information: a trivial body, every parameter explicitly typed with a
+     * self-documenting type, a self-documenting return type, and no throws.
+     */
+    private function isTriviallySelfDocumenting(Stmt\ClassMethod $node): bool
+    {
+        return $this->hasTrivialBody($node)
+            && ! $this->hasParamsRequiringDocs($node)
+            && ! $this->returnRequiresDocs($node)
+            && ! $this->mightThrowException($node);
+    }
+
+    /**
+     * A body is "trivial" when a complete docblock would add nothing beyond the signature:
+     *
+     * - A bodyless declaration (interface or abstract method): there is no implementation,
+     *   so a fully-typed signature is the entire contract. Generic/ambiguous signatures are
+     *   still caught by the param/return checks in isTriviallySelfDocumenting().
+     * - A single statement.
+     * - A single `return` preceded only by local variable assignments that feed that return
+     *   value — the common assign-then-return idiom (often forced by a `@var` type-narrowing
+     *   hint under static analysis), e.g. `$x = query()->first(); return $x;`.
+     *
+     * Any other statement before the return (a side-effecting call, a conditional, a loop)
+     * or an assignment whose variable never feeds the return makes the method non-trivial.
+     */
+    private function hasTrivialBody(Stmt\ClassMethod $node): bool
+    {
+        $stmts = $node->stmts;
+
+        // Interface / abstract method declaration — no body to assess.
+        if ($stmts === null) {
+            return true;
+        }
+
+        if ($stmts === []) {
+            return false;
+        }
+
+        if (count($stmts) === 1) {
+            return true;
+        }
+
+        $return = $stmts[count($stmts) - 1];
+
+        if (! $return instanceof Stmt\Return_ || $return->expr === null) {
+            return false;
+        }
+
+        $preceding = array_slice($stmts, 0, -1);
+
+        // Collect every variable referenced by the return value and by assignment values,
+        // so we can verify each assigned variable actually feeds the return.
+        $referenced = $this->referencedVariableNames($return->expr);
+        $assignedVars = [];
+
+        foreach ($preceding as $stmt) {
+            if (! $stmt instanceof Stmt\Expression || ! $stmt->expr instanceof Expr\Assign) {
+                return false;
+            }
+
+            $target = $stmt->expr->var;
+
+            if (! $target instanceof Expr\Variable || ! is_string($target->name)) {
+                return false;
+            }
+
+            $assignedVars[] = $target->name;
+            $referenced = array_merge($referenced, $this->referencedVariableNames($stmt->expr->expr));
+        }
+
+        foreach ($assignedVars as $name) {
+            if (! in_array($name, $referenced, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Collect the names of all variables referenced within an expression subtree.
+     *
+     * @return array<string>
+     */
+    private function referencedVariableNames(Node $node): array
+    {
+        $names = [];
+
+        foreach ((new NodeFinder)->findInstanceOf($node, Expr\Variable::class) as $variable) {
+            if (is_string($variable->name)) {
+                $names[] = $variable->name;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Check if any parameter is untyped or has a generic type (so it needs @param docs).
+     */
+    private function hasParamsRequiringDocs(Stmt\ClassMethod $node): bool
+    {
+        foreach ($node->params as $param) {
+            if ($param->type === null || $this->isGenericType($param->type)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the return type is missing or ambiguous (so it needs a @return tag).
+     */
+    private function returnRequiresDocs(Stmt\ClassMethod $node): bool
+    {
+        return $node->returnType === null || $this->requiresReturnDocumentation($node->returnType);
     }
 
     /**

--- a/tests/Unit/Analyzers/CodeQuality/MissingDocBlockAnalyzerTest.php
+++ b/tests/Unit/Analyzers/CodeQuality/MissingDocBlockAnalyzerTest.php
@@ -7,6 +7,7 @@ namespace ShieldCI\Tests\Unit\Analyzers\CodeQuality;
 use PHPUnit\Framework\Attributes\Test;
 use ShieldCI\Analyzers\CodeQuality\MissingDocBlockAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
+use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\Tests\AnalyzerTestCase;
 
 class MissingDocBlockAnalyzerTest extends AnalyzerTestCase
@@ -1489,5 +1490,1346 @@ PHP;
 
         // Seeders are scaffolding/test-support files
         $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_mailable_contract_methods(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Mail\Mailable;
+
+class OrderShipped extends Mailable
+{
+    public function envelope(): Envelope
+    {
+        return new Envelope(subject: 'Order Shipped');
+    }
+
+    public function content(): Content
+    {
+        return new Content(view: 'emails.orders.shipped');
+    }
+
+    public function attachments(): array
+    {
+        return [];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Mail/OrderShipped.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // envelope/content/attachments are Mailable framework contracts
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_form_request_contract_methods(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return ['title' => 'required'];
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->merge(['slug' => 'x']);
+    }
+
+    public function withValidator($validator): void
+    {
+        //
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Requests/StorePostRequest.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // authorize/rules/prepareForValidation/withValidator are FormRequest contracts
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_all_public_controller_methods(): void
+    {
+        // Controllers are exempt wholesale — both REST-named actions (store) and
+        // app-specific actions (switch) are route handlers with typed signatures.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Support\ActiveBusiness;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class BusinessSwitcherController
+{
+    public function store(Request $request, ActiveBusiness $active): RedirectResponse
+    {
+        $business = $this->persist($request);
+        $active->set($business->id);
+
+        return redirect()->route('dashboard');
+    }
+
+    public function switch(Request $request, ActiveBusiness $active): RedirectResponse
+    {
+        $data = $request->validate(['business_id' => ['required', 'integer']]);
+        abort_unless($request->user() !== null, 403);
+        $active->set((int) $data['business_id']);
+
+        return redirect()->back();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/BusinessSwitcherController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // store (REST name) and switch (custom name) are both controller actions
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_job_contract_methods_via_should_queue(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class ProcessPodcast implements ShouldQueue
+{
+    public function handle(): void
+    {
+        //
+    }
+
+    public function failed($exception): void
+    {
+        //
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Jobs/ProcessPodcast.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // handle/failed are queued-job framework contracts
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_listener_contract_methods_via_namespace(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Listeners;
+
+class SendShipmentNotification
+{
+    public function handle($event): void
+    {
+        //
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Listeners/SendShipmentNotification.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // handle is a listener framework contract (gated by namespace/path)
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_store_update_in_repository(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Repositories;
+
+class PostRepository
+{
+    public function store($data)
+    {
+        return $data;
+    }
+
+    public function update($id, $data)
+    {
+        return $id;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Repositories/PostRepository.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // store/update in a repository are NOT controller actions — still flagged
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('store', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_handle_in_plain_service(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class PaymentService
+{
+    public function handle($payment)
+    {
+        return $payment;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/PaymentService.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // handle() in a plain service is not a job/listener — still flagged
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('handle', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_rules_in_plain_class(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Support;
+
+class RuleEngine
+{
+    public function rules()
+    {
+        return [];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Support/RuleEngine.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // rules() in a plain class is not a FormRequest — still flagged
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('rules', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_build_in_non_mailable(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Builders;
+
+class QueryBuilder
+{
+    public function build()
+    {
+        return [];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Builders/QueryBuilder.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // build() in a non-Mailable class is still flagged
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('build', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_even_helper_methods_in_controller(): void
+    {
+        // Consequence of the whole-file controller exemption: even a public helper that
+        // is not an action is exempt. Public helpers on controllers are an anti-pattern
+        // (they should be private/protected, which the analyzer never checks anyway).
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class PostController
+{
+    public function recalculateStats($rows)
+    {
+        return $rows;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/PostController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_store_in_non_controller_path(): void
+    {
+        // A 'store' method in a class that is NOT a controller (path/filename) stays flagged
+        // — the exemption is the controller location, not the method name.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Repositories;
+
+class PostStore
+{
+    public function store($data)
+    {
+        $saved = $this->persist($data);
+
+        return $saved;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Repositories/PostStore.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('store', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_suppresses_trivially_self_documenting_enum_method(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Enums;
+
+enum FounderBand: string
+{
+    case Emerging = 'emerging';
+    case Strong = 'strong';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Emerging => 'Emerging',
+            self::Strong => 'Strong',
+        };
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Enums/FounderBand.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // label(): string is single-statement, self-documenting return, no params, no throws
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_suppresses_self_documenting_value_object_methods(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Support;
+
+class Plan
+{
+    public function tier(): PlanTier
+    {
+        return $this->tier;
+    }
+
+    public function id(): ?int
+    {
+        return $this->id;
+    }
+
+    public function clear(): void
+    {
+        $this->items = [];
+    }
+
+    public function can(Capability $capability): bool
+    {
+        return $this->capabilities->contains($capability);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Support/Plan.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // All four are single-statement, fully-typed, non-throwing — self-documenting
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_self_documenting_signature_with_control_flow(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class OrderService
+{
+    public function process(Order $order): Receipt
+    {
+        if ($order->isEmpty()) {
+            return Receipt::empty();
+        }
+
+        return new Receipt($order->total());
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/OrderService.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // A branching body is not "trivial" even with concrete types — still nudged, but
+        // the recommendation should only ask for a summary (no @param/@return/@throws).
+        $this->assertWarning($result);
+        $recommendation = $this->recommendationFor('process', $result);
+        $this->assertStringContainsString('short description', $recommendation);
+        $this->assertStringNotContainsString('@param', $recommendation);
+        $this->assertStringNotContainsString('@return', $recommendation);
+        $this->assertStringNotContainsString('@throws', $recommendation);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_suppresses_assign_then_return_with_self_documenting_signature(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Support;
+
+class ActiveBusiness
+{
+    public function id(): ?int
+    {
+        $value = $this->session->get('active_business_id');
+
+        return is_numeric($value) ? (int) $value : null;
+    }
+
+    public function owner(): ?User
+    {
+        $owner = User::query()->where('role', 'owner')->first();
+
+        return $owner;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Support/ActiveBusiness.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Local assignments feeding a single return, with self-documenting signatures
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_assign_then_return_when_variable_does_not_feed_return(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class Auditor
+{
+    public function record(): int
+    {
+        $logged = $this->writeAuditLog();
+
+        return 42;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/Auditor.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // $logged is a side-effecting statement that never feeds the return — not trivial
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('record', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_when_statement_before_return_is_not_assignment(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class ReportService
+{
+    public function assemble(): Report
+    {
+        $this->prepare();
+
+        return new Report();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/ReportService.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // A side-effecting call before the return makes the body non-trivial
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('assemble', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_missing_docblock_recommendation_includes_only_needed_tags(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class Transformer
+{
+    public function transform($input): array
+    {
+        $output = (array) $input;
+
+        return $output;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/Transformer.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $recommendation = $this->recommendationFor('transform', $result);
+        // Untyped param needs @param; generic array return needs @return; nothing thrown.
+        $this->assertStringContainsString('@param', $recommendation);
+        $this->assertStringContainsString('@return', $recommendation);
+        $this->assertStringNotContainsString('@throws', $recommendation);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_enum_method_issue_reports_enum_name_not_unknown(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Enums;
+
+enum Palette: string
+{
+    case Warm = 'warm';
+    case Cool = 'cool';
+
+    public function swatches(): array
+    {
+        $base = ['#fff'];
+
+        return $base;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Enums/Palette.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // swatches(): array is generic, multi-statement — flagged. Its class context must
+        // resolve to the enum name now that Stmt\Enum_ is tracked.
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('swatches', $result);
+
+        $issue = $result->getIssues()[0];
+        $this->assertSame('Palette', $issue->metadata['class'] ?? null);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_middleware_contract_methods(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureActiveBusiness
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->user() === null) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+
+    public function terminate(Request $request, Response $response): void
+    {
+        $this->log($request, $response);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Middleware/EnsureActiveBusiness.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // handle/terminate are fixed by the Laravel middleware contract, even with real logic
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_custom_method_in_middleware(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        return $next($request);
+    }
+
+    public function resolveRole($user)
+    {
+        return $user->role;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Middleware/CheckRole.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // handle is skipped, but a custom middleware method is still flagged
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('resolveRole', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_eloquent_scope_apply_method(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class BusinessScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $businessId = app('active')->id();
+
+        $builder->where($model->qualifyColumn('business_id'), $businessId ?? 0);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Scopes/BusinessScope.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // apply() is mandated by the Illuminate\Database\Eloquent\Scope interface
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_apply_method_in_non_scope_class(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class DiscountApplier
+{
+    public function apply(Order $order): void
+    {
+        if ($order->isEmpty()) {
+            return;
+        }
+
+        $order->discount(0.1);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/DiscountApplier.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // apply() in a class that does not implement Scope is not a contract method
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('apply', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_validation_rule_contract_method(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class Lowercase implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $normalized = strtolower((string) $value);
+
+        if ($normalized !== $value) {
+            $fail('The :attribute must be lowercase.');
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Rules/Lowercase.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // validate() is mandated by the ValidationRule interface
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_legacy_validation_rule_contract_methods(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class NonEmpty implements Rule
+{
+    public function passes($attribute, $value): bool
+    {
+        $clean = trim((string) $value);
+
+        return $clean !== '';
+    }
+
+    public function message(): array
+    {
+        return ['en' => 'Required', 'es' => 'Requerido'];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Rules/NonEmpty.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // passes/message are the legacy Rule contract
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_responsable_contract_method(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Responses;
+
+use Illuminate\Contracts\Support\Responsable;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckoutResponse implements Responsable
+{
+    public function toResponse($request): Response
+    {
+        if ($this->failed) {
+            return response('error', 500);
+        }
+
+        return response('ok');
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Responses/CheckoutResponse.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // toResponse() is mandated by the Responsable interface
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_console_command_handle(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class SyncReports extends Command
+{
+    public function handle(): int
+    {
+        $this->info('Syncing...');
+
+        return self::SUCCESS;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Console/Commands/SyncReports.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // handle() is the console command framework contract
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_notification_channel_methods(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Notifications\Notification;
+
+class InvoicePaid extends Notification
+{
+    public function via($notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toArray($notifiable): array
+    {
+        $data = ['amount' => 100];
+
+        return $data;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Notifications/InvoicePaid.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // via/toArray are Notification channel contracts
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_json_resource_to_array(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+        ];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Resources/UserResource.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // toArray() is the JsonResource framework contract
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_to_array_in_plain_class(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Support;
+
+class Payload
+{
+    public function toArray($data): array
+    {
+        $out = (array) $data;
+
+        return $out;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Support/Payload.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // toArray() in a class that is neither a Resource nor a Notification is still flagged
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('toArray', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_message_on_non_illuminate_rule_interface(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Validation;
+
+use App\Contracts\Rule;
+
+class PricingRule implements Rule
+{
+    public function message(): array
+    {
+        return ['price' => 'invalid'];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Validation/PricingRule.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // A non-Illuminate interface ending in \Rule must NOT be suffix-matched (exact-only)
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('message', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_fully_typed_interface_method(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services\ActionPlan\Contracts;
+
+use App\Support\ActionPlan\ActionPlanContent;
+use App\Support\ActionPlan\PlanInput;
+
+interface PlanGenerator
+{
+    public function generate(PlanInput $input): ActionPlanContent;
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/ActionPlan/Contracts/PlanGenerator.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // A bodyless declaration with a fully-typed signature is the entire contract
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_interface_method_with_generic_signature(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Contracts;
+
+interface Transformer
+{
+    public function transform(array $payload): array;
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Contracts/Transformer.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // array param and array return are ambiguous — a docblock still adds value
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('transform', $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_excludes_fully_typed_abstract_method(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Repositories;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class Repository
+{
+    abstract public function find(int $id): ?Model;
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Repositories/Repository.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Fully-typed abstract declaration carries nothing beyond its signature
+        $this->assertPassed($result);
+    }
+
+    /** @test */
+    #[Test]
+    public function test_still_flags_abstract_method_with_ambiguous_return(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+abstract class Aggregator
+{
+    abstract public function summarize(int $id): array;
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/Aggregator.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // array return is ambiguous — a @return documenting the shape still adds value
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('summarize', $result);
+    }
+
+    /**
+     * Find the recommendation for the issue raised against the named method.
+     */
+    private function recommendationFor(string $method, ResultInterface $result): string
+    {
+        foreach ($result->getIssues() as $issue) {
+            if (str_contains($issue->message, "'{$method}'")) {
+                return $issue->recommendation;
+            }
+        }
+
+        $this->fail("No issue found for method '{$method}'");
     }
 }


### PR DESCRIPTION
## Summary

`MissingDocBlockAnalyzer` flagged every public method without a PHPDoc comment, producing dozens of low-value findings on modern fully-typed Laravel apps — on methods whose meaning is already fixed by a framework contract or fully carried by a typed signature. This extends the analyzer's own "framework hook = noise" principle (already applied to Filament classes and dev files) to the rest of the common Laravel surface.

## What changed

- **Framework-contract methods** are skipped, each gated to its specific base class / interface / namespace so identically-named methods in plain classes stay flagged: Mailable, FormRequest, queued Job/Listener, Middleware, Eloquent Scope, ValidationRule / legacy Rule, Responsable, Console Command, Notification channels, JsonResource, Filament.
- **Trivially self-documenting methods** are skipped: a single statement, local assignments feeding a single `return`, or a fully-typed interface/abstract declaration — where a docblock would only restate the signature. Methods with generic/untyped params or ambiguous returns are still flagged.
- **Controllers are exempt wholesale** (a whole-file skip, like migrations/seeders): every public controller method is a route action, so a name-based exemption (`store` but not `switch`) was arbitrary.
- **Recommendations are signature-aware**: a missing-docblock finding only suggests the tags a method actually needs, instead of a blanket `@param`/`@return`/`@throws` checklist that contradicted the analyzer's own self-documenting-type rules.
- **Enum class context is tracked**, so findings inside an `enum` report the enum name instead of `Unknown`.

## Verification

- `MissingDocBlockAnalyzerTest`: 72 passing (35 new cases — positives plus negatives proving plain classes are unaffected)
- Full suite: 4253 tests, 0 failures
- PHPStan Level 9: clean · Pint: clean