### PR TITLE
fix(cookie): detect EncryptCookies in the Laravel 11+ web middleware group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.9.3
 
 ### Fixed
-- `CookieSecurityAnalyzer` no longer reports EncryptCookies as "not registered" when it lives in the Laravel 11+ default `web` middleware group — the runtime check now inspects middleware groups (via `appUsesGroupMiddleware`), not just the global stack and route middleware — and no longer flags a `bootstrap/app.php` that omits an explicit EncryptCookies reference, which is the framework's normal secure default (#258)
+- `CookieSecurityAnalyzer` no longer reports EncryptCookies as "not registered" when it's in the Laravel 11+ default `web` middleware group (#258)
 
 ## v1.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.9.3
+
+### Fixed
+- `CookieSecurityAnalyzer` no longer reports EncryptCookies as "not registered" when it lives in the Laravel 11+ default `web` middleware group — the runtime check now inspects middleware groups (via `appUsesGroupMiddleware`), not just the global stack and route middleware — and no longer flags a `bootstrap/app.php` that omits an explicit EncryptCookies reference, which is the framework's normal secure default (#258)
+
 ## v1.9.2
 
 ### Fixed

--- a/src/Analyzers/Security/CookieSecurityAnalyzer.php
+++ b/src/Analyzers/Security/CookieSecurityAnalyzer.php
@@ -7,16 +7,10 @@ namespace ShieldCI\Analyzers\Security;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Router;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
-use PhpParser\Node\Scalar\String_;
-use PhpParser\NodeFinder;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
-use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
@@ -190,12 +184,10 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
         $kernelFile = $this->buildPath('app', 'Http', 'Kernel.php');
 
         if (! file_exists($kernelFile)) {
-            // Check bootstrap/app.php for Laravel 11+
-            $bootstrapApp = $this->buildPath('bootstrap', 'app.php');
-            if (file_exists($bootstrapApp)) {
-                $this->checkBootstrapApp($bootstrapApp, $issues);
-            }
-
+            // No app/Http/Kernel.php means a Laravel 11+ app, where EncryptCookies
+            // ships in the framework-default `web` middleware group. The runtime
+            // check above is the authoritative signal; a missing static reference
+            // in bootstrap/app.php is the normal, secure default, not a problem.
             return;
         }
 
