### PR TITLE
Don't flag uniqueness-probe loops as N+1

### DIFF
--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -7,6 +7,7 @@ namespace ShieldCI\Analyzers\BestPractices;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
@@ -537,6 +538,14 @@ class NPlusOneVisitor extends NodeVisitorAbstract
     private array $loopStack = [];
 
     /**
+     * spl_object_id() of exists()/doesntExist() query nodes that form a uniqueness-probe
+     * loop condition (generate-until-unique idiom) and must not be flagged as N+1.
+     *
+     * @var array<int, true>
+     */
+    private array $uniquenessProbeNodes = [];
+
+    /**
      * Track variables and their eager loaded relationships.
      *
      * @var array<string, array<string>>
@@ -635,6 +644,7 @@ class NPlusOneVisitor extends NodeVisitorAbstract
 
         if ($node instanceof Stmt\While_) {
             $condVars = $this->extractConditionVariables($node->cond);
+            $this->registerUniquenessProbes($node->cond, $node->stmts);
             $this->loopStack[] = [
                 'variables' => $condVars,
                 'type' => self::LOOP_TYPE_WHILE,
@@ -645,6 +655,7 @@ class NPlusOneVisitor extends NodeVisitorAbstract
 
         if ($node instanceof Stmt\Do_) {
             $condVars = $this->extractConditionVariables($node->cond);
+            $this->registerUniquenessProbes($node->cond, $node->stmts);
             $this->loopStack[] = [
                 'variables' => $condVars,
                 'type' => self::LOOP_TYPE_DO_WHILE,
@@ -793,8 +804,10 @@ class NPlusOneVisitor extends NodeVisitorAbstract
                     // Walk up the chain to find if it starts with a static call (Model::)
                     $queryDescription = $this->getQueryChainDescription($node);
                     if ($queryDescription !== null) {
-                        // Only flag if query depends on loop variable (true N+1 pattern)
-                        if ($this->queryDependsOnLoop($node, $currentLoop)) {
+                        // Only flag if query depends on loop variable (true N+1 pattern) and
+                        // is not a uniqueness-probe loop condition (generate-until-unique idiom).
+                        if ($this->queryDependsOnLoop($node, $currentLoop)
+                            && ! isset($this->uniquenessProbeNodes[spl_object_id($node)])) {
                             $this->queryIssues[] = [
                                 'query' => $queryDescription,
                                 'line' => $node->getStartLine(),
@@ -1004,6 +1017,70 @@ class NPlusOneVisitor extends NodeVisitorAbstract
         $this->collectVariables($condition, $variables);
 
         return array_unique($variables);
+    }
+
+    /**
+     * Register uniqueness-probe queries in a while/do-while condition.
+     *
+     * The "generate-until-unique" idiom probes for a free value:
+     *   while (Model::where('code', $code)->exists()) { $code = ...; }
+     * Each iteration tests a DIFFERENT candidate, so the query drives loop termination
+     * rather than running per row — it is a bounded uniqueness search, not an N+1, and the
+     * eager-loading remediation does not apply. We treat an exists()/doesntExist() call in
+     * the loop condition as a probe only when a variable it filters by is reassigned in the
+     * loop body (the signal that each iteration checks a new candidate). Poll loops with a
+     * constant condition have no loop-dependent variable and are already not flagged.
+     *
+     * @param  array<Stmt>  $stmts
+     */
+    private function registerUniquenessProbes(Node $cond, array $stmts): void
+    {
+        $assigned = $this->collectAssignedVariables($stmts);
+        if ($assigned === []) {
+            return;
+        }
+
+        $finder = new NodeFinder;
+        $existsCalls = $finder->find([$cond], fn (Node $n): bool => $n instanceof Expr\MethodCall
+            && $n->name instanceof Node\Identifier
+            && in_array(strtolower($n->name->toString()), ['exists', 'doesntexist'], true));
+
+        foreach ($existsCalls as $existsCall) {
+            $queryVars = [];
+            $this->collectVariables($existsCall, $queryVars);
+            if (array_intersect($queryVars, $assigned) !== []) {
+                $this->uniquenessProbeNodes[spl_object_id($existsCall)] = true;
+            }
+        }
+    }
+
+    /**
+     * Collect names of variables assigned (or in/decremented) anywhere within statements.
+     *
+     * @param  array<Stmt>  $stmts
+     * @return array<string>
+     */
+    private function collectAssignedVariables(array $stmts): array
+    {
+        $names = [];
+        $finder = new NodeFinder;
+
+        $assignments = $finder->find($stmts, fn (Node $n): bool => $n instanceof Expr\Assign
+            || $n instanceof Expr\AssignOp
+            || $n instanceof Expr\PreInc
+            || $n instanceof Expr\PostInc
+            || $n instanceof Expr\PreDec
+            || $n instanceof Expr\PostDec);
+
+        foreach ($assignments as $assignment) {
+            /** @var Expr\Assign|Expr\AssignOp|Expr\PreInc|Expr\PostInc|Expr\PreDec|Expr\PostDec $assignment */
+            $target = $assignment->var;
+            if ($target instanceof Expr\Variable && is_string($target->name)) {
+                $names[] = $target->name;
+            }
+        }
+
+        return array_values(array_unique($names));
     }
 
     /**

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
@@ -15,6 +15,127 @@ class EloquentNPlusOneAnalyzerTest extends AnalyzerTestCase
         return new EloquentNPlusOneAnalyzer($this->parser);
     }
 
+    public function test_passes_uniqueness_probe_while_loop(): void
+    {
+        // Generate-until-unique idiom: the exists() query IS the loop condition and the
+        // probed value ($code) is reassigned each iteration. This is a bounded uniqueness
+        // search, not a per-row N+1, and the eager-loading remediation does not apply.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Question;
+use Illuminate\Support\Str;
+
+class CatalogueService
+{
+    private function generateCode($pillar, string $text): string
+    {
+        $base = $pillar->slug.'_'.Str::slug($text, '_');
+        $code = $base;
+        $n = 1;
+        while (Question::where('code', $code)->exists()) {
+            $code = $base.'_'.(++$n);
+        }
+
+        return $code;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/CatalogueService.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_uniqueness_probe_do_while_loop(): void
+    {
+        // Same idiom in do-while form: probed value reassigned in the body, exists() in the
+        // condition.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Post;
+use Illuminate\Support\Str;
+
+class SlugGenerator
+{
+    public function unique(string $base): string
+    {
+        $slug = $base;
+        do {
+            $slug = $base.'-'.Str::random(4);
+        } while (Post::where('slug', $slug)->exists());
+
+        return $slug;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/SlugGenerator.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_still_detects_exists_check_per_item_in_foreach(): void
+    {
+        // A genuine N+1: running an existence check for every item in a fetched collection.
+        // This is NOT a uniqueness-probe condition, so it must remain flagged.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Question;
+
+class Importer
+{
+    public function run(array $codes): array
+    {
+        $existing = [];
+        foreach ($codes as $code) {
+            if (Question::where('code', $code)->exists()) {
+                $existing[] = $code;
+            }
+        }
+
+        return $existing;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/Importer.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+    }
+
     public function test_detects_n_plus_one_queries(): void
     {
         $code = <<<'PHP'
@@ -73,6 +194,116 @@ PHP;
 
         $tempDir = $this->createTempDirectory([
             'app/Http/Controllers/PostController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_with_inline_foreach_closure_eager_loading(): void
+    {
+        // Mirrors Compass AssessmentService::stageQuestionCodes: eager loading applied inline
+        // in the foreach() expression via a closure-constrained relation.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services\Assessment;
+
+class AssessmentService
+{
+    public function stageQuestionCodes()
+    {
+        $codesByPillar = [];
+        foreach (Pillar::with(['questions' => fn ($q) => $q->where('is_active', true)])->orderBy('display_order')->get() as $pillar) {
+            $questions = $pillar->questions->map(fn ($question) => $question->code)->all();
+            $codesByPillar[$pillar->slug] = $questions;
+        }
+
+        return $codesByPillar;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/Assessment/AssessmentService.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_with_assigned_closure_keyed_eager_loading(): void
+    {
+        // Mirrors Compass CatalogueController::index: closure-keyed eager loading with a
+        // nested ->with() assigned to a variable, then iterated.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers\Staff;
+
+class CatalogueController
+{
+    public function index()
+    {
+        $pillars = Pillar::with([
+            'questions' => fn ($q) => $q->withoutGlobalScopes()->with('options')->orderBy('display_order'),
+        ])->orderBy('display_order')->get();
+
+        foreach ($pillars as $pillar) {
+            echo $pillar->questions->count();
+        }
+
+        return $pillars;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/Staff/CatalogueController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_with_standalone_aggregate_not_in_loop(): void
+    {
+        // Mirrors Compass ConsoleMetricsService::kpis: standalone aggregate queries are
+        // not per-row loops and must not be flagged as N+1.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services\Console;
+
+class ConsoleMetricsService
+{
+    public function kpis()
+    {
+        return [
+            'completed' => Assessment::where('status', 'completed')->count(),
+            'total' => Business::count(),
+        ];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/Console/ConsoleMetricsService.php' => $code,
         ]);
 
         $analyzer = $this->createAnalyzer();


### PR DESCRIPTION
## Problem

The **generate-until-unique** idiom is flagged as an N+1:

```php
$code = $base;
while (Question::where('code', $code)->exists()) {
    $code = $base.'_'.(++$n);
}
```

This is not an N+1. The `exists()` query drives loop *termination*, and each iteration probes a **different** candidate value — it's a bounded uniqueness search, not a per-row query over a fetched collection. The analyzer's suggested remediation ("fetch all required data before the loop using whereIn() or eager loading") doesn't even apply, since you can't eager-load a value you're generating. This idiom is extremely common (slug/code/token generators).

## Fix

On entering a `while`/`do-while`, register any `exists()`/`doesntExist()` call in the **loop condition** as a uniqueness probe — but only when a variable it filters by is **reassigned in the loop body** (the signal that each iteration checks a new candidate). Registered probe nodes are then skipped in query-in-loop detection.

The check is deliberately narrow, so genuine problems stay flagged:
- a query in the loop **body** (not the condition) — still flagged;
- a non-existence terminal (`get()`/`first()`/`find()`) — still flagged;
- a constant/poll condition with no reassigned probe variable — unaffected (and already not flagged, since it has no loop-dependent variable);
- existence checks per item in a `foreach` over a fetched collection — still flagged.

## Tests

- `test_passes_uniqueness_probe_while_loop` and `test_passes_uniqueness_probe_do_while_loop` — the idiom passes.
- `test_still_detects_exists_check_per_item_in_foreach` — a real per-item existence N+1 stays flagged.
- Also adds regression guards for eager-loading edge cases the analyzer already handles (inline `foreach` with closure-keyed eager loading, assigned closure-keyed eager loading, standalone aggregates).

Verified against the real service that raised this (a `generateCode` while-loop) — no longer flagged. Full analyzer suite passes (80 tests), PHPStan Level 9 clean, Pint clean.