### PR TITLE
fix(fat-model): qualify the "Model" parent suffix with a Models namespace

### DIFF
--- a/src/Analyzers/BestPractices/FatModelAnalyzer.php
+++ b/src/Analyzers/BestPractices/FatModelAnalyzer.php
@@ -176,13 +176,20 @@ class FatModelVisitor extends NodeVisitorAbstract
                 : $class->extends->toString();
         }
 
-        // Standard Eloquent Model
-        if ($parentClass === 'Illuminate\\Database\\Eloquent\\Model') {
+        $parentShort = ($pos = strrpos($parentClass, '\\')) !== false
+            ? substr($parentClass, $pos + 1)
+            : $parentClass;
+
+        // Standard Eloquent Model, plus any custom base whose short name is exactly "Model"
+        if ($parentShort === 'Model') {
             return true;
         }
 
-        // Any class ending with "Model" is likely a custom base model
-        if (str_ends_with($parentClass, 'Model')) {
+        // A compound custom base (e.g. BaseModel) counts only within a Models namespace.
+        // Without that guard, every App\ViewModels\BaseViewModel — and any *ReadModel or
+        // *DomainModel — would be mistaken for an Eloquent base.
+        if (str_ends_with($parentShort, 'Model')
+            && ($this->inModelsNamespace($parentClass) || $this->inModelsNamespace($this->classFqn($class)))) {
             return true;
         }
 
@@ -205,6 +212,34 @@ class FatModelVisitor extends NodeVisitorAbstract
         }
 
         return false;
+    }
+
+    /**
+     * Whether a fully-qualified class name sits in a namespace with a "Models" segment.
+     *
+     * Matches App\Models, App\Models\Admin, and modular layouts such as
+     * Modules\Billing\Models. Exact segment match, so App\ViewModels does not qualify.
+     */
+    private function inModelsNamespace(?string $fqn): bool
+    {
+        if ($fqn === null) {
+            return false;
+        }
+
+        $segments = explode('\\', $fqn);
+        array_pop($segments);
+
+        return in_array('Models', $segments, true);
+    }
+
+    /**
+     * Fully-qualified name of the analyzed class, resolved by NameResolver.
+     */
+    private function classFqn(Node\Stmt\Class_ $class): ?string
+    {
+        return $class->namespacedName instanceof Node\Name
+            ? $class->namespacedName->toString()
+            : null;
     }
 
     private function analyzeModel(Node\Stmt\Class_ $class): void

--- a/tests/Unit/Analyzers/BestPractices/FatModelAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/FatModelAnalyzerTest.php
@@ -28,6 +28,98 @@ class FatModelAnalyzerTest extends AnalyzerTestCase
         return new FatModelAnalyzer($this->parser, $configRepo);
     }
 
+    public function test_does_not_treat_view_model_base_as_eloquent(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\ViewModels;
+
+use App\ViewModels\BaseViewModel;
+
+class ProductPage extends BaseViewModel
+{
+    public function helper1() { return 1; }
+    public function helper2() { return 2; }
+    public function helper3() { return 3; }
+    public function helper4() { return 4; }
+    public function helper5() { return 5; }
+    public function helper6() { return 6; }
+    public function helper7() { return 7; }
+    public function helper8() { return 8; }
+    public function helper9() { return 9; }
+    public function helper10() { return 10; }
+    public function helper11() { return 11; }
+    public function helper12() { return 12; }
+    public function helper13() { return 13; }
+    public function helper14() { return 14; }
+    public function helper15() { return 15; }
+    public function helper16() { return 16; }
+    public function helper17() { return 17; }
+    public function helper18() { return 18; }
+    public function helper19() { return 19; }
+    public function helper20() { return 20; }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['ViewModels/ProductPage.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // BaseViewModel is not an Eloquent base; a fat view model is not a fat *model*
+        $this->assertPassed($result);
+    }
+
+    public function test_detects_fat_model_on_a_custom_models_namespace_base(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use App\Models\BaseModel;
+
+class Post extends BaseModel
+{
+    public function helper1() { return 1; }
+    public function helper2() { return 2; }
+    public function helper3() { return 3; }
+    public function helper4() { return 4; }
+    public function helper5() { return 5; }
+    public function helper6() { return 6; }
+    public function helper7() { return 7; }
+    public function helper8() { return 8; }
+    public function helper9() { return 9; }
+    public function helper10() { return 10; }
+    public function helper11() { return 11; }
+    public function helper12() { return 12; }
+    public function helper13() { return 13; }
+    public function helper14() { return 14; }
+    public function helper15() { return 15; }
+    public function helper16() { return 16; }
+    public function helper17() { return 17; }
+    public function helper18() { return 18; }
+    public function helper19() { return 19; }
+    public function helper20() { return 20; }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Models/Post.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // A custom base inside a Models namespace is still an Eloquent base
+        $this->assertWarning($result);
+    }
+
     public function test_passes_with_small_model(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
Closes #267

`str_ends_with($parentClass, "Model")` had no namespace boundary, so any parent merely ending in `Model` was treated as an Eloquent base — every `*ViewModel`, `*ReadModel` and `*DomainModel` subclass got analyzed as a fat model. The adjacent `Pivot` / `MorphPivot` / `Authenticatable` checks all use a `\` boundary; this one did not.

## Deviation from the fix proposed in the issue

The issue suggested a bare `\Model` boundary. That is wrong: it would only match a parent whose short name is exactly `Model`, which the `Illuminate\...\Model` check directly above already covers — deleting the line's entire purpose (catching custom bases like `App\Models\BaseModel`, which is what its comment says it is for).

Instead, a compound suffix is accepted only inside a `Models` namespace segment:

| Parent | Before | After |
|---|---|---|
| `Illuminate\...\Model` | model | model |
| `App\Models\BaseModel` | model | model |
| `Modules\Billing\Models\BaseModel` | model | model |
| `App\ViewModels\BaseViewModel` | **model** | not a model |

Exact segment match, so `ViewModels` never qualifies. The namespace of either the parent or the analyzed class satisfies the guard, so `App\Models\Post extends App\BaseModel` still works.

Same heuristic as `laravel-pro`'s `PolicyAuthorizationAnalyzer::namespaceLooksLikeModels()`, which pre-aligns this call site with the unification in #268.

Note the default scan path is `app/Models`, so the false positive only bites projects that widen `paths` — real, but conditional.
