### PR TITLE
feat: unify Eloquent model detection into EloquentModelDetector

### DIFF
--- a/src/Analyzers/BestPractices/FatModelAnalyzer.php
+++ b/src/Analyzers/BestPractices/FatModelAnalyzer.php
@@ -78,6 +78,11 @@ class FatModelAnalyzer extends AbstractFileAnalyzer
         $modelFiles = $this->getPhpFiles();
         $affectedModels = [];
 
+        // One detector for the whole run: a file's verdict is a pure function of its
+        // on-disk contents, so sharing the instance lets its per-file cache avoid
+        // re-parsing a common project base once per child model.
+        $detector = new EloquentModelDetector($this->parser);
+
         foreach ($modelFiles as $file) {
             try {
                 $ast = $this->parser->parseFile($file);
@@ -89,7 +94,7 @@ class FatModelAnalyzer extends AbstractFileAnalyzer
                     $this->methodThreshold,
                     $this->locThreshold,
                     $this->complexityThreshold,
-                    new EloquentModelDetector($this->parser),
+                    $detector,
                     $ast,
                     $this->getBasePath(),
                 );

--- a/src/Analyzers/BestPractices/FatModelAnalyzer.php
+++ b/src/Analyzers/BestPractices/FatModelAnalyzer.php
@@ -15,6 +15,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Support\EloquentModelDetector;
 
 /**
  * Detects models with too much business logic (fat models).
@@ -84,7 +85,14 @@ class FatModelAnalyzer extends AbstractFileAnalyzer
                     continue;
                 }
 
-                $visitor = new FatModelVisitor($this->methodThreshold, $this->locThreshold, $this->complexityThreshold);
+                $visitor = new FatModelVisitor(
+                    $this->methodThreshold,
+                    $this->locThreshold,
+                    $this->complexityThreshold,
+                    new EloquentModelDetector($this->parser),
+                    $ast,
+                    $this->getBasePath(),
+                );
                 $traverser = new NodeTraverser;
                 $traverser->addVisitor(new NameResolver);
                 $traverser->addVisitor($visitor);
@@ -131,10 +139,16 @@ class FatModelVisitor extends NodeVisitorAbstract
 
     private ?string $currentClassName = null;
 
+    /**
+     * @param  array<Node>  $fileAst
+     */
     public function __construct(
         private readonly int $methodThreshold,
         private readonly int $locThreshold,
-        private readonly int $complexityThreshold
+        private readonly int $complexityThreshold,
+        private readonly EloquentModelDetector $detector,
+        private readonly array $fileAst,
+        private readonly string $basePath,
     ) {}
 
     public function enterNode(Node $node): ?Node
@@ -160,86 +174,7 @@ class FatModelVisitor extends NodeVisitorAbstract
 
     private function extendsModel(Node\Stmt\Class_ $class): bool
     {
-        if ($class->extends === null) {
-            return false;
-        }
-
-        // Get the fully qualified name from NameResolver
-        // - FullyQualified nodes: use toString() directly
-        // - Unresolved names: check namespacedName attribute (namespace-relative)
-        if ($class->extends instanceof Node\Name\FullyQualified) {
-            $parentClass = $class->extends->toString();
-        } else {
-            $namespacedName = $class->extends->getAttribute('namespacedName');
-            $parentClass = $namespacedName instanceof Node\Name
-                ? $namespacedName->toString()
-                : $class->extends->toString();
-        }
-
-        $parentShort = ($pos = strrpos($parentClass, '\\')) !== false
-            ? substr($parentClass, $pos + 1)
-            : $parentClass;
-
-        // Standard Eloquent Model, plus any custom base whose short name is exactly "Model"
-        if ($parentShort === 'Model') {
-            return true;
-        }
-
-        // A compound custom base (e.g. BaseModel) counts only within a Models namespace.
-        // Without that guard, every App\ViewModels\BaseViewModel — and any *ReadModel or
-        // *DomainModel — would be mistaken for an Eloquent base.
-        if (str_ends_with($parentShort, 'Model')
-            && ($this->inModelsNamespace($parentClass) || $this->inModelsNamespace($this->classFqn($class)))) {
-            return true;
-        }
-
-        // Pivot models
-        if ($parentClass === 'Illuminate\\Database\\Eloquent\\Relations\\Pivot'
-            || str_ends_with($parentClass, '\\Pivot')) {
-            return true;
-        }
-
-        // MorphPivot models
-        if ($parentClass === 'Illuminate\\Database\\Eloquent\\Relations\\MorphPivot'
-            || str_ends_with($parentClass, '\\MorphPivot')) {
-            return true;
-        }
-
-        // Authenticatable (User model base)
-        if ($parentClass === 'Illuminate\\Foundation\\Auth\\User'
-            || str_ends_with($parentClass, '\\Authenticatable')) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Whether a fully-qualified class name sits in a namespace with a "Models" segment.
-     *
-     * Matches App\Models, App\Models\Admin, and modular layouts such as
-     * Modules\Billing\Models. Exact segment match, so App\ViewModels does not qualify.
-     */
-    private function inModelsNamespace(?string $fqn): bool
-    {
-        if ($fqn === null) {
-            return false;
-        }
-
-        $segments = explode('\\', $fqn);
-        array_pop($segments);
-
-        return in_array('Models', $segments, true);
-    }
-
-    /**
-     * Fully-qualified name of the analyzed class, resolved by NameResolver.
-     */
-    private function classFqn(Node\Stmt\Class_ $class): ?string
-    {
-        return $class->namespacedName instanceof Node\Name
-            ? $class->namespacedName->toString()
-            : null;
+        return $this->detector->isModel($class, $this->fileAst, $this->basePath);
     }
 
     private function analyzeModel(Node\Stmt\Class_ $class): void

--- a/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
+++ b/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
@@ -1095,22 +1095,6 @@ class TableExtractorVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * Get fully qualified class name only if it directly extends a known Eloquent base.
-     *
-     * @deprecated Use getRawClassName() and let the analyzer resolve inheritance.
-     */
-    public function getClassName(): ?string
-    {
-        if (! $this->className || ! $this->isEloquentModel()) {
-            return null;
-        }
-
-        return $this->namespace
-            ? $this->namespace.'\\'.$this->className
-            : $this->className;
-    }
-
-    /**
      * Get fully qualified class name regardless of parent class.
      *
      * This method returns the FQCN without checking if it's a model,
@@ -1156,36 +1140,5 @@ class TableExtractorVisitor extends NodeVisitorAbstract
     public function isAbstract(): bool
     {
         return $this->isAbstract;
-    }
-
-    /**
-     * Check if the class directly extends a known Eloquent model base.
-     *
-     * Note: This method only checks direct inheritance. For resolving
-     * custom base classes (e.g., User extends BaseModel extends Model),
-     * use the multi-pass resolution in MixedQueryBuilderEloquentAnalyzer.
-     */
-    private function isEloquentModel(): bool
-    {
-        if ($this->parentClass === null) {
-            return false;
-        }
-
-        $normalized = ltrim($this->parentClass, '\\');
-
-        // Direct Eloquent Model
-        if ($normalized === 'Model' || str_ends_with($normalized, '\\Model')) {
-            return true;
-        }
-
-        // Common Laravel model base classes
-        $baseModels = ['Authenticatable', 'Pivot', 'MorphPivot'];
-        foreach ($baseModels as $base) {
-            if ($normalized === $base || str_ends_with($normalized, '\\'.$base)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
+++ b/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
@@ -16,6 +16,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Support\EloquentModelDetector;
 
 /**
  * Detects mixing Query Builder and Eloquent for the same model.
@@ -376,7 +377,8 @@ class MixedQueryBuilderEloquentAnalyzer extends AbstractFileAnalyzer
                     $this->whitelist,
                     $this->treatToBaseAsQueryBuilder,
                     $this->mixingThreshold,
-                    $this->tableRegistry
+                    $this->tableRegistry,
+                    new EloquentModelDetector($this->parser),
                 );
                 $traverser = new NodeTraverser;
                 $traverser->addVisitor(new NameResolver);
@@ -450,20 +452,24 @@ class MixedQueryVisitor extends NodeVisitorAbstract
         'delete', 'truncate', 'increment', 'decrement',
     ];
 
+    private EloquentModelDetector $detector;
+
     /**
      * @param  array<string>  $whitelist
      * @param  array<string, string|null>  $tableRegistry
      */
     public function __construct(
-        array $whitelist = [],
-        bool $treatToBaseAsQueryBuilder = true,
-        int $mixingThreshold = 2,
-        array $tableRegistry = []
+        array $whitelist,
+        bool $treatToBaseAsQueryBuilder,
+        int $mixingThreshold,
+        array $tableRegistry,
+        EloquentModelDetector $detector
     ) {
         $this->whitelist = $whitelist;
         $this->treatToBaseAsQueryBuilder = $treatToBaseAsQueryBuilder;
         $this->mixingThreshold = $mixingThreshold;
         $this->tableRegistry = $tableRegistry;
+        $this->detector = $detector;
     }
 
     public function enterNode(Node $node): ?Node
@@ -872,18 +878,22 @@ class MixedQueryVisitor extends NodeVisitorAbstract
             return true;
         }
 
-        // POSITIVE CHECK 1: Model namespace patterns
-        if (str_starts_with($normalized, 'App\\Models\\') ||
-            str_starts_with($normalized, 'App\\Model\\')) {
+        // POSITIVE CHECK 1: any Models namespace segment — App\Models, App\Models\Admin,
+        // Domain\Users\Models — excluding helper sub-namespaces such as Models\Scopes.
+        $namespace = ($pos = strrpos($normalized, '\\')) !== false ? substr($normalized, 0, $pos) : '';
+        if ($this->detector->namespaceLooksLikeModels($namespace)) {
             return true;
         }
 
-        // POSITIVE CHECK 2: Domain-driven patterns (e.g., Domain\Users\Models\User)
-        if (str_contains($normalized, '\\Models\\')) {
+        // POSITIVE CHECK 2: legacy singular App\Model\ layout, which the shared helper's
+        // exact-segment match on "Models" deliberately does not cover.
+        if (str_starts_with($normalized, 'App\\Model\\')) {
             return true;
         }
 
-        // POSITIVE CHECK 3: Class name ends with "Model" suffix
+        // POSITIVE CHECK 3: class-name suffix. Unbounded on purpose — see issue #267.
+        // Safe here because this classifies a referenced name inside a query chain
+        // (UserModel::query()), not a class declaration.
         if (str_ends_with($shortName, 'Model')) {
             return true;
         }

--- a/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
+++ b/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
@@ -18,6 +18,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Support\EloquentModelDetector;
 
 /**
  * Detects manual service container resolution in application code.
@@ -98,18 +99,6 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
         'Illuminate\\Foundation\\Support\\Providers\\RouteServiceProvider',
         'Illuminate\\Foundation\\Support\\Providers\\EventServiceProvider',
         'Illuminate\\Foundation\\Support\\Providers\\AuthServiceProvider',
-    ];
-
-    /**
-     * Known Eloquent base model FQNs.
-     *
-     * @var array<string>
-     */
-    private const ELOQUENT_MODEL_CLASSES = [
-        'Illuminate\\Database\\Eloquent\\Model',
-        'Illuminate\\Foundation\\Auth\\User',
-        'Illuminate\\Database\\Eloquent\\Relations\\Pivot',
-        'Illuminate\\Database\\Eloquent\\Relations\\MorphPivot',
     ];
 
     /** @var array<string> */
@@ -478,65 +467,22 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
-     * Check if AST represents an Eloquent model by checking class extends.
+     * Whether the file declares an Eloquent model.
      *
-     * Uses the same CloningVisitor + NameResolver pattern as isServiceProviderFromAst
-     * to resolve class names to FQN before checking.
+     * Unknown verdicts (a parent in vendor code, outside any Models namespace) do NOT
+     * suppress: that population is dominated by controllers, providers and commands,
+     * not by models.
      *
      * @param  array<Node>  $ast
      */
     private function isEloquentModelFromAst(array $ast): bool
     {
-        $traverser = new NodeTraverser;
-        $traverser->addVisitor(new CloningVisitor);
-        $traverser->addVisitor(new NameResolver);
-        $resolvedAst = $traverser->traverse($ast);
+        $detector = new EloquentModelDetector($this->parser);
 
-        foreach ($resolvedAst as $node) {
-            if ($node instanceof Stmt\Namespace_) {
-                foreach ($node->stmts as $stmt) {
-                    if ($stmt instanceof Stmt\Class_ && $this->extendsEloquentModel($stmt)) {
-                        return true;
-                    }
-                }
-            } elseif ($node instanceof Stmt\Class_ && $this->extendsEloquentModel($node)) {
+        foreach ($this->parser->findClasses($ast) as $class) {
+            if ($detector->isModel($class, $ast, $this->getBasePath(), unknownIs: false)) {
                 return true;
             }
-        }
-
-        return false;
-    }
-
-    /**
-     * Check if class extends an Eloquent Model.
-     *
-     * After NameResolver has been applied, parent class names should be FQN.
-     * We check against known Eloquent model FQNs and common base model patterns.
-     */
-    private function extendsEloquentModel(Stmt\Class_ $class): bool
-    {
-        if ($class->extends === null) {
-            return false;
-        }
-
-        $parent = ltrim($class->extends->toString(), '\\');
-
-        // Direct FQN match against known Eloquent model classes
-        if (in_array($parent, self::ELOQUENT_MODEL_CLASSES, true)) {
-            return true;
-        }
-
-        // FQN ends with \Model (namespace separator required)
-        // This catches a custom base whose short name is exactly Model, e.g. App\Domain\Model.
-        // A base named App\Models\BaseModel is NOT matched here — resolving that would
-        // require following the extends chain (see ShieldCI/laravel#268).
-        if (str_ends_with($parent, '\\Model')) {
-            return true;
-        }
-
-        // Illuminate namespace models (any Illuminate-based model)
-        if (str_starts_with($parent, 'Illuminate\\') && str_ends_with($parent, 'Model')) {
-            return true;
         }
 
         return false;

--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -14,6 +14,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\EloquentModelHelper;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Support\EloquentModelDetector;
 
 /**
  * Detects ownership/impersonation foreign keys exposed to mass assignment.
@@ -52,6 +53,8 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
+        $detector = new EloquentModelDetector($this->parser);
+
         foreach ($this->getPhpFiles() as $file) {
             $ast = $this->parser->parseFile($file);
             if (empty($ast)) {
@@ -60,7 +63,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 
             $classes = $this->parser->findClasses($ast);
             foreach ($classes as $class) {
-                if ($this->isEloquentModel($class)) {
+                if ($detector->isModel($class, $ast, $this->getBasePath())) {
                     return true;
                 }
             }
@@ -79,6 +82,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
         $this->loadDangerousPatterns();
 
         $issues = [];
+        $detector = new EloquentModelDetector($this->parser);
 
         foreach ($this->getPhpFiles() as $file) {
             $ast = $this->parser->parseFile($file);
@@ -88,7 +92,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 
             $classes = $this->parser->findClasses($ast);
             foreach ($classes as $class) {
-                if ($this->isEloquentModel($class)) {
+                if ($detector->isModel($class, $ast, $this->getBasePath())) {
                     if (! $this->hasLocalFillable($class) && ! $this->hasLocalGuarded($class)) {
                         $issues[] = $this->createIssue(
                             message: sprintf('Model "%s" does not define a local $fillable property; inherited fillable fields cannot be analyzed', $class->name?->toString() ?? 'Unknown'),
@@ -113,38 +117,6 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
             : sprintf('Found %d foreign key%s in fillable arrays', count($issues), count($issues) === 1 ? '' : 's');
 
         return $this->resultBySeverity($summary, $issues);
-    }
-
-    /**
-     * Check if a class is an Eloquent model.
-     */
-    private function isEloquentModel(Node\Stmt\Class_ $class): bool
-    {
-        if ($class->extends === null) {
-            return false;
-        }
-
-        $parentClass = $class->extends->toString();
-
-        // Check for direct Model class or namespaced Model
-        if ($parentClass === 'Model' || str_ends_with($parentClass, '\\Model')) {
-            return true;
-        }
-
-        // Check for common Laravel model base classes
-        $commonModelClasses = [
-            'Authenticatable',
-            'Pivot',
-            'MorphPivot',
-        ];
-
-        foreach ($commonModelClasses as $modelClass) {
-            if ($parentClass === $modelClass || str_ends_with($parentClass, '\\'.$modelClass)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/src/Analyzers/Security/MassAssignmentAnalyzer.php
+++ b/src/Analyzers/Security/MassAssignmentAnalyzer.php
@@ -13,6 +13,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\EloquentModelHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Support\EloquentModelDetector;
 
 /**
  * Detects mass assignment vulnerabilities in Eloquent models.
@@ -149,6 +150,7 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
     protected function runAnalysis(): ResultInterface
     {
         $issues = [];
+        $detector = new EloquentModelDetector($this->parser);
 
         foreach ($this->getPhpFiles() as $file) {
             $ast = $this->parser->parseFile($file);
@@ -159,7 +161,7 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
             // Check models for proper protection
             $classes = $this->parser->findClasses($ast);
             foreach ($classes as $class) {
-                if ($this->isEloquentModel($file, $class)) {
+                if ($detector->isModel($class, $ast, $this->getBasePath())) {
                     $this->checkModelProtection($file, $class, $issues);
                     $this->checkHiddenAttributes($file, $class, $issues);
                     $this->checkRelationshipSecurity($file, $class, $issues);
@@ -184,56 +186,6 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
             : sprintf('Found %d potential mass assignment vulnerabilit%s', count($issues), count($issues) === 1 ? 'y' : 'ies');
 
         return $this->resultBySeverity($summary, $issues);
-    }
-
-    /**
-     * Check if a class is an Eloquent model.
-     */
-    private function isEloquentModel(string $file, Node\Stmt\Class_ $class): bool
-    {
-        // First check the parent class (most reliable). Covers Model plus the other
-        // Eloquent bases that carry mass-assignment behaviour: Authenticatable (the
-        // User model) and Pivot/MorphPivot (join models), which may live outside the
-        // App\Models namespace.
-        if ($class->extends !== null) {
-            $parentClass = $class->extends->toString();
-
-            foreach (['Model', 'Authenticatable', 'Pivot', 'MorphPivot'] as $base) {
-                if ($parentClass === $base || str_ends_with($parentClass, '\\'.$base)) {
-                    return true;
-                }
-            }
-        }
-
-        // Secondary check: namespace
-        $content = FileParser::readFile($file);
-        if ($content === null) {
-            return false;
-        }
-
-        // Check if in App\Models namespace (but NOT subdirectories like Scopes, Observers, Casts)
-        // Match "namespace App\Models;" or "namespace App\Models\{ModelName}"
-        // but exclude "namespace App\Models\Scopes", "namespace App\Models\Observers", etc.
-        if (preg_match('/namespace\s+App\\\\Models\s*;/', $content)) {
-            return true;
-        }
-
-        // Check for specific model subdirectories (e.g., Domain\Users\Models)
-        // but exclude helper subdirectories
-        if (preg_match('/namespace\s+App\\\\Models\\\\Scopes\b/', $content) ||
-            preg_match('/namespace\s+App\\\\Models\\\\Observers\b/', $content) ||
-            preg_match('/namespace\s+App\\\\Models\\\\Casts\b/', $content) ||
-            preg_match('/namespace\s+App\\\\Models\\\\Collections\b/', $content) ||
-            preg_match('/namespace\s+App\\\\Models\\\\Traits\b/', $content)) {
-            return false;
-        }
-
-        // Check for models in subdirectories like "namespace App\Models\Admin"
-        if (preg_match('/namespace\s+App\\\\Models\\\\[A-Z]/', $content)) {
-            return true;
-        }
-
-        return false;
     }
 
     /**

--- a/src/Support/EloquentModelDetector.php
+++ b/src/Support/EloquentModelDetector.php
@@ -56,6 +56,9 @@ final class EloquentModelDetector
 
     public function __construct(private readonly ParserInterface $parser) {}
 
+    /** @var array<string, bool|null> File path => Eloquent verdict */
+    private array $fileVerdictCache = [];
+
     /**
      * Whether a namespace denotes Eloquent models.
      *
@@ -90,6 +93,57 @@ final class EloquentModelDetector
      */
     public function verdictFor(Stmt\Class_ $class, array $fileAst, string $basePath): ?bool
     {
+        return $this->classVerdict($class, $fileAst, $basePath);
+    }
+
+    /**
+     * Three-valued verdict for the classes declared in a file, memoized by path.
+     */
+    private function fileVerdict(string $filePath, string $basePath): ?bool
+    {
+        if (array_key_exists($filePath, $this->fileVerdictCache)) {
+            return $this->fileVerdictCache[$filePath];
+        }
+
+        // Reserve the slot before recursing so a cyclic chain resolves to null
+        // instead of looping. This is the sole termination mechanism: acyclic
+        // `extends` chains are finite, and a cycle re-entering a file already
+        // in progress hits this reserved cache entry and returns immediately.
+        $this->fileVerdictCache[$filePath] = null;
+
+        $fileAst = $this->parser->parseFile($filePath);
+        if ($fileAst === []) {
+            return null;
+        }
+
+        $verdict = false;
+
+        foreach ($this->parser->findClasses($fileAst) as $class) {
+            $classVerdict = $this->classVerdict($class, $fileAst, $basePath);
+
+            if ($classVerdict === true) {
+                $verdict = true;
+
+                break;
+            }
+
+            if ($classVerdict === null) {
+                $verdict = null;
+            }
+        }
+
+        $this->fileVerdictCache[$filePath] = $verdict;
+
+        return $verdict;
+    }
+
+    /**
+     * The step 1-7 algorithm for one class.
+     *
+     * @param  array<Node>  $fileAst
+     */
+    private function classVerdict(Stmt\Class_ $class, array $fileAst, string $basePath): ?bool
+    {
         // Step 1: a class that extends nothing is never an Eloquent model.
         if ($class->extends === null) {
             return false;
@@ -98,8 +152,7 @@ final class EloquentModelDetector
         $parentName = $class->extends->toString();
 
         // Step 2: the parent's short name is a known Eloquent base.
-        $parentShort = $this->shortName($parentName);
-        if (in_array($parentShort, self::ELOQUENT_BASE_CLASSES, true)) {
+        if (in_array($this->shortName($parentName), self::ELOQUENT_BASE_CLASSES, true)) {
             return true;
         }
 
@@ -116,7 +169,53 @@ final class EloquentModelDetector
             return true;
         }
 
+        // Step 4: the parent itself lives in a Models namespace.
+        if ($this->namespaceLooksLikeModels($this->namespaceOf($parentFqn))) {
+            return true;
+        }
+
+        // Step 5: follow the chain into a project class we can read.
+        //         A definite verdict from the chain outranks the convention below.
+        $parentPath = $this->fqnToFilePath($parentFqn, $basePath);
+        if ($parentPath !== null) {
+            $chainVerdict = $this->fileVerdict($parentPath, $basePath);
+            if ($chainVerdict !== null) {
+                return $chainVerdict;
+            }
+        }
+
+        // Step 6: the analyzed class's own namespace is a Models namespace.
+        if ($this->namespaceLooksLikeModels($namespace)) {
+            return true;
+        }
+
+        // Step 7: unknown.
         return null;
+    }
+
+    /**
+     * Map an App\ FQN to a file under app/. Null when outside App\ or the file is absent.
+     */
+    private function fqnToFilePath(string $fqn, string $basePath): ?string
+    {
+        if (! str_starts_with($fqn, 'App\\')) {
+            return null;
+        }
+
+        $relative = substr($fqn, 4);
+        $path = rtrim($basePath, '/').'/app/'.str_replace('\\', '/', $relative).'.php';
+
+        return file_exists($path) ? $path : null;
+    }
+
+    /**
+     * The namespace portion of a fully-qualified class name ('' for a global class).
+     */
+    private function namespaceOf(string $fqn): string
+    {
+        $pos = strrpos($fqn, '\\');
+
+        return $pos !== false ? substr($fqn, 0, $pos) : '';
     }
 
     private function shortName(string $fqn): string

--- a/src/Support/EloquentModelDetector.php
+++ b/src/Support/EloquentModelDetector.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+/**
+ * Answers one question: is this class declaration an Eloquent model?
+ *
+ * Three-valued on purpose. `true` = model, `false` = definitively not (the class
+ * extends nothing, or its `extends` chain terminates at a non-model), `null` = unknown
+ * (the chain leaves the project into vendor code we cannot read). Callers choose what
+ * `unknown` means for their polarity via isModel(..., unknownIs:).
+ *
+ * Resolves parent class names itself from the declaring file's use statements and
+ * namespace, so it is correct whether or not the caller ran NameResolver: an already
+ * resolved FullyQualified parent contains a backslash and passes through untouched.
+ */
+final class EloquentModelDetector
+{
+    /**
+     * Sub-namespaces of a Models namespace that hold helpers rather than models.
+     *
+     * @var array<int, string>
+     */
+    private const NON_MODEL_SUBNAMESPACES = [
+        'Scopes', 'Observers', 'Casts', 'Collections', 'Traits', 'Concerns', 'Builders', 'Enums',
+    ];
+
+    /**
+     * Whether a namespace denotes Eloquent models.
+     *
+     * Accepts any exact `Models` segment — App\Models, App\Models\Admin, and modular
+     * layouts such as Modules\Billing\Models — while excluding the helper sub-namespaces
+     * that live alongside models. `App\ViewModels` never qualifies: the match is on a
+     * whole segment, not a suffix.
+     */
+    public function namespaceLooksLikeModels(?string $namespace): bool
+    {
+        if ($namespace === null || $namespace === '') {
+            return false;
+        }
+
+        $segments = explode('\\', $namespace);
+        $index = array_search('Models', $segments, true);
+
+        if (! is_int($index)) {
+            return false;
+        }
+
+        $next = $segments[$index + 1] ?? null;
+
+        return $next === null || ! in_array($next, self::NON_MODEL_SUBNAMESPACES, true);
+    }
+}

--- a/src/Support/EloquentModelDetector.php
+++ b/src/Support/EloquentModelDetector.php
@@ -97,6 +97,20 @@ final class EloquentModelDetector
     }
 
     /**
+     * Two-valued verdict. The caller states what `unknown` means for its polarity.
+     *
+     * For an analyzer where "is a model" means *analyze this class*, unknown should be
+     * false (a missed model beats a bogus finding). For one where it means *suppress*,
+     * the caller must still weigh what populates unknown — see the class docblock.
+     *
+     * @param  array<Node>  $fileAst
+     */
+    public function isModel(Stmt\Class_ $class, array $fileAst, string $basePath, bool $unknownIs = false): bool
+    {
+        return $this->verdictFor($class, $fileAst, $basePath) ?? $unknownIs;
+    }
+
+    /**
      * Three-valued verdict for the classes declared in a file, memoized by path.
      */
     private function fileVerdict(string $filePath, string $basePath): ?bool

--- a/src/Support/EloquentModelDetector.php
+++ b/src/Support/EloquentModelDetector.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace ShieldCI\Support;
 
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\UseItem;
+use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
+
 /**
  * Answers one question: is this class declaration an Eloquent model?
  *
@@ -26,6 +33,28 @@ final class EloquentModelDetector
     private const NON_MODEL_SUBNAMESPACES = [
         'Scopes', 'Observers', 'Casts', 'Collections', 'Traits', 'Concerns', 'Builders', 'Enums',
     ];
+
+    /**
+     * Short class names of the Eloquent base classes a model may extend.
+     *
+     * @var array<int, string>
+     */
+    private const ELOQUENT_BASE_CLASSES = ['Model', 'Authenticatable', 'Pivot', 'MorphPivot'];
+
+    /**
+     * Fully-qualified Eloquent base classes, matched after resolving `extends`
+     * through the declaring file's use statements (handles `use Model as Eloquent`).
+     *
+     * @var array<int, string>
+     */
+    private const ELOQUENT_BASE_FQNS = [
+        'Illuminate\\Database\\Eloquent\\Model',
+        'Illuminate\\Foundation\\Auth\\User',
+        'Illuminate\\Database\\Eloquent\\Relations\\Pivot',
+        'Illuminate\\Database\\Eloquent\\Relations\\MorphPivot',
+    ];
+
+    public function __construct(private readonly ParserInterface $parser) {}
 
     /**
      * Whether a namespace denotes Eloquent models.
@@ -51,5 +80,124 @@ final class EloquentModelDetector
         $next = $segments[$index + 1] ?? null;
 
         return $next === null || ! in_array($next, self::NON_MODEL_SUBNAMESPACES, true);
+    }
+
+    /**
+     * Three-valued Eloquent verdict for a class declaration.
+     *
+     * @param  array<Node>  $fileAst  AST of the file declaring $class
+     * @param  string  $basePath  Project root, used to locate app/
+     */
+    public function verdictFor(Stmt\Class_ $class, array $fileAst, string $basePath): ?bool
+    {
+        // Step 1: a class that extends nothing is never an Eloquent model.
+        if ($class->extends === null) {
+            return false;
+        }
+
+        $parentName = $class->extends->toString();
+
+        // Step 2: the parent's short name is a known Eloquent base.
+        $parentShort = $this->shortName($parentName);
+        if (in_array($parentShort, self::ELOQUENT_BASE_CLASSES, true)) {
+            return true;
+        }
+
+        $useStatements = $this->extractUseStatements($fileAst);
+        $namespace = $this->extractNamespace($fileAst);
+
+        $parentFqn = $this->resolveClassName($parentName, $useStatements, $namespace);
+        if ($parentFqn === null) {
+            return null;
+        }
+
+        // Step 3: the resolved parent FQN is a known Eloquent base.
+        if (in_array($parentFqn, self::ELOQUENT_BASE_FQNS, true)) {
+            return true;
+        }
+
+        return null;
+    }
+
+    private function shortName(string $fqn): string
+    {
+        $pos = strrpos($fqn, '\\');
+
+        return $pos !== false ? substr($fqn, $pos + 1) : $fqn;
+    }
+
+    /**
+     * Resolve a class name to an FQN.
+     *
+     * A name containing a backslash is already qualified (this covers FullyQualified
+     * nodes produced by NameResolver). Otherwise consult the use map, then fall back
+     * to the enclosing namespace, matching PHP's own name resolution.
+     *
+     * @param  array<string, string>  $useStatements
+     */
+    private function resolveClassName(string $name, array $useStatements, ?string $namespace): ?string
+    {
+        if (str_contains($name, '\\')) {
+            return $name;
+        }
+
+        if (isset($useStatements[$name])) {
+            return $useStatements[$name];
+        }
+
+        return $namespace !== null && $namespace !== '' ? $namespace.'\\'.$name : null;
+    }
+
+    /**
+     * Short-name => FQN map of the file's imports.
+     *
+     * @param  array<Node>  $fileAst
+     * @return array<string, string>
+     */
+    private function extractUseStatements(array $fileAst): array
+    {
+        $map = [];
+
+        /** @var array<Use_> $uses */
+        $uses = $this->parser->findNodes($fileAst, Use_::class);
+        foreach ($uses as $use) {
+            foreach ($use->uses as $useItem) {
+                if ($useItem instanceof UseItem) {
+                    $map[$useItem->getAlias()->toString()] = $useItem->name->toString();
+                }
+            }
+        }
+
+        /** @var array<GroupUse> $groupUses */
+        $groupUses = $this->parser->findNodes($fileAst, GroupUse::class);
+        foreach ($groupUses as $groupUse) {
+            $prefix = $groupUse->prefix->toString();
+            foreach ($groupUse->uses as $useItem) {
+                if ($useItem instanceof UseItem) {
+                    $map[$useItem->getAlias()->toString()] = $prefix.'\\'.$useItem->name->toString();
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * The first namespace declared in a file, if any.
+     *
+     * @param  array<Node>  $fileAst
+     */
+    private function extractNamespace(array $fileAst): ?string
+    {
+        /** @var array<Stmt\Namespace_> $namespaces */
+        $namespaces = $this->parser->findNodes($fileAst, Stmt\Namespace_::class);
+
+        foreach ($namespaces as $namespace) {
+            if ($namespace->name !== null) {
+                return $namespace->name->toString();
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Unit/Analyzers/BestPractices/FatModelAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/FatModelAnalyzerTest.php
@@ -1844,5 +1844,6 @@ PHP;
         // Neither the child nor the parent is in a Models namespace, so the
         // convention (steps 4 and 6) cannot help — only the chain walk finds this.
         $this->assertWarning($result);
+        $this->assertHasIssueContaining('business methods', $result);
     }
 }

--- a/tests/Unit/Analyzers/BestPractices/FatModelAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/FatModelAnalyzerTest.php
@@ -1797,4 +1797,52 @@ PHP;
         $this->assertWarning($result);
         $this->assertHasIssueContaining('business methods', $result);
     }
+
+    public function test_detects_fat_model_extending_an_out_of_namespace_project_base(): void
+    {
+        $base = <<<'PHP'
+<?php
+
+namespace App\Support;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class RecordBase extends Model
+{
+}
+PHP;
+
+        $methods = implode("\n", array_map(
+            static fn (int $i): string => "    public function helper{$i}() { return {$i}; }",
+            range(1, 20)
+        ));
+
+        $code = <<<PHP
+<?php
+
+namespace App\Entities;
+
+use App\Support\RecordBase;
+
+class Post extends RecordBase
+{
+{$methods}
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Support/RecordBase.php' => $base,
+            'app/Entities/Post.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // Neither the child nor the parent is in a Models namespace, so the
+        // convention (steps 4 and 6) cannot help — only the chain walk finds this.
+        $this->assertWarning($result);
+    }
 }

--- a/tests/Unit/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzerTest.php
@@ -2365,4 +2365,41 @@ class OrderService
         $this->assertNotNull($issues[0]->location);
         $this->assertSame(10, $issues[0]->location->line);
     }
+
+    public function test_model_scope_class_is_not_treated_as_a_model(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+use App\Models\Scopes\ActiveScope;
+use Illuminate\Support\Facades\DB;
+
+class ReportService
+{
+    public function run()
+    {
+        $a = ActiveScope::where('x', 1)->get();
+        $b = DB::table('active_scopes')->where('y', 2)->get();
+
+        return [$a, $b];
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['app/Services/ReportService.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // Before this change, ActiveScope counted as a model and its inferred table
+        // (active_scopes) collided with the DB::table('active_scopes') call, so this
+        // was flagged as mixing. The helper sub-namespace App\Models\Scopes is now
+        // excluded, so ActiveScope is not treated as a model and there is no mixing.
+        $this->assertPassed($result);
+    }
 }

--- a/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
@@ -2825,6 +2825,115 @@ PHP;
         $this->assertPassed($result);
     }
 
+    public function test_eloquent_model_with_custom_project_base_is_suppressed(): void
+    {
+        $base = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class BaseModel extends Model
+{
+}
+PHP;
+
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+class Post extends BaseModel
+{
+    public function getSummaryAttribute()
+    {
+        $service = app(SomeService::class);
+
+        return $service->compute($this->value);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/BaseModel.php' => $base,
+            'app/Models/Post.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_eloquent_model_extending_a_vendor_base_is_suppressed(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Spatie\Permission\Models\Role as SpatieRole;
+
+class Role extends SpatieRole
+{
+    public function getLabelAttribute()
+    {
+        $service = app(SomeService::class);
+
+        return $service->compute($this->value);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['app/Models/Role.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_controller_extending_a_vendor_base_is_still_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Controller as BaseController;
+
+class ReportController extends BaseController
+{
+    public function index()
+    {
+        $service = app(SomeService::class);
+
+        return $service->run();
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['app/Http/Controllers/ReportController.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Unknown verdict (vendor parent, no Models namespace) must NOT suppress.
+        // App\Http\Controllers is a high-severity namespace, so the unsuppressed
+        // finding escalates to High severity, i.e. Status::Failed.
+        $this->assertFailed($result);
+    }
+
     // ============================================================
     // TESTS FOR SHOULD_QUEUE SUPPRESSION
     // ============================================================

--- a/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
@@ -623,6 +623,32 @@ PHP;
         $this->assertHasIssueContaining('tenant_id', $result);
     }
 
+    public function test_analyzes_a_model_using_an_aliased_eloquent_import(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class Post extends Eloquent
+{
+    protected $fillable = ['title', 'user_id'];
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['app/Models/Post.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertHasIssueContaining('impersonate', $result);
+    }
+
     public function test_detects_pivot_model(): void
     {
         $code = <<<'PHP'

--- a/tests/Unit/Analyzers/Security/MassAssignmentAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/MassAssignmentAnalyzerTest.php
@@ -3261,4 +3261,74 @@ PHP;
         // message; the guarded walkers now let analysis finish cleanly.
         $this->assertPassed($analyzer->analyze());
     }
+
+    public function test_analyzes_a_model_extending_a_project_base_model(): void
+    {
+        $base = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class BaseModel extends Model
+{
+}
+PHP;
+
+        $code = <<<'PHP'
+<?php
+
+namespace App\Entities;
+
+use App\Models\BaseModel;
+
+class Invoice extends BaseModel
+{
+    // No $fillable or $guarded
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/BaseModel.php' => $base,
+            'app/Entities/Invoice.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app/Entities']);
+
+        $result = $analyzer->analyze();
+
+        // The old analyzer skipped Invoice: its parent "BaseModel" matched no
+        // short-name base and App\Entities is not a Models namespace. The detector
+        // now recognizes it via its parent App\Models\BaseModel. Scanning only
+        // app/Entities ensures the finding is Invoice's, not BaseModel's.
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining("Model 'Invoice'", $result);
+    }
+
+    public function test_does_not_treat_a_parentless_class_in_app_models_as_a_model(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+class Dto
+{
+    // No $fillable or $guarded, and no parent — not an Eloquent model.
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['app/Models/Dto.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
 }

--- a/tests/Unit/Support/EloquentModelDetectorTest.php
+++ b/tests/Unit/Support/EloquentModelDetectorTest.php
@@ -403,4 +403,38 @@ PHP);
             'the shared cache from the deep-chain call above must not poison a later, shallower lookup'
         );
     }
+
+    public function test_is_model_maps_unknown_to_the_callers_default(): void
+    {
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace Domain\Billing;
+use Laravel\Cashier\Subscription;
+class Invoice extends Subscription {}
+PHP);
+
+        $this->assertNull($this->detector->verdictFor($class, $ast, '/nonexistent'));
+        $this->assertFalse($this->detector->isModel($class, $ast, '/nonexistent'));
+        $this->assertFalse($this->detector->isModel($class, $ast, '/nonexistent', unknownIs: false));
+        $this->assertTrue($this->detector->isModel($class, $ast, '/nonexistent', unknownIs: true));
+    }
+
+    public function test_is_model_ignores_the_default_for_definite_verdicts(): void
+    {
+        [$model, $modelAst] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Post extends Model {}
+PHP);
+
+        [$plain, $plainAst] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Support;
+class ActiveBusiness {}
+PHP);
+
+        $this->assertTrue($this->detector->isModel($model, $modelAst, '/nonexistent', unknownIs: false));
+        $this->assertFalse($this->detector->isModel($plain, $plainAst, '/nonexistent', unknownIs: true));
+    }
 }

--- a/tests/Unit/Support/EloquentModelDetectorTest.php
+++ b/tests/Unit/Support/EloquentModelDetectorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use PHPUnit\Framework\TestCase;
+use ShieldCI\Support\EloquentModelDetector;
+
+class EloquentModelDetectorTest extends TestCase
+{
+    private EloquentModelDetector $detector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->detector = new EloquentModelDetector;
+    }
+
+    public function test_namespace_looks_like_models_accepts_app_models(): void
+    {
+        $this->assertTrue($this->detector->namespaceLooksLikeModels('App\\Models'));
+    }
+
+    public function test_namespace_looks_like_models_accepts_nested_and_modular(): void
+    {
+        $this->assertTrue($this->detector->namespaceLooksLikeModels('App\\Models\\Admin'));
+        $this->assertTrue($this->detector->namespaceLooksLikeModels('Modules\\Billing\\Models'));
+    }
+
+    public function test_namespace_looks_like_models_rejects_view_models(): void
+    {
+        $this->assertFalse($this->detector->namespaceLooksLikeModels('App\\ViewModels'));
+    }
+
+    public function test_namespace_looks_like_models_rejects_helper_subnamespaces(): void
+    {
+        foreach (['Scopes', 'Observers', 'Casts', 'Collections', 'Traits', 'Concerns', 'Builders', 'Enums'] as $helper) {
+            $this->assertFalse(
+                $this->detector->namespaceLooksLikeModels('App\\Models\\'.$helper),
+                $helper.' must not qualify'
+            );
+        }
+    }
+
+    public function test_namespace_looks_like_models_rejects_null_and_empty(): void
+    {
+        $this->assertFalse($this->detector->namespaceLooksLikeModels(null));
+        $this->assertFalse($this->detector->namespaceLooksLikeModels(''));
+    }
+}

--- a/tests/Unit/Support/EloquentModelDetectorTest.php
+++ b/tests/Unit/Support/EloquentModelDetectorTest.php
@@ -437,4 +437,52 @@ PHP);
         $this->assertTrue($this->detector->isModel($model, $modelAst, '/nonexistent', unknownIs: false));
         $this->assertFalse($this->detector->isModel($plain, $plainAst, '/nonexistent', unknownIs: true));
     }
+
+    public function test_chain_walk_into_an_empty_parent_file_yields_unknown(): void
+    {
+        // The parent file exists (so the chain walk reads it) but parses to an empty
+        // AST — e.g. a stub containing only the opening tag. fileVerdict() returns null
+        // for that file, and with neither class in a Models namespace the verdict is unknown.
+        $dir = $this->createTempDir([
+            'app/Support/EmptyBase.php' => "<?php\n",
+        ]);
+
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Entities;
+use App\Support\EmptyBase;
+class Order extends EmptyBase {}
+PHP);
+
+        $this->assertNull($this->detector->verdictFor($class, $ast, $dir));
+    }
+
+    public function test_global_class_extending_an_unresolvable_bare_name_is_unknown(): void
+    {
+        // No namespace, no import: the parent name "Bar" cannot be resolved to an FQN
+        // (not qualified, absent from the use map, no enclosing namespace to prefix with),
+        // so the verdict is unknown rather than a guess. Also exercises extractNamespace()
+        // returning null for a file that declares no namespace.
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+class Foo extends Bar {}
+PHP);
+
+        $this->assertNull($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
+
+    public function test_aliased_eloquent_base_imported_via_group_use_is_a_model(): void
+    {
+        // Group-use syntax `use A\{Model as Eloquent};` — the parent short name "Eloquent"
+        // is not a base, so resolution must go through the grouped import map to reach the
+        // Eloquent base FQN at step 3.
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Domain;
+use Illuminate\Database\Eloquent\{Model as Eloquent};
+class Invoice extends Eloquent {}
+PHP);
+
+        $this->assertTrue($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
 }

--- a/tests/Unit/Support/EloquentModelDetectorTest.php
+++ b/tests/Unit/Support/EloquentModelDetectorTest.php
@@ -14,10 +14,66 @@ class EloquentModelDetectorTest extends TestCase
 {
     private EloquentModelDetector $detector;
 
+    /** @var array<int, string> */
+    private array $tempDirs = [];
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->detector = new EloquentModelDetector(new AstParser);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->removeDir($dir);
+        }
+        $this->tempDirs = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param  array<string, string>  $files  relative path => contents
+     */
+    private function createTempDir(array $files): string
+    {
+        $dir = sys_get_temp_dir().'/eloquent_model_detector_test_'.uniqid();
+        mkdir($dir, 0755, true);
+        $this->tempDirs[] = $dir;
+
+        foreach ($files as $relative => $contents) {
+            $path = $dir.'/'.$relative;
+            $parent = dirname($path);
+            if (! is_dir($parent)) {
+                mkdir($parent, 0755, true);
+            }
+            file_put_contents($path, $contents);
+        }
+
+        return $dir;
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+
+        $entries = scandir($dir);
+        if ($entries === false) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir.'/'.$entry;
+            is_dir($path) ? $this->removeDir($path) : unlink($path);
+        }
+
+        rmdir($dir);
     }
 
     public function test_namespace_looks_like_models_accepts_app_models(): void
@@ -143,5 +199,208 @@ class Admin extends \Illuminate\Foundation\Auth\User {}
 PHP);
 
         $this->assertTrue($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
+
+    public function test_parent_in_a_models_namespace_is_a_model(): void
+    {
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Models;
+use Spatie\Permission\Models\Role as SpatieRole;
+class Role extends SpatieRole {}
+PHP);
+
+        $this->assertTrue($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
+
+    public function test_own_models_namespace_rescues_a_vendor_base(): void
+    {
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Models;
+use Laravel\Cashier\Subscription as CashierSubscription;
+class Subscription extends CashierSubscription {}
+PHP);
+
+        $this->assertTrue($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
+
+    public function test_modular_models_namespace_is_a_model(): void
+    {
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace Modules\Billing\Models;
+use Vendor\Base\Entity;
+class Customer extends Entity {}
+PHP);
+
+        $this->assertTrue($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
+
+    public function test_chain_walk_resolves_a_project_base_model(): void
+    {
+        // Both child and parent live OUTSIDE any Models namespace, so neither step 4
+        // (parent's own Models namespace) nor step 6 (analyzed class's own Models
+        // namespace) can produce the verdict. The only way to reach `true` is step 5
+        // actually reading RecordBase.php off disk and finding it extends Model.
+        $base = <<<'PHP'
+<?php
+namespace App\Domain;
+use Illuminate\Database\Eloquent\Model;
+abstract class RecordBase extends Model {}
+PHP;
+
+        $child = <<<'PHP'
+<?php
+namespace App\Domain;
+use App\Domain\RecordBase;
+class Order extends RecordBase {}
+PHP;
+
+        $dir = $this->createTempDir(['app/Domain/RecordBase.php' => $base]);
+        [$class, $ast] = $this->parseClass($child);
+
+        $this->assertTrue($this->detector->verdictFor($class, $ast, $dir));
+    }
+
+    public function test_chain_walk_returns_definitive_false_for_a_view_model_base(): void
+    {
+        $base = <<<'PHP'
+<?php
+namespace App\ViewModels;
+abstract class BaseViewModel {}
+PHP;
+
+        $child = <<<'PHP'
+<?php
+namespace App\ViewModels;
+class ProductPage extends BaseViewModel {}
+PHP;
+
+        $dir = $this->createTempDir(['app/ViewModels/BaseViewModel.php' => $base]);
+        [$class, $ast] = $this->parseClass($child);
+
+        $this->assertFalse($this->detector->verdictFor($class, $ast, $dir));
+    }
+
+    public function test_chain_false_outranks_the_models_namespace_convention(): void
+    {
+        $base = <<<'PHP'
+<?php
+namespace App\Support;
+class Base {}
+PHP;
+
+        $child = <<<'PHP'
+<?php
+namespace App\Models;
+use App\Support\Base;
+class Dto extends Base {}
+PHP;
+
+        $dir = $this->createTempDir(['app/Support/Base.php' => $base]);
+        [$class, $ast] = $this->parseClass($child);
+
+        $this->assertFalse(
+            $this->detector->verdictFor($class, $ast, $dir),
+            'a resolved chain terminating at a non-model must beat the App\Models convention'
+        );
+    }
+
+    public function test_unknown_when_chain_leaves_the_project(): void
+    {
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace Domain\Billing;
+use Laravel\Cashier\Subscription;
+class Invoice extends Subscription {}
+PHP);
+
+        $this->assertNull($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
+
+    public function test_cyclic_extends_chain_terminates_with_unknown(): void
+    {
+        $a = <<<'PHP'
+<?php
+namespace App\Support;
+class A extends B {}
+PHP;
+
+        $b = <<<'PHP'
+<?php
+namespace App\Support;
+class B extends A {}
+PHP;
+
+        $dir = $this->createTempDir([
+            'app/Support/A.php' => $a,
+            'app/Support/B.php' => $b,
+        ]);
+
+        [$class, $ast] = $this->parseClass($a);
+
+        $this->assertNull($this->detector->verdictFor($class, $ast, $dir));
+    }
+
+    public function test_deep_chain_and_shared_instance_do_not_poison_cache(): void
+    {
+        // Chain of 6 hops to Model (L0->L1->L2->L3->L4->L5->Model), deeper than the old
+        // MAX_INHERITANCE_DEPTH=5 cap. All classes live outside any Models namespace so
+        // only the actual chain walk can produce a verdict, never the namespace convention.
+        $dir = $this->createTempDir([
+            'app/Chain/L1.php' => <<<'PHP'
+<?php
+namespace App\Chain;
+class L1 extends L2 {}
+PHP,
+            'app/Chain/L2.php' => <<<'PHP'
+<?php
+namespace App\Chain;
+class L2 extends L3 {}
+PHP,
+            'app/Chain/L3.php' => <<<'PHP'
+<?php
+namespace App\Chain;
+class L3 extends L4 {}
+PHP,
+            'app/Chain/L4.php' => <<<'PHP'
+<?php
+namespace App\Chain;
+class L4 extends L5 {}
+PHP,
+            'app/Chain/L5.php' => <<<'PHP'
+<?php
+namespace App\Chain;
+use Illuminate\Database\Eloquent\Model;
+class L5 extends Model {}
+PHP,
+        ]);
+
+        [$topClass, $topAst] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Chain;
+class L0 extends L1 {}
+PHP);
+
+        $this->assertTrue(
+            $this->detector->verdictFor($topClass, $topAst, $dir),
+            'a 6-hop chain to Model must resolve to true now that the depth cap is gone'
+        );
+
+        // Same detector instance, same directory: a fresh class extending a mid-chain
+        // ancestor (L4, two hops from Model) must still resolve to true. Before the fix,
+        // the verdictFor(L0) call above would have poisoned the cache entry for L4's file
+        // with a stale, budget-starved null, and this assertion would wrongly get null.
+        [$midClass, $midAst] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Chain;
+class M0 extends L4 {}
+PHP);
+
+        $this->assertTrue(
+            $this->detector->verdictFor($midClass, $midAst, $dir),
+            'the shared cache from the deep-chain call above must not poison a later, shallower lookup'
+        );
     }
 }

--- a/tests/Unit/Support/EloquentModelDetectorTest.php
+++ b/tests/Unit/Support/EloquentModelDetectorTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace ShieldCI\Tests\Unit\Support;
 
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
 use PHPUnit\Framework\TestCase;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\Support\EloquentModelDetector;
 
 class EloquentModelDetectorTest extends TestCase
@@ -14,7 +17,7 @@ class EloquentModelDetectorTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->detector = new EloquentModelDetector;
+        $this->detector = new EloquentModelDetector(new AstParser);
     }
 
     public function test_namespace_looks_like_models_accepts_app_models(): void
@@ -47,5 +50,98 @@ class EloquentModelDetectorTest extends TestCase
     {
         $this->assertFalse($this->detector->namespaceLooksLikeModels(null));
         $this->assertFalse($this->detector->namespaceLooksLikeModels(''));
+    }
+
+    /**
+     * Parse $code and return [firstClassNode, fullFileAst].
+     *
+     * @return array{0: Class_, 1: array<Node>}
+     */
+    private function parseClass(string $code): array
+    {
+        $parser = new AstParser;
+        $ast = $parser->parseCode($code);
+        $classes = $parser->findClasses($ast);
+
+        $this->assertNotEmpty($classes, 'fixture must declare a class');
+
+        return [$classes[0], $ast];
+    }
+
+    public function test_class_with_no_parent_is_definitively_not_a_model(): void
+    {
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Support;
+class ActiveBusiness {}
+PHP);
+
+        $this->assertFalse($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
+
+    public function test_extends_model_short_name_is_a_model(): void
+    {
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Post extends Model {}
+PHP);
+
+        $this->assertTrue($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
+
+    public function test_extends_pivot_authenticatable_and_morph_pivot_are_models(): void
+    {
+        foreach (['Pivot', 'MorphPivot', 'Authenticatable'] as $base) {
+            [$class, $ast] = $this->parseClass(<<<PHP
+<?php
+namespace App\Models;
+class Thing extends {$base} {}
+PHP);
+
+            $this->assertTrue(
+                $this->detector->verdictFor($class, $ast, '/nonexistent'),
+                $base.' must be an Eloquent base'
+            );
+        }
+    }
+
+    public function test_fully_qualified_eloquent_base_is_a_model(): void
+    {
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Entities;
+class Post extends \Illuminate\Database\Eloquent\Model {}
+PHP);
+
+        $this->assertTrue($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
+
+    public function test_aliased_eloquent_import_is_a_model(): void
+    {
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Domain\Billing;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+class Invoice extends Eloquent {}
+PHP);
+
+        $this->assertTrue($this->detector->verdictFor($class, $ast, '/nonexistent'));
+    }
+
+    public function test_fully_qualified_authenticatable_resolves_via_fqn_pass_through(): void
+    {
+        // Short name "User" is NOT an Eloquent base short name, so step 2 cannot match.
+        // The parent is a FullyQualified name, so resolveClassName() passes it through
+        // unchanged and the verdict can only come from the step-3 FQN match — the exact
+        // branch that keeps the detector correct for callers that ran NameResolver.
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Auth;
+class Admin extends \Illuminate\Foundation\Auth\User {}
+PHP);
+
+        $this->assertTrue($this->detector->verdictFor($class, $ast, '/nonexistent'));
     }
 }


### PR DESCRIPTION
Closes #268

## Problem

Ten private answers to "is this class an Eloquent model?" existed across the package, disagreeing on at least six concrete class shapes (custom project bases, aliased imports, vendor bases, `MorphPivot`, DDD `*\Models\*` namespaces). Root cause: `AstParser::parseFile()` doesn't run `NameResolver`, so some sites saw `extends Model` as the bare string `"Model"` and others saw the FQN — each invented its own heuristic.

## This PR

Introduces one shared `EloquentModelDetector` (`src/Support/EloquentModelDetector.php`) and migrates five analyzers to it.

**Detector contract** — three-valued, first match wins:

| # | Test | Result |
|---|---|---|
| 1 | `extends === null` | not a model |
| 2 | parent short name ∈ `Model/Authenticatable/Pivot/MorphPivot` | model |
| 3 | resolved parent FQN ∈ the four Eloquent base FQNs | model |
| 4 | parent's namespace has a `Models` segment | model |
| 5 | parent file resolvable under `app/` → recurse (definite verdict outranks convention) | propagate |
| 6 | analyzed class's own namespace has a `Models` segment | model |
| 7 | otherwise | unknown (`null`) |

`isModel(..., unknownIs:)` lets each caller state what `unknown` means for its polarity — the API is three-valued because a suppress-on-model analyzer and an analyze-on-model analyzer need opposite safe defaults. The detector resolves parent names itself from the declaring file's `use` statements + namespace, so it is correct whether or not the caller ran `NameResolver`. Termination is guaranteed by a per-file memo cache (slot reserved before recursing, cutting cycles) plus the finiteness of acyclic chains — no depth cap.

## Behavior deltas per analyzer

- **ServiceContainerResolution** — model ⇒ suppress; `unknownIs: false`. Fewer findings (custom/vendor bases now suppress). Controllers still flag (their unknown verdict doesn't suppress) — locked by a regression test.
- **FillableForeignKey** — model ⇒ analyze. Pure widening (old check was a strict subset).
- **MassAssignment** — model ⇒ analyze. Both directions: gains chains/aliases/vendor bases; stops treating a parentless class merely sitting in `App\Models` as a model.
- **FatModel** — near-neutral (PR #270 pre-aligned it); detector threaded into the visitor.
- **MixedQueryBuilder** — only `looksLikeModel()` (which classifies a *referenced* FQN, a different question) delegates its two namespace checks to the shared `namespaceLooksLikeModels()`; the legacy singular `App\Model\` prefix and the model registry are untouched. A dead `TableExtractorVisitor::getClassName()`/`isEloquentModel()` pair is deleted.

## Known residuals (in-contract, degrade to `unknown`, never to a wrong answer)

- A model outside any `Models` namespace **and** extending a vendor base can't be chain-walked (`fqnToFilePath` only maps the `App\` root); the `Models`-namespace convention covers the common cases.
- `resolveClassName` treats any name containing `\` as already-qualified; the two visitor-based callers run `NameResolver` first, so this is moot for them.

## Verification

PHPStan level 9 clean, Pint clean, full suite green (4322 tests, 0 failures). Each migration is tested on both sides of its behavior delta.