@@ -323,6 +315,17 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
                 }
 
                 if (! $isRegistered) {
+                    // Laravel 11+ registers EncryptCookies in the default `web` middleware
+                    // group rather than the global stack, so inspect groups before failing.
+                    foreach ($encryptCookiesClasses as $middlewareClass) {
+                        if ($this->appUsesGroupMiddleware($middlewareClass)) {
+                            $isRegistered = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (! $isRegistered) {
                     // Check if it's registered on any route (less ideal but still acceptable)
                     try {
                         $isRegistered = $this->appUsesMiddleware('Illuminate\Cookie\Middleware\EncryptCookies');
@@ -339,11 +342,11 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
                     $configFile = file_exists($kernelFile) ? $kernelFile : (file_exists($bootstrapApp) ? $bootstrapApp : $kernelFile);
 
                     $issues[] = $this->createIssueWithSnippet(
-                        message: 'EncryptCookies middleware is not registered globally',
+                        message: 'EncryptCookies middleware is not registered',
                         filePath: $configFile,
                         lineNumber: null,
                         severity: Severity::Critical,
-                        recommendation: 'Register EncryptCookies middleware globally in app/Http/Kernel.php (Laravel 9/10) or bootstrap/app.php (Laravel 11+) to enable cookie encryption',
+                        recommendation: 'Without EncryptCookies, cookies are stored in plaintext and can be read or tampered with by the client. Register it so the app encrypts cookies — in the web middleware group (the Laravel 11+ default) or the global middleware stack in app/Http/Kernel.php (Laravel 9/10).',
                         metadata: [
                             'file' => file_exists($kernelFile) ? 'Kernel.php' : 'bootstrap/app.php',
                             'middleware' => 'EncryptCookies',
@@ -362,79 +365,6 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
         } catch (\Throwable $e) {
             // If runtime check fails for any reason, fall back to file-based checks
             return false;
-        }
-    }
-
-    /**
-     * Check bootstrap/app.php for Laravel 11+ applications using AST.
-     * This is a fallback when runtime checks aren't available.
-     */
-    private function checkBootstrapApp(string $file, array &$issues): void
-    {
-        $astParser = new AstParser;
-        $ast = $astParser->parseFile($file);
-
-        if ($ast === []) {
-            return;
-        }
-
-        $nodeFinder = new NodeFinder;
-        $hasEncryptCookies = false;
-
-        // Look for method calls named encryptCookies/EncryptCookies (e.g. $middleware->encryptCookies())
-        /** @var MethodCall[] $methodCalls */
-        $methodCalls = $nodeFinder->findInstanceOf($ast, MethodCall::class);
-
-        foreach ($methodCalls as $call) {
-            if ($call->name instanceof Identifier
-                && strtolower($call->name->name) === 'encryptcookies'
-            ) {
-                $hasEncryptCookies = true;
-                break;
-            }
-        }
-
-        // Look for EncryptCookies class name references (e.g. EncryptCookies::class)
-        if (! $hasEncryptCookies) {
-            /** @var Name[] $names */
-            $names = $nodeFinder->findInstanceOf($ast, Name::class);
-
-            foreach ($names as $name) {
-                if (str_contains($name->toString(), 'EncryptCookies')) {
-                    $hasEncryptCookies = true;
-                    break;
-                }
-            }
-        }
-
-        // Look for string references to EncryptCookies (e.g. 'EncryptCookies' as argument)
-        if (! $hasEncryptCookies) {
-            /** @var String_[] $strings */
-            $strings = $nodeFinder->findInstanceOf($ast, String_::class);
-
-            foreach ($strings as $string) {
-                if (str_contains($string->value, 'EncryptCookies') || str_contains($string->value, 'encryptCookies')) {
-                    $hasEncryptCookies = true;
-                    break;
-                }
-            }
-        }
-
-        if (! $hasEncryptCookies) {
-            $issues[] = $this->createIssueWithSnippet(
-                message: 'EncryptCookies middleware may not be properly configured in bootstrap/app.php',
-                filePath: $file,
-                lineNumber: null,
-                severity: Severity::High,
-                recommendation: 'Register the EncryptCookies middleware via the middleware configuration in bootstrap/app.php to enable cookie encryption.',
-                metadata: [
-                    'file' => 'bootstrap/app.php',
-                    'laravel_version' => '11+',
-                    'middleware' => 'EncryptCookies',
-                    'detection_method' => 'file_analysis',
-                    'code' => 'encrypt-cookies',
-                ]
-            );
         }
     }
 

--- a/src/Concerns/AnalyzesMiddleware.php
+++ b/src/Concerns/AnalyzesMiddleware.php
@@ -133,6 +133,43 @@ trait AnalyzesMiddleware
     }
 
     /**
+     * Determine if the application registers the given middleware in any middleware group.
+     *
+     * Laravel 11+ ships EncryptCookies (and the rest of the web stack) inside the
+     * default `web` middleware group rather than the global stack, so detecting such
+     * middleware requires inspecting groups, not just global/route middleware.
+     */
+    protected function appUsesGroupMiddleware(string $middlewareClass): bool
+    {
+        $groups = $this->router->getMiddlewareGroups();
+
+        if (! is_array($groups)) {
+            return false;
+        }
+
+        foreach ($groups as $middlewareList) {
+            if (! is_array($middlewareList)) {
+                continue;
+            }
+
+            foreach ($middlewareList as $middleware) {
+                if (! is_string($middleware)) {
+                    continue;
+                }
+
+                $name = Str::before($middleware, ':');
+
+                if ($name === $middlewareClass
+                    || (class_exists($middlewareClass) && is_subclass_of($name, $middlewareClass))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Determine if the route uses the provided middleware.
      *
      * @param  Route  $route

--- a/tests/Unit/Analyzers/Security/CookieSecurityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/CookieSecurityAnalyzerTest.php
@@ -667,8 +667,11 @@ PHP;
         $this->assertPassed($result);
     }
 
-    public function test_warns_when_laravel_11_encrypt_cookies_missing(): void
+    public function test_passes_when_laravel_11_bootstrap_app_omits_encrypt_cookies(): void
     {
+        // A standard Laravel 11+ app never references EncryptCookies in bootstrap/app.php:
+        // it ships in the framework-default `web` middleware group. Absence of a static
+        // reference is the normal, secure state, not a missing-middleware problem.
         $bootstrapApp = <<<'PHP'
 <?php
 
@@ -688,8 +691,29 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $this->assertFailed($result);
-        $this->assertHasIssueContaining('EncryptCookies middleware may not be properly configured', $result);
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_at_runtime_when_encrypt_cookies_is_in_web_group_only(): void
+    {
+        // Regression: Laravel 11+ registers EncryptCookies in the framework-default
+        // `web` middleware group, not the global stack. Pointing the analyzer at the
+        // real booted app (base paths match, so the runtime check actually runs) must
+        // NOT report "not registered" — group registration counts as registered.
+        $app = $this->app;
+        $this->assertNotNull($app);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($app->basePath());
+
+        $result = $analyzer->analyze();
+
+        // The runtime check finds EncryptCookies in the `web` group, so no
+        // cookie-encryption issue is raised.
+        $this->assertPassed($result);
+        foreach ($result->getIssues() as $issue) {
+            $this->assertStringNotContainsString('EncryptCookies', $issue->message);
+        }
     }
 
     // ==================== EDGE CASES ====================

--- a/tests/Unit/Concerns/AnalyzesMiddlewareTest.php
+++ b/tests/Unit/Concerns/AnalyzesMiddlewareTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ShieldCI\Tests\Unit\Concerns;
 
 use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
@@ -263,6 +264,56 @@ class AnalyzesMiddlewareTest extends TestCase
 
         $this->assertIsArray($groups);
         $this->assertNotContains('custom-api', $groups);
+    }
+
+    // =========================================================================
+    // appUsesGroupMiddleware()
+    // =========================================================================
+
+    /** @test */
+    #[Test]
+    public function app_uses_group_middleware_detects_middleware_in_a_group(): void
+    {
+        // Laravel 11+ ships EncryptCookies in the default `web` group, not the
+        // global stack — this is the registration the analyzer must detect.
+        $router = $this->getRouter();
+        $router->middlewareGroup('web', [EncryptCookies::class]);
+
+        $class = $this->createMiddlewareAnalyzerClass();
+
+        $this->assertTrue($class->publicAppUsesGroupMiddleware(EncryptCookies::class));
+    }
+
+    /** @test */
+    #[Test]
+    public function app_uses_group_middleware_returns_false_when_absent_from_all_groups(): void
+    {
+        $router = $this->getRouter();
+        $router->middlewareGroup('web', [StartSession::class]);
+
+        $class = $this->createMiddlewareAnalyzerClass();
+
+        // A middleware registered in no group must not be reported as present.
+        $this->assertFalse($class->publicAppUsesGroupMiddleware('App\Http\Middleware\NeverRegisteredMiddleware'));
+    }
+
+    /** @test */
+    #[Test]
+    public function app_uses_group_middleware_matches_a_subclass(): void
+    {
+        // A custom App\Http\Middleware\EncryptCookies extending the framework one
+        // should still be detected when queried by the parent class.
+        $subclass = new class extends EncryptCookies
+        {
+            public function __construct() {} // avoid DI requirements
+        };
+
+        $router = $this->getRouter();
+        $router->middlewareGroup('web', [$subclass::class]);
+
+        $class = $this->createMiddlewareAnalyzerClass();
+
+        $this->assertTrue($class->publicAppUsesGroupMiddleware(EncryptCookies::class));
     }
 
     // =========================================================================
@@ -545,6 +596,11 @@ class AnalyzesMiddlewareTest extends TestCase
             public function publicAppUsesGlobalMiddleware(string $class): bool
             {
                 return $this->appUsesGlobalMiddleware($class);
+            }
+
+            public function publicAppUsesGroupMiddleware(string $class): bool
+            {
+                return $this->appUsesGroupMiddleware($class);
             }
 
             public function publicGetMiddleware(Route $route): array

--- a/tests/Unit/Concerns/AnalyzesMiddlewareTest.php
+++ b/tests/Unit/Concerns/AnalyzesMiddlewareTest.php
@@ -316,6 +316,52 @@ class AnalyzesMiddlewareTest extends TestCase
         $this->assertTrue($class->publicAppUsesGroupMiddleware(EncryptCookies::class));
     }
 
+    /** @test */
+    #[Test]
+    public function app_uses_group_middleware_returns_false_when_groups_is_not_an_array(): void
+    {
+        // getMiddlewareGroups() is documented `@return array` but is untyped, so the
+        // method guards against a malformed (non-array) value rather than crashing.
+        // Mutate after the wrapper is built so the kernel's middleware sync can't
+        // repopulate the groups before the assertion runs.
+        $class = $this->createMiddlewareAnalyzerClass();
+        $this->setRouterMiddlewareGroups('not-an-array');
+
+        $this->assertFalse($class->publicAppUsesGroupMiddleware(EncryptCookies::class));
+    }
+
+    /** @test */
+    #[Test]
+    public function app_uses_group_middleware_skips_groups_with_a_non_array_value(): void
+    {
+        $class = $this->createMiddlewareAnalyzerClass();
+        $this->setRouterMiddlewareGroups(['web' => 'not-an-array']);
+
+        $this->assertFalse($class->publicAppUsesGroupMiddleware(EncryptCookies::class));
+    }
+
+    /** @test */
+    #[Test]
+    public function app_uses_group_middleware_skips_non_string_group_members(): void
+    {
+        // A non-string member (here an int) is skipped — proving the guard continues
+        // instead of crashing on Str::before() — and a real class after it still matches.
+        $class = $this->createMiddlewareAnalyzerClass();
+        $this->setRouterMiddlewareGroups(['web' => [123, EncryptCookies::class]]);
+
+        $this->assertTrue($class->publicAppUsesGroupMiddleware(EncryptCookies::class));
+    }
+
+    /**
+     * Overwrite the router singleton's middleware groups with arbitrary (possibly
+     * malformed) data to exercise the defensive guards in appUsesGroupMiddleware().
+     */
+    private function setRouterMiddlewareGroups(mixed $groups): void
+    {
+        $router = $this->getRouter();
+        (new \ReflectionProperty($router, 'middlewareGroups'))->setValue($router, $groups);
+    }
+
     // =========================================================================
     // hasSessionInGlobalMiddleware()
     // =========================================================================


### PR DESCRIPTION
## Problem

`CookieSecurityAnalyzer` reported a **Critical** false positive — "EncryptCookies middleware is not registered globally" — on standard Laravel 11+ apps (seen on a real Laravel 13 consumer). Cookie encryption *is* active: Laravel 11+ ships `EncryptCookies` in the framework-default **`web` middleware group**, not the global stack, and the analyzer never inspected groups.

## Fix

- **`AnalyzesMiddleware`**: add `appUsesGroupMiddleware()`, inspecting `router->getMiddlewareGroups()` (reuses the same pattern as `getGroupsContainingSession()`).
- **`CookieSecurityAnalyzer`**: the runtime check now consults middleware groups between the global-stack and route-fallback checks; reframed message/recommendation off "globally"; removed the unsound `checkBootstrapApp()` fallback — absence of an `EncryptCookies` string in `bootstrap/app.php` is the normal, secure Laravel 11+ default.

## Tests

Deterministic trait tests for group detection (present/absent/subclass) and an end-to-end runtime test against the booted app (EncryptCookies in `web` group only → passes). Flipped the old Laravel-11 "missing-warns" test to assert a pass.

`composer check` clean: Pint, PHPStan Level 9, 4268 tests pass.