### PR TITLE
fix(missing-database-transactions): resolve transaction delegation transitively

### DIFF
--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -925,11 +925,20 @@ class TransactionVisitor extends NodeVisitorAbstract
 }
 
 /**
- * Pre-scan visitor that identifies private/protected methods exclusively called
- * from within DB::transaction() closures in the same class.
+ * Pre-scan visitor that identifies methods whose every execution path runs
+ * inside a DB::transaction() — and which therefore should not be flagged for
+ * missing transaction protection.
  *
- * These "transaction-delegated" methods should not be flagged for missing
- * transaction protection because every execution path runs inside a transaction.
+ * Protection is resolved transitively over the intra-class `$this->method()`
+ * call graph. A method is "delegated" when, for every call site:
+ *   - the call sits lexically inside a DB::transaction() closure, OR
+ *   - the caller is itself a delegated *private/protected* method (so it has
+ *     no externally-reachable entry point that could bypass the transaction).
+ *
+ * The visibility gate matters only for transitive propagation: a public
+ * intermediary may be invoked externally without a transaction, so protection
+ * never flows *through* it. A method whose call sites are *all* directly inside
+ * transaction closures is delegated regardless of its own visibility.
  */
 class TransactionDelegatedMethodScanner extends NodeVisitorAbstract
 {
@@ -938,14 +947,26 @@ class TransactionDelegatedMethodScanner extends NodeVisitorAbstract
 
     private int $transactionDepth = 0;
 
-    /** @var array<string, true> Method names called from within a transaction closure. */
-    private array $calledInsideTransaction = [];
+    private ?string $currentMethodName = null;
 
-    /** @var array<string, true> Method names called outside any transaction closure. */
-    private array $calledOutsideTransaction = [];
+    /** @var array<string, bool> Method name → whether it is declared private or protected. */
+    private array $methodIsHidden = [];
+
+    /**
+     * Intra-class call edges keyed by callee method name.
+     *
+     * @var array<string, list<array{caller: string|null, inTx: bool}>>
+     */
+    private array $edgesByCallee = [];
 
     public function enterNode(Node $node): ?Node
     {
+        // Track the method we are currently inside (and its visibility).
+        if ($node instanceof Node\Stmt\ClassMethod) {
+            $this->currentMethodName = $node->name->toString();
+            $this->methodIsHidden[$this->currentMethodName] = $node->isPrivate() || $node->isProtected();
+        }
+
         // Record closures passed directly to DB::transaction().
         if ($node instanceof Node\Expr\StaticCall
             && $node->class instanceof Node\Name
@@ -967,19 +988,17 @@ class TransactionDelegatedMethodScanner extends NodeVisitorAbstract
             }
         }
 
-        // Collect $this->method() calls and partition by transaction context.
+        // Record each $this->method() call edge with its caller and transaction context.
         if (
             $node instanceof Node\Expr\MethodCall
             && $node->var instanceof Node\Expr\Variable
             && $node->var->name === 'this'
             && $node->name instanceof Node\Identifier
         ) {
-            $methodName = $node->name->toString();
-            if ($this->transactionDepth > 0) {
-                $this->calledInsideTransaction[$methodName] = true;
-            } else {
-                $this->calledOutsideTransaction[$methodName] = true;
-            }
+            $this->edgesByCallee[$node->name->toString()][] = [
+                'caller' => $this->currentMethodName,
+                'inTx' => $this->transactionDepth > 0,
+            ];
         }
 
         return null;
@@ -987,6 +1006,10 @@ class TransactionDelegatedMethodScanner extends NodeVisitorAbstract
 
     public function leaveNode(Node $node): ?Node
     {
+        if ($node instanceof Node\Stmt\ClassMethod) {
+            $this->currentMethodName = null;
+        }
+
         if ($node instanceof Node\Expr\Closure || $node instanceof Node\Expr\ArrowFunction) {
             if (isset($this->transactionClosurePositions[$node->getStartFilePos()]) && $this->transactionDepth > 0) {
                 $this->transactionDepth--;
@@ -997,13 +1020,57 @@ class TransactionDelegatedMethodScanner extends NodeVisitorAbstract
     }
 
     /**
-     * Returns method names that are called exclusively from within DB::transaction() closures.
+     * Returns method names whose every call path runs inside a transaction,
+     * resolved to a fixed point over the intra-class call graph.
      *
      * @return array<string, true>
      */
     public function getDelegatedMethods(): array
     {
-        return array_diff_key($this->calledInsideTransaction, $this->calledOutsideTransaction);
+        /** @var array<string, true> $delegated */
+        $delegated = [];
+
+        do {
+            $changed = false;
+
+            foreach ($this->edgesByCallee as $callee => $edges) {
+                if (isset($delegated[$callee])) {
+                    continue;
+                }
+
+                $allInTx = true;
+                $allProtected = true;
+
+                foreach ($edges as $edge) {
+                    if ($edge['inTx']) {
+                        continue;
+                    }
+                    $allInTx = false;
+
+                    // A non-transaction edge is only protected when the caller is
+                    // itself a delegated private/protected method (no external entry).
+                    $caller = $edge['caller'];
+                    $safeCaller = $caller !== null
+                        && isset($delegated[$caller])
+                        && ($this->methodIsHidden[$caller] ?? false);
+
+                    if (! $safeCaller) {
+                        $allProtected = false;
+                    }
+                }
+
+                // Direct case: every call site is inside a transaction closure
+                // (preserves prior behavior, regardless of the callee's visibility).
+                // Transitive case: protection only propagates to a private/protected
+                // callee, since a public callee may be reached externally without one.
+                if ($allInTx || ($allProtected && ($this->methodIsHidden[$callee] ?? false))) {
+                    $delegated[$callee] = true;
+                    $changed = true;
+                }
+            }
+        } while ($changed);
+
+        return $delegated;
     }
 }
 

--- a/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzerTest.php
@@ -2054,6 +2054,202 @@ PHP;
         $this->assertPassed($result);
     }
 
+    public function test_passes_when_writes_in_transitively_delegated_private_helper(): void
+    {
+        // Two-hop delegation: the public orchestrator opens the transaction and
+        // delegates to a private helper, which in turn delegates the actual writes
+        // to a second private helper. Every path runs inside the transaction.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Account;
+use Illuminate\Support\Facades\DB;
+
+class AccountCloser
+{
+    public function close(Account $account): void
+    {
+        DB::transaction(function () use ($account): void {
+            $this->settleBalances($account);
+            $account->delete();
+        });
+    }
+
+    private function settleBalances(Account $account): void
+    {
+        $this->writeOffLedger($account);
+    }
+
+    private function writeOffLedger(Account $account): void
+    {
+        DB::table('ledgers')->where('account_id', $account->id)->update(['written_off' => true]);
+        $account->entries()->delete();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/AccountCloser.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_when_writes_in_three_hop_delegated_chain(): void
+    {
+        // a -> b -> c, all private; the transaction is opened only at the public
+        // entry point. Proves the fixed point converges beyond two levels.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Account;
+use Illuminate\Support\Facades\DB;
+
+class AccountCloser
+{
+    public function close(Account $account): void
+    {
+        DB::transaction(function () use ($account): void {
+            $this->stepA($account);
+        });
+    }
+
+    private function stepA(Account $account): void
+    {
+        $this->stepB($account);
+    }
+
+    private function stepB(Account $account): void
+    {
+        $this->stepC($account);
+    }
+
+    private function stepC(Account $account): void
+    {
+        $account->update(['status' => 'closed']);
+        $account->entries()->delete();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/AccountCloser.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_flags_transitively_delegated_helper_also_reached_without_transaction(): void
+    {
+        // The helper is reachable transitively from a transaction AND directly from
+        // a second entry point that has no transaction. The unprotected path must
+        // still be flagged.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Account;
+use Illuminate\Support\Facades\DB;
+
+class AccountService
+{
+    public function closeWithTransaction(Account $account): void
+    {
+        DB::transaction(function () use ($account): void {
+            $this->settle($account);
+        });
+    }
+
+    public function purgeWithoutTransaction(Account $account): void
+    {
+        $this->writeOffLedger($account);
+    }
+
+    private function settle(Account $account): void
+    {
+        $this->writeOffLedger($account);
+    }
+
+    private function writeOffLedger(Account $account): void
+    {
+        $account->update(['written_off' => true]);
+        $account->entries()->delete();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/AccountService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('database write operation(s) outside transaction protection', $result);
+    }
+
+    public function test_flags_helper_delegated_only_through_public_intermediary(): void
+    {
+        // The transaction wraps a call to a PUBLIC intermediary. Because that
+        // intermediary can be invoked externally without a transaction, protection
+        // must not propagate to the private leaf it calls.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Account;
+use Illuminate\Support\Facades\DB;
+
+class AccountService
+{
+    public function entry(Account $account): void
+    {
+        DB::transaction(function () use ($account): void {
+            $this->mid($account);
+        });
+    }
+
+    public function mid(Account $account): void
+    {
+        $this->leaf($account);
+    }
+
+    private function leaf(Account $account): void
+    {
+        $account->update(['status' => 'closed']);
+        $account->entries()->delete();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/AccountService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('database write operation(s) outside transaction protection', $result);
+    }
+
     public function test_passes_with_third_party_static_create_calls(): void
     {
         // Spatie\Sitemap\Tags\Url and Spatie\Sitemap\Sitemap are not Eloquent models.


### PR DESCRIPTION
## Problem

`MissingDatabaseTransactionsAnalyzer` flagged writes in a private helper that is protected by a caller's `DB::transaction()`, when the protection only holds *transitively*:

```
erase() ──DB::transaction──▶ $this->handleOwnedBusiness() ──▶ $this->detachFromCoOwnedBusiness()  // flagged
```

The existing `TransactionDelegatedMethodScanner` only resolved **one hop**: it partitioned `$this->method()` calls by the lexical transaction depth at the call site. The second-hop call sits at depth 0 inside `handleOwnedBusiness()`'s body, so the leaf helper was recorded as "called outside a transaction" and flagged — a false positive for the idiomatic orchestrator-plus-helpers pattern.

## Fix

The scanner now records per-edge call-graph data (caller + lexical-transaction flag) plus method visibility, and computes the delegated set as a **transitive fixed point**: a method is protected if every call site is either lexically inside a `DB::transaction()` closure, or comes from an already-protected `private`/`protected` caller.

Propagation is visibility-gated — protection never flows *through* a public intermediary (which could be invoked externally without a transaction). The prior one-hop behavior is preserved exactly. The public contract (`getDelegatedMethods()`) is unchanged.

## Tests

Four new tests: two-hop pass, three-hop pass, mixed-path still-flags, and no-propagation-through-public-intermediary. Full suite passes (4279 tests), PHPStan level 9 clean, Pint clean.