### PR TITLE
docs(changelog): add v1.9.5 entry for transitive transaction-delegation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.9.5
+
+### Fixed
+- `MissingDatabaseTransactionsAnalyzer` no longer flags writes in a private/protected helper that is protected by a caller's `DB::transaction()` only transitively — transaction-delegation now resolves through the whole intra-class call graph, not just one hop (#260)
+
 ## v1.9.4
 
 ### Fixed


### PR DESCRIPTION
Adds the `v1.9.5` CHANGELOG entry for #260, which made `MissingDatabaseTransactionsAnalyzer`'s transaction-delegation resolve transitively across the intra-class call graph rather than only one hop.

Markdown-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)