### PR TITLE
fix(cookie): read middleware groups from the kernel, not the router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.9.4
+
+### Fixed
+- `CookieSecurityAnalyzer` no longer reports a false EncryptCookies "not registered" on Laravel 11+ apps that keep it in the default `web` middleware group when running the full analyzer suite — middleware-group detection now reads the HTTP kernel's groups, which the framework retains even when the router's are reset mid-run (#259)
+
 ## v1.9.3
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.9.4
 
 ### Fixed
-- `CookieSecurityAnalyzer` no longer reports a false EncryptCookies "not registered" on Laravel 11+ apps that keep it in the default `web` middleware group when running the full analyzer suite — middleware-group detection now reads the HTTP kernel's groups, which the framework retains even when the router's are reset mid-run (#259)
+- `CookieSecurityAnalyzer`: completes the v1.9.3 `web`-group fix, which still misfired during a full `shield:analyze` run — group detection now reads the HTTP kernel's middleware groups instead of the router's, which the analyzer suite resets mid-run (#259)
 
 ## v1.9.3
 

--- a/src/Concerns/AnalyzesMiddleware.php
+++ b/src/Concerns/AnalyzesMiddleware.php
@@ -141,22 +141,8 @@ trait AnalyzesMiddleware
      */
     protected function appUsesGroupMiddleware(string $middlewareClass): bool
     {
-        $groups = $this->router->getMiddlewareGroups();
-
-        if (! is_array($groups)) {
-            return false;
-        }
-
-        foreach ($groups as $middlewareList) {
-            if (! is_array($middlewareList)) {
-                continue;
-            }
-
+        foreach ($this->getMiddlewareGroups() as $middlewareList) {
             foreach ($middlewareList as $middleware) {
-                if (! is_string($middleware)) {
-                    continue;
-                }
-
                 $name = Str::before($middleware, ':');
 
                 if ($name === $middlewareClass
@@ -167,6 +153,58 @@ trait AnalyzesMiddleware
         }
 
         return false;
+    }
+
+    /**
+     * Get the application's middleware groups, preferring the HTTP kernel's view and
+     * merging in the router's.
+     *
+     * Laravel 11+ attaches the framework-default web/api middleware (EncryptCookies,
+     * StartSession, …) to the router lazily, via the one-time afterResolving(HttpKernel)
+     * callback. A runner that snapshots and restores the router's middleware maps — to
+     * keep provider overrides intact — can revert the router to a pre-resolution state
+     * missing those defaults, so the router alone is unreliable. The kernel keeps the
+     * defaults regardless, while the router still contributes any Route::middlewareGroup()
+     * registrations; a middleware present in either source counts.
+     *
+     * @return array<string, array<int, string>>
+     */
+    protected function getMiddlewareGroups(): array
+    {
+        $groups = $this->normalizeMiddlewareGroups($this->router->getMiddlewareGroups());
+
+        if (method_exists($this->kernel, 'getMiddlewareGroups')) {
+            /** @phpstan-ignore-next-line method.notFound */
+            foreach ($this->normalizeMiddlewareGroups($this->kernel->getMiddlewareGroups()) as $name => $list) {
+                $merged = array_merge($groups[$name] ?? [], $list);
+                $groups[$name] = array_values(array_unique($merged));
+            }
+        }
+
+        return $groups;
+    }
+
+    /**
+     * Coerce a raw middleware-group map into <string group name, list<string middleware>>,
+     * dropping malformed entries so callers can iterate without per-element guards.
+     *
+     * @return array<string, array<int, string>>
+     */
+    private function normalizeMiddlewareGroups(mixed $groups): array
+    {
+        if (! is_array($groups)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($groups as $name => $list) {
+            if (is_string($name) && is_array($list)) {
+                $normalized[$name] = array_values(array_filter($list, 'is_string'));
+            }
+        }
+
+        return $normalized;
     }
 
     /**
@@ -330,24 +368,10 @@ trait AnalyzesMiddleware
      */
     protected function getGroupsContainingSession(): array
     {
-        $groups = $this->router->getMiddlewareGroups();
-
-        if (! is_array($groups)) {
-            return [];
-        }
-
         $sessionGroups = [];
 
-        foreach ($groups as $groupName => $middlewareList) {
-            if (! is_string($groupName) || ! is_array($middlewareList)) {
-                continue;
-            }
-
+        foreach ($this->getMiddlewareGroups() as $groupName => $middlewareList) {
             foreach ($middlewareList as $middleware) {
-                if (! is_string($middleware)) {
-                    continue;
-                }
-
                 if ($this->isStartSessionMiddleware(Str::before($middleware, ':'))) {
                     $sessionGroups[] = $groupName;
                     break;

--- a/tests/Unit/Concerns/AnalyzesMiddlewareTest.php
+++ b/tests/Unit/Concerns/AnalyzesMiddlewareTest.php
@@ -321,13 +321,13 @@ class AnalyzesMiddlewareTest extends TestCase
     public function app_uses_group_middleware_returns_false_when_groups_is_not_an_array(): void
     {
         // getMiddlewareGroups() is documented `@return array` but is untyped, so the
-        // method guards against a malformed (non-array) value rather than crashing.
-        // Mutate after the wrapper is built so the kernel's middleware sync can't
-        // repopulate the groups before the assertion runs.
+        // normalizer guards against a malformed (non-array) router value rather than
+        // crashing. Query a class registered in no group (the kernel's real groups are
+        // still merged in) to assert the malformed router input is simply ignored.
         $class = $this->createMiddlewareAnalyzerClass();
         $this->setRouterMiddlewareGroups('not-an-array');
 
-        $this->assertFalse($class->publicAppUsesGroupMiddleware(EncryptCookies::class));
+        $this->assertFalse($class->publicAppUsesGroupMiddleware('App\Http\Middleware\NeverRegisteredMiddleware'));
     }
 
     /** @test */
@@ -337,7 +337,7 @@ class AnalyzesMiddlewareTest extends TestCase
         $class = $this->createMiddlewareAnalyzerClass();
         $this->setRouterMiddlewareGroups(['web' => 'not-an-array']);
 
-        $this->assertFalse($class->publicAppUsesGroupMiddleware(EncryptCookies::class));
+        $this->assertFalse($class->publicAppUsesGroupMiddleware('App\Http\Middleware\NeverRegisteredMiddleware'));
     }
 
     /** @test */
@@ -360,6 +360,120 @@ class AnalyzesMiddlewareTest extends TestCase
     {
         $router = $this->getRouter();
         (new \ReflectionProperty($router, 'middlewareGroups'))->setValue($router, $groups);
+    }
+
+    /** @test */
+    #[Test]
+    public function app_uses_group_middleware_reads_from_kernel_when_router_groups_are_wiped(): void
+    {
+        // Regression: a runner that snapshots/restores the router's middleware maps can
+        // leave the web group without its lazily-attached framework defaults. The kernel
+        // retains them, so group detection must consult the kernel — not the router alone.
+        $kernel = new class
+        {
+            /** @return array<string, array<int, string>> */
+            public function getMiddlewareGroups(): array
+            {
+                return ['web' => [EncryptCookies::class]];
+            }
+        };
+
+        $class = $this->createMiddlewareAnalyzerClassWithKernel($kernel);
+        $this->setRouterMiddlewareGroups([]); // router has no web group at all
+
+        $this->assertTrue($class->publicAppUsesGroupMiddleware(EncryptCookies::class));
+    }
+
+    /** @test */
+    #[Test]
+    public function app_uses_group_middleware_falls_back_to_router_when_kernel_lacks_method(): void
+    {
+        // Older Laravel HTTP kernels expose no getMiddlewareGroups(); detection then
+        // relies solely on the router's groups.
+        $kernel = new class
+        {
+            // intentionally no getMiddlewareGroups()
+        };
+
+        $class = $this->createMiddlewareAnalyzerClassWithKernel($kernel);
+        $this->setRouterMiddlewareGroups(['web' => [EncryptCookies::class]]);
+
+        $this->assertTrue($class->publicAppUsesGroupMiddleware(EncryptCookies::class));
+    }
+
+    /** @test */
+    #[Test]
+    public function get_middleware_groups_skips_non_string_group_names(): void
+    {
+        // Numeric/empty keys (possible in a raw, untyped group map) are dropped so callers
+        // that key on the group name — e.g. getGroupsContainingSession() — stay well-typed.
+        $kernel = new class
+        {
+            /** @return array<int, array<int, string>> */
+            public function getMiddlewareGroups(): array
+            {
+                return [0 => [StartSession::class]];
+            }
+        };
+
+        $class = $this->createMiddlewareAnalyzerClassWithKernel($kernel);
+        $this->setRouterMiddlewareGroups([]);
+
+        $this->assertSame([], $class->publicGetMiddlewareGroups());
+    }
+
+    /** @test */
+    #[Test]
+    public function get_groups_containing_session_reads_from_kernel(): void
+    {
+        // The session-group path uses the same kernel-preferred source, so a kernel-only
+        // web group (router wiped) is still recognized as session-bearing.
+        $kernel = new class
+        {
+            /** @return array<string, array<int, string>> */
+            public function getMiddlewareGroups(): array
+            {
+                return ['web' => [StartSession::class]];
+            }
+        };
+
+        $class = $this->createMiddlewareAnalyzerClassWithKernel($kernel);
+        $this->setRouterMiddlewareGroups([]);
+
+        $this->assertSame(['web'], $class->publicGetGroupsContainingSession());
+    }
+
+    /**
+     * Build the middleware-analyzer wrapper with a caller-supplied kernel, so tests can
+     * control kernel->getMiddlewareGroups() independently of the router (including a kernel
+     * without that method, which exercises the older-Laravel router-only path).
+     */
+    private function createMiddlewareAnalyzerClassWithKernel(object $kernel): object
+    {
+        $router = $this->getRouter();
+
+        return new class($router, $kernel)
+        {
+            use AnalyzesMiddleware;
+
+            public function __construct(protected Router $router, protected $kernel) {}
+
+            public function publicAppUsesGroupMiddleware(string $class): bool
+            {
+                return $this->appUsesGroupMiddleware($class);
+            }
+
+            public function publicGetGroupsContainingSession(): array
+            {
+                return $this->getGroupsContainingSession();
+            }
+
+            /** @return array<string, array<int, string>> */
+            public function publicGetMiddlewareGroups(): array
+            {
+                return $this->getMiddlewareGroups();
+            }
+        };
     }
 
     // =========================================================================


### PR DESCRIPTION
## Problem

`CookieSecurityAnalyzer` still reported a **Critical** false positive — EncryptCookies "not registered" — on Laravel 11+ apps that keep it in the default `web` group, when run via the full analyzer suite. The #258 fix works in isolation but is defeated at runtime.

## Root cause

- Laravel 11+ attaches the framework-default `web` group middleware (EncryptCookies, StartSession) to the **router** lazily, via the one-time `afterResolving(HttpKernel)` callback.
- `AnalyzerManager::getAllInstances()` (`AnalyzerManager.php:151-188`) **snapshots the router's middleware maps before that callback fires, then restores them** (to protect provider overrides). This reverts the `web` group to a pre-resolution state without EncryptCookies; the cached kernel never re-fires the callback.
- #258 read `$router->getMiddlewareGroups()` → missed EncryptCookies → false positive.

Validated against Compass: router-only sees *no* EncryptCookies post-restore; kernel-merged sees it.

## Fix

`AnalyzesMiddleware` now resolves groups via a kernel-preferred `getMiddlewareGroups()` helper that merges the HTTP kernel's groups (authoritative, untouched by the router restore) with the router's (for `Route::middlewareGroup()` registrations). Both `appUsesGroupMiddleware()` and the session-group path (`getGroupsContainingSession()`) use it.

## Tests

Regression test (kernel has the group, router wiped → detected), older-Laravel router-only fallback, session-from-kernel, and normalizer guard coverage. `composer check` clean: Pint, PHPStan Level 9, 4275 tests.