### PR TITLE
fix(chunk-missing): downgrade single-parent relationship reads to warning

### DIFF
--- a/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
+++ b/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
@@ -141,7 +141,7 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
                 $this->issues[] = [
                     'message' => 'Looping over ->all() or ->get() without chunk() can cause memory issues on large datasets',
                     'line' => $node->getLine(),
-                    'severity' => Severity::High,
+                    'severity' => $this->severityFor($loopIterator),
                     'recommendation' => 'Use the chunk method to process records in batches of a fixed size, or the cursor or lazy methods for generator-based iteration. All three avoid loading the entire result set into memory at once.',
                     'code' => $this->getCodeSnippet($loopIterator),
                 ];
@@ -153,7 +153,7 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
                     $this->issues[] = [
                         'message' => 'Looping over a variable assigned with ->all() or ->get() can cause memory issues on large datasets',
                         'line' => $node->getLine(),
-                        'severity' => Severity::High,
+                        'severity' => $this->severityFor($this->variableAssignments[$loopIterator->name]),
                         'recommendation' => 'Use the chunk method to process records in batches, or the cursor or lazy methods for generator-based iteration, to avoid loading the entire dataset into memory.',
                         'code' => $this->getCodeSnippet($loopIterator),
                     ];
@@ -281,6 +281,18 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
         }
 
         return false;
+    }
+
+    /**
+     * Pick a severity for a flagged fetch chain by how strong the memory-risk signal is.
+     *
+     * A table-wide scan (Model::…/DB::table()) is the high-confidence risk and stays High. A read
+     * rooted at an instance accessor ($model->relation()->get(), $builder->get()) reads one parent's
+     * children — far more often bounded than a table-wide scan — so it is a warning, not a failure.
+     */
+    private function severityFor(Node\Expr $expr): Severity
+    {
+        return $this->isStaticCallChain($expr) ? Severity::High : Severity::Medium;
     }
 
     /**

--- a/tests/Unit/Analyzers/BestPractices/ChunkMissingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ChunkMissingAnalyzerTest.php
@@ -1195,4 +1195,112 @@ PHP;
         $this->assertFailed($result);
         $this->assertHasIssueContaining('get()', $result);
     }
+
+    public function test_downgrades_relationship_accessor_read_to_warning(): void
+    {
+        // A read rooted at an instance relationship accessor ($order->lineItems()) reads one
+        // parent's children — far more often bounded than a table-wide scan — so it is a warning,
+        // not a hard failure.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Order;
+
+class OrderService
+{
+    public function totals(Order $order): void
+    {
+        foreach ($order->lineItems()->get() as $line) {
+            // sum each line
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/OrderService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('get()', $result);
+    }
+
+    public function test_downgrades_variable_assigned_relationship_read_to_warning(): void
+    {
+        // Same downgrade applies when the relationship read is assigned to a variable first.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Order;
+
+class OrderService
+{
+    public function totals(Order $order): void
+    {
+        $lines = $order->lineItems()->get();
+        foreach ($lines as $line) {
+            // sum each line
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/OrderService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $this->assertHasIssueContaining('variable', $result);
+    }
+
+    public function test_static_scan_still_fails_when_mixed_with_relationship_read(): void
+    {
+        // A table-wide Model::all() scan stays High, so a file mixing it with a downgraded
+        // relationship read still fails overall (High dominates).
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Order;
+use App\Models\User;
+
+class ReportService
+{
+    public function build(Order $order): void
+    {
+        foreach (User::all() as $user) {
+            // process user
+        }
+
+        foreach ($order->lineItems()->get() as $line) {
+            // sum each line
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/ReportService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertCount(2, $result->getIssues());
+    }
 }


### PR DESCRIPTION
## What

`foreach ($model->relation()->get() as ...)` was flagged at **High** (a hard failure) just like a table-wide scan. `resolveChainRootTable()` can't resolve an instance-accessor root, so the seeded-catalogue exemption never applied.

At the AST level an instance-rooted read is indistinguishable from a genuinely-unbounded one (`$user->orders()->get()`), but one parent's child set is far more often bounded than a `Model::`/`DB::table()` scan. So instead of proving boundedness (fragile, needs migration unique-key + relationship-target + FK→catalogue inference), this downgrades confidence.

## How

- `severityFor()` (reuses existing `isStaticCallChain()`): instance-rooted reads emit `Severity::Medium` → **warning**; table-wide `Model::`/`DB::table()` scans stay **High**.
- A file mixing both still fails — `resultBySeverity()` returns failed when any issue is ≥High.

## Tests

3 added (relationship read → warning; variable-assigned → warning; mixed file → still fails). Full suite green: 4264 passed, PHPStan L9 clean, Pint clean. No existing should-fail test changes status (all are `Model::`/`DB::table()`-rooted).