### PR TITLE
Add scope-aware heuristic to MixedQueryBuilderEloquent

### DIFF
--- a/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
+++ b/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
@@ -437,6 +437,19 @@ class MixedQueryVisitor extends NodeVisitorAbstract
 
     private ?string $currentClassName = null;
 
+    /** @var bool Whether the current class writes via the query builder (DB::table()->insert/update/delete/...). */
+    private bool $classHasQueryBuilderWrite = false;
+
+    /** @var bool Whether the current class explicitly manages global scopes (withoutGlobalScope[s]()). */
+    private bool $classManagesGlobalScopes = false;
+
+    /** @var array<string> Query-builder write methods that bypass model events/casts. */
+    private const QUERY_BUILDER_WRITE_METHODS = [
+        'insert', 'insertGetId', 'insertOrIgnore', 'insertUsing',
+        'update', 'updateOrInsert', 'upsert',
+        'delete', 'truncate', 'increment', 'decrement',
+    ];
+
     /**
      * @param  array<string>  $whitelist
      * @param  array<string, string|null>  $tableRegistry
@@ -458,11 +471,38 @@ class MixedQueryVisitor extends NodeVisitorAbstract
         // Track current class
         if ($node instanceof Node\Stmt\Class_) {
             $this->currentClassName = $node->name?->toString();
+            $this->classHasQueryBuilderWrite = false;
+            $this->classManagesGlobalScopes = false;
         }
 
         // Reset variable tracking at method boundaries for proper scoping
         if ($node instanceof Node\Stmt\ClassMethod) {
             $this->variableTracking = [];
+        }
+
+        // Detect query-builder writes on a DB::table() chain, and deliberate global-scope
+        // management. A read-only class that explicitly manages scopes is doing intentional
+        // cross-cutting reads (e.g. cross-tenant analytics), not accidental scope bypass.
+        if ($node instanceof Node\Expr\MethodCall && $node->name instanceof Node\Identifier) {
+            $method = $node->name->toString();
+            if (in_array($method, self::QUERY_BUILDER_WRITE_METHODS, true)) {
+                $root = $this->findRootStaticCall($node->var);
+                if ($root !== null
+                    && $root->class instanceof Node\Name
+                    && $this->isDbFacade($root->class)
+                    && $root->name instanceof Node\Identifier
+                    && $root->name->toString() === 'table') {
+                    $this->classHasQueryBuilderWrite = true;
+                }
+            }
+            if (in_array($method, ['withoutGlobalScope', 'withoutGlobalScopes'], true)) {
+                $this->classManagesGlobalScopes = true;
+            }
+        }
+        if ($node instanceof Node\Expr\StaticCall
+            && $node->name instanceof Node\Identifier
+            && in_array($node->name->toString(), ['withoutGlobalScope', 'withoutGlobalScopes'], true)) {
+            $this->classManagesGlobalScopes = true;
         }
 
         // Detect DB::table() calls
@@ -697,6 +737,15 @@ class MixedQueryVisitor extends NodeVisitorAbstract
 
     private function checkMixedUsage(): void
     {
+        // A read-only class that explicitly manages global scopes (withoutGlobalScope[s]()) is
+        // performing deliberate cross-cutting reads (e.g. cross-tenant staff analytics). The
+        // scope bypass is intentional and signalled, so mixing Eloquent + Query Builder here is
+        // a considered architectural choice rather than an accidental scope-bypass risk. Writes
+        // via the query builder still bypass model events/casts, so they remain flagged.
+        if ($this->classManagesGlobalScopes && ! $this->classHasQueryBuilderWrite) {
+            return;
+        }
+
         $eloquentTables = [];
         $queryBuilderTables = [];
         $mixedTables = [];

--- a/tests/Unit/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzerTest.php
@@ -162,6 +162,94 @@ PHP;
         $this->assertHasIssueContaining('both Eloquent and Query Builder', $result);
     }
 
+    public function test_does_not_flag_readonly_scope_managed_analytics(): void
+    {
+        // Mirrors Compass ConsoleMetricsService: a read-only staff analytics service that
+        // deliberately bypasses the tenant global scope (withoutGlobalScope) and mixes
+        // DB::table() aggregation with Eloquent. The scope bypass is intentional and signalled,
+        // and there are no query-builder writes, so this considered pattern must not be flagged.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services\Console;
+
+use App\Models\User;
+use App\Models\Assessment;
+use App\Scopes\BusinessScope;
+use Illuminate\Support\Facades\DB;
+
+class ConsoleMetricsService
+{
+    public function kpis()
+    {
+        return [
+            'founders' => User::count(),
+            'completed' => Assessment::withoutGlobalScope(BusinessScope::class)->where('status', 'completed')->count(),
+        ];
+    }
+
+    public function signupsByWeek()
+    {
+        return DB::table('users')->whereNotNull('created_at')->get();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/Console/ConsoleMetricsService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_still_flags_mixing_when_class_writes_via_query_builder(): void
+    {
+        // Even when a class manages global scopes, a query-builder WRITE bypasses model
+        // events/casts, so the mixing must still be flagged.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Repositories;
+
+use App\Models\User;
+use App\Scopes\BusinessScope;
+use Illuminate\Support\Facades\DB;
+
+class ReportRepository
+{
+    public function summary()
+    {
+        return User::where('active', true)->count();
+    }
+
+    public function crossTenant()
+    {
+        return User::withoutGlobalScope(BusinessScope::class)->where('active', true)->count();
+    }
+
+    public function purge()
+    {
+        return DB::table('users')->where('inactive', true)->delete();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Repositories/ReportRepository.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('both Eloquent and Query Builder', $result);
+    }
+
     public function test_detects_significant_mixing(): void
     {
         // Models to register so QB tables count toward threshold


### PR DESCRIPTION
## Problem

`MixedQueryBuilderEloquentAnalyzer` flags a class that uses both `DB::table()` and Eloquent for the same table — reading via the query builder silently bypasses global scopes (soft deletes, tenant isolation), so this is correct behavior for *accidental* mixing. But it produces a **false positive** for deliberate cross-tenant read-only analytics services that intentionally and explicitly bypass scopes to aggregate across tenants.

## Fix

Suppress mixed-usage findings for a class that **both**:

1. performs **no query-builder writes** (`insert`, `insertGetId`, `insertOrIgnore`, `insertUsing`, `update`, `updateOrInsert`, `upsert`, `delete`, `truncate`, `increment`, `decrement`), **and**
2. explicitly manages global scopes via `withoutGlobalScope()` / `withoutGlobalScopes()`.

The explicit `withoutGlobalScope()` call is a strong signal the bypass is deliberate; requiring read-only keeps genuinely risky query-builder **writes** (which bypass model events/casts) flagged. Classes that never call `withoutGlobalScope()` are completely unaffected, so accidental scope-bypass mixing is still detected exactly as before.

The two signals are tracked on the visitor (`classHasQueryBuilderWrite`, `classManagesGlobalScopes`), reset per class, and `checkMixedUsage()` short-circuits when both hold.

## Tests

- Added `test_does_not_flag_readonly_scope_managed_analytics` — a read-only service mixing `DB::table()` aggregation with Eloquent that uses `withoutGlobalScope()` now passes.
- Added `test_still_flags_mixing_when_class_writes_via_query_builder` — a scope-managing class that also writes via the query builder is still flagged.
- All existing mixing-detection tests remain green (none use `withoutGlobalScope()`).

PHPStan Level 9 clean, Pint clean.