### PR TITLE
docs(changelog): add v1.9.2 entry for chunk-missing relationship-read downgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.9.2
+
+### Fixed
+- `ChunkMissingAnalyzer` now downgrades single-parent relationship-accessor reads (`$model->relation()->get()`) from a failure to a warning, since one parent's child set is far more often bounded than a table-wide `Model::`/`DB::table()` scan (#256)
+
 ## v1.9.1
 
 ### Fixed


### PR DESCRIPTION
Adds the `v1.9.2` CHANGELOG entry for the `chunk-missing` fix merged in #256 (single-parent relationship-accessor reads downgraded from failure to warning).