### PR TITLE
fix(service-container-resolution): recognize MorphPivot as an Eloquent base

### DIFF
--- a/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
+++ b/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
@@ -109,6 +109,7 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
         'Illuminate\\Database\\Eloquent\\Model',
         'Illuminate\\Foundation\\Auth\\User',
         'Illuminate\\Database\\Eloquent\\Relations\\Pivot',
+        'Illuminate\\Database\\Eloquent\\Relations\\MorphPivot',
     ];
 
     /** @var array<string> */
@@ -526,7 +527,9 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
         }
 
         // FQN ends with \Model (namespace separator required)
-        // This catches custom base models like App\Models\BaseModel
+        // This catches a custom base whose short name is exactly Model, e.g. App\Domain\Model.
+        // A base named App\Models\BaseModel is NOT matched here — resolving that would
+        // require following the extends chain (see ShieldCI/laravel#268).
         if (str_ends_with($parent, '\\Model')) {
             return true;
         }

--- a/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
@@ -2727,6 +2727,71 @@ PHP;
         $this->assertPassed($result);
     }
 
+    public function test_eloquent_morph_pivot_model_is_suppressed(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
+
+class Taggable extends MorphPivot
+{
+    public function getLabelAttribute()
+    {
+        $service = app(SomeService::class);
+        return $service->compute($this->value);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/Taggable.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // MorphPivot is an Eloquent base and bypasses __construct like any other model
+        $this->assertPassed($result);
+    }
+
+    public function test_eloquent_pivot_model_is_suppressed(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class Membership extends Pivot
+{
+    public function getRoleAttribute()
+    {
+        $service = app(SomeService::class);
+        return $service->compute($this->value);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/Membership.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
     public function test_eloquent_model_custom_base_class_suppressed(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
Closes #266

`MorphPivot` was absent from `ELOQUENT_MODEL_CLASSES`, and neither fallback rescued it — `str_ends_with("...\Relations\MorphPivot", "\Model")` is false, and the `Illuminate\* + Model suffix` check fails for the same reason.

A model extending `MorphPivot` was therefore flagged for manual container resolution, despite bypassing `__construct` via `newInstance()` exactly like every other Eloquent model. Every other model detector in the package already accepts it.

Also corrects the comment on the `\Model` suffix check, which claimed to catch `App\Models\BaseModel`. It does not — that string does not end with `\Model`. The check only matches a parent whose short name is exactly `Model` (e.g. the existing `App\Domain\Model` test fixture).

Tests: `MorphPivot` suppression (was failing) plus a `Pivot` control (was already passing).
