### PR TITLE
Skip PHP-side filter on JSON/array-cast attribute predicates

### DIFF
--- a/src/Analyzers/BestPractices/PhpSideFilteringAnalyzer.php
+++ b/src/Analyzers/BestPractices/PhpSideFilteringAnalyzer.php
@@ -393,12 +393,14 @@ class PhpFilteringVisitor extends NodeVisitorAbstract
             return;
         }
 
-        // Filtering by an authorization check (->can(), ->hasRole(), Gate::allows())
-        // cannot be expressed as a SQL where clause, so flagging it as "filter in the
-        // database" is a false positive. Skip filter()/reject() with such closures.
+        // Filtering by an authorization check (->can(), ->hasRole(), Gate::allows()) or by a
+        // JSON/array-cast attribute sub-key ($q->config['required']) cannot be expressed as a
+        // portable SQL where clause, so flagging it as "filter in the database" is a false
+        // positive. Skip filter()/reject() with such closures.
         $methodName = $node->name->toString();
         if (in_array($methodName, ['filter', 'reject'], true)
-            && $this->filterCallbackUsesAuthorization($node)) {
+            && ($this->filterCallbackUsesAuthorization($node)
+                || $this->filterCallbackAccessesJsonAttribute($node))) {
             return;
         }
 
@@ -476,6 +478,54 @@ class PhpFilteringVisitor extends NodeVisitorAbstract
                 if ($inner->name instanceof Node\Identifier) {
                     return in_array($inner->name->toString(), self::AUTHORIZATION_METHODS, true);
                 }
+            }
+
+            return false;
+        });
+
+        return $found !== null;
+    }
+
+    /**
+     * Check whether a filter()/reject() closure filters on a JSON/array-cast attribute.
+     *
+     * Predicates that read a sub-key of a JSON-cast attribute — e.g.
+     * ->filter(fn ($q) => $q->config['required']) — have no portable SQL equivalent
+     * (JSON path operators differ across SQLite and MySQL), so pushing them into the
+     * database is not viable. This is legitimate PHP-side filtering and must not be flagged.
+     */
+    private function filterCallbackAccessesJsonAttribute(Node\Expr\MethodCall $node): bool
+    {
+        $firstArg = $node->args[0] ?? null;
+        if (! ($firstArg instanceof Node\Arg)) {
+            return false;
+        }
+
+        $callback = $firstArg->value;
+        if (! ($callback instanceof Node\Expr\Closure) && ! ($callback instanceof Node\Expr\ArrowFunction)) {
+            return false;
+        }
+
+        $finder = new NodeFinder;
+        $found = $finder->findFirst($callback, function (Node $inner): bool {
+            // Sub-key access on a cast attribute: $model->config['required']
+            if ($inner instanceof Node\Expr\ArrayDimFetch && $inner->var instanceof Node\Expr\PropertyFetch) {
+                return true;
+            }
+
+            // Nested access helpers: data_get($q, 'config.required'), Arr::get($q->config, 'required')
+            if ($inner instanceof Node\Expr\FuncCall
+                && $inner->name instanceof Node\Name
+                && $inner->name->getLast() === 'data_get') {
+                return true;
+            }
+
+            if ($inner instanceof Node\Expr\StaticCall
+                && $inner->class instanceof Node\Name
+                && $inner->class->getLast() === 'Arr'
+                && $inner->name instanceof Node\Identifier
+                && $inner->name->toString() === 'get') {
+                return true;
             }
 
             return false;

--- a/tests/Unit/Analyzers/BestPractices/PhpSideFilteringAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/PhpSideFilteringAnalyzerTest.php
@@ -242,6 +242,39 @@ PHP;
         $this->assertHasIssueContaining('reject', $result);
     }
 
+    public function test_does_not_flag_filter_on_json_cast_attribute(): void
+    {
+        // Mirrors Compass AssessmentService::requiredStageQuestionCodes: the predicate reads a
+        // sub-key of a JSON-cast attribute ($q->config['required']), which has no portable SQL
+        // equivalent across SQLite and MySQL, so PHP-side filtering here is intentional.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services\Assessment;
+
+class AssessmentService
+{
+    public function requiredStageQuestionCodes()
+    {
+        return \App\Models\Question::all()
+            ->filter(fn ($q) => $q->is_scored || ($q->config['required'] ?? false) === true)
+            ->map(fn ($q) => $q->code)
+            ->all();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Services/Assessment/AssessmentService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
     public function test_detects_wherein_after_get(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Problem

`filter()`/`reject()` predicates that read a **sub-key of a JSON/array-cast attribute** — e.g. `->filter(fn ($q) => $q->config['required'])` — were flagged as "filter in the database." These have no portable SQL equivalent: JSON path operators differ across SQLite and MySQL (a project may deliberately avoid driver-specific SQL), so pushing the predicate into the query is not viable and the analyzer's recommendation is wrong. This is legitimate PHP-side filtering.

## Fix

Mirror the existing authorization-predicate skip. Add `filterCallbackAccessesJsonAttribute()`, which inspects the `filter`/`reject` closure/arrow-fn predicate for:

- an array-dim access on a property — `$model->config['required']` (`ArrayDimFetch` whose var is a `PropertyFetch`), or
- a nested-access helper — `data_get($q, 'config.required')` / `Arr::get($q->config, 'required')`.

The existing skip block in `analyzeMethodChain()` is extended to bail when a predicate uses authorization **or** JSON-attribute access. This applies only to `filter()`/`reject()` (closure predicates); `whereIn()`/`whereNotIn()` take array arguments and are unaffected.

## Tests

- Added `test_does_not_flag_filter_on_json_cast_attribute` — `Question::all()->filter(fn ($q) => $q->is_scored || ($q->config['required'] ?? false))` now passes.
- All existing tests remain green; predicates touching only plain columns are still flagged.

PHPStan Level 9 clean, Pint clean.