### PR TITLE
refactor(support): add EloquentModelHelper in the free package

### DIFF
--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -11,10 +11,10 @@ use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
-use ShieldCI\AnalyzersCore\Support\EloquentModelHelper;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Support\EloquentModelDetector;
+use ShieldCI\Support\EloquentModelHelper;
 
 /**
  * Detects ownership/impersonation foreign keys exposed to mass assignment.

--- a/src/Analyzers/Security/MassAssignmentAnalyzer.php
+++ b/src/Analyzers/Security/MassAssignmentAnalyzer.php
@@ -10,10 +10,10 @@ use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
-use ShieldCI\AnalyzersCore\Support\EloquentModelHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\Support\EloquentModelDetector;
+use ShieldCI\Support\EloquentModelHelper;
 
 /**
  * Detects mass assignment vulnerabilities in Eloquent models.

--- a/src/Support/EloquentModelHelper.php
+++ b/src/Support/EloquentModelHelper.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+use PhpParser\Node;
+
+/**
+ * Helpers for reading Eloquent model mass-assignment configuration from an AST.
+ *
+ * Laravel exposes mass-assignment configuration in two interchangeable ways:
+ *  - the classic protected properties: `protected $fillable = [...]` / `protected $guarded = [...]`
+ *  - first-class attributes (Laravel 12+): `#[Fillable(...)]`, `#[Guarded(...)]`, `#[Unguarded]`
+ *
+ * Analyzers that only inspect properties produce false positives on attribute-based
+ * models. These helpers read both forms so callers don't have to.
+ */
+final class EloquentModelHelper
+{
+    /**
+     * True if the class declares fillable OR guarded configuration in either form.
+     */
+    public static function hasFillableConfig(Node\Stmt\Class_ $class): bool
+    {
+        return self::hasFillable($class) || self::hasGuarded($class);
+    }
+
+    /**
+     * True if a `$fillable` property OR a `#[Fillable]` attribute is present.
+     */
+    public static function hasFillable(Node\Stmt\Class_ $class): bool
+    {
+        return self::hasProperty($class, 'fillable')
+            || self::hasAttribute($class, ['Fillable']);
+    }
+
+    /**
+     * True if a `$guarded` property OR a `#[Guarded]`/`#[Unguarded]` attribute is present.
+     */
+    public static function hasGuarded(Node\Stmt\Class_ $class): bool
+    {
+        return self::hasProperty($class, 'guarded')
+            || self::hasAttribute($class, ['Guarded', 'Unguarded']);
+    }
+
+    /**
+     * True if a `$hidden` property OR a `#[Hidden]` attribute is present.
+     */
+    public static function hasHidden(Node\Stmt\Class_ $class): bool
+    {
+        return self::hasProperty($class, 'hidden')
+            || self::hasAttribute($class, ['Hidden']);
+    }
+
+    /**
+     * Fillable field names from a `$fillable` property OR `#[Fillable(...)]` attribute.
+     *
+     * @return list<string>
+     */
+    public static function extractFillableFields(Node\Stmt\Class_ $class): array
+    {
+        return array_values(array_merge(
+            self::extractFieldsFromProperty($class, 'fillable'),
+            self::extractFillableFieldsFromAttribute($class),
+        ));
+    }
+
+    /**
+     * Guarded field names from a `$guarded` property OR `#[Guarded(...)]` attribute.
+     *
+     * @return list<string>
+     */
+    public static function extractGuardedFields(Node\Stmt\Class_ $class): array
+    {
+        return array_values(array_merge(
+            self::extractFieldsFromProperty($class, 'guarded'),
+            self::extractFieldsFromAttribute($class, 'Guarded'),
+        ));
+    }
+
+    /**
+     * Hidden field names from a `$hidden` property OR `#[Hidden(...)]` attribute.
+     *
+     * @return list<string>
+     */
+    public static function extractHiddenFields(Node\Stmt\Class_ $class): array
+    {
+        return array_values(array_merge(
+            self::extractFieldsFromProperty($class, 'hidden'),
+            self::extractFieldsFromAttribute($class, 'Hidden'),
+        ));
+    }
+
+    /**
+     * Field names declared by a `#[Fillable(...)]` attribute.
+     *
+     * Handles both constructor shapes:
+     *   #[Fillable(['user_id', 'title'])]  -> single arg whose value is an array literal
+     *   #[Fillable('user_id', 'title')]    -> multiple string args (variadic)
+     *
+     * Returns an empty list when no `#[Fillable]` attribute is present.
+     *
+     * @return list<string>
+     */
+    public static function extractFillableFieldsFromAttribute(Node\Stmt\Class_ $class): array
+    {
+        return self::extractFieldsFromAttribute($class, 'Fillable');
+    }
+
+    /**
+     * String field names from a class-level attribute, handling both the array
+     * (`#[Attr(['a', 'b'])]`) and variadic (`#[Attr('a', 'b')]`) constructor shapes.
+     *
+     * @return list<string>
+     */
+    private static function extractFieldsFromAttribute(Node\Stmt\Class_ $class, string $attributeShortName): array
+    {
+        $fields = [];
+
+        foreach (self::attributes($class) as $attr) {
+            if (self::shortName($attr->name->toString()) !== $attributeShortName) {
+                continue;
+            }
+
+            foreach ($attr->args as $arg) {
+                if ($arg->value instanceof Node\Expr\Array_) {
+                    foreach ($arg->value->items as $item) {
+                        if ($item instanceof Node\Expr\ArrayItem && $item->value instanceof Node\Scalar\String_) {
+                            $fields[] = $item->value->value;
+                        }
+                    }
+                } elseif ($arg->value instanceof Node\Scalar\String_) {
+                    $fields[] = $arg->value->value;
+                }
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * String field names from a `protected $name = [...]` array property.
+     *
+     * @return list<string>
+     */
+    private static function extractFieldsFromProperty(Node\Stmt\Class_ $class, string $name): array
+    {
+        $fields = [];
+
+        foreach ($class->stmts as $stmt) {
+            if (! $stmt instanceof Node\Stmt\Property) {
+                continue;
+            }
+
+            foreach ($stmt->props as $prop) {
+                if ($prop->name->toString() !== $name || ! $prop->default instanceof Node\Expr\Array_) {
+                    continue;
+                }
+
+                foreach ($prop->default->items as $item) {
+                    if ($item instanceof Node\Expr\ArrayItem && $item->value instanceof Node\Scalar\String_) {
+                        $fields[] = $item->value->value;
+                    }
+                }
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * True if the class defines a property with the given name.
+     */
+    private static function hasProperty(Node\Stmt\Class_ $class, string $name): bool
+    {
+        foreach ($class->stmts as $stmt) {
+            if (! $stmt instanceof Node\Stmt\Property) {
+                continue;
+            }
+
+            foreach ($stmt->props as $prop) {
+                if ($prop->name->toString() === $name) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * True if the class carries any class-level attribute whose short name matches one of $names.
+     *
+     * @param  list<string>  $names
+     */
+    private static function hasAttribute(Node\Stmt\Class_ $class, array $names): bool
+    {
+        foreach (self::attributes($class) as $attr) {
+            if (in_array(self::shortName($attr->name->toString()), $names, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * All class-level attributes on the class.
+     *
+     * @return list<Node\Attribute>
+     */
+    private static function attributes(Node\Stmt\Class_ $class): array
+    {
+        $attributes = [];
+
+        foreach ($class->attrGroups as $group) {
+            foreach ($group->attrs as $attr) {
+                $attributes[] = $attr;
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Last `\`-separated segment of a name (attributes are usually written unqualified
+     * after a `use` import).
+     */
+    private static function shortName(string $name): string
+    {
+        $pos = strrpos($name, '\\');
+
+        return $pos === false ? $name : substr($name, $pos + 1);
+    }
+}

--- a/tests/Unit/Support/EloquentModelHelperTest.php
+++ b/tests/Unit/Support/EloquentModelHelperTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use PhpParser\Node;
+use PHPUnit\Framework\TestCase;
+use ShieldCI\AnalyzersCore\Support\AstParser;
+use ShieldCI\Support\EloquentModelHelper;
+
+class EloquentModelHelperTest extends TestCase
+{
+    private AstParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new AstParser;
+    }
+
+    private function classFrom(string $code): Node\Stmt\Class_
+    {
+        $ast = $this->parser->parseCode($code);
+        $classes = $this->parser->findClasses($ast);
+        $this->assertNotEmpty($classes, 'Expected fixture code to contain a class');
+
+        return $classes[0];
+    }
+
+    public function test_has_fillable_detects_property(): void
+    {
+        $class = $this->classFrom('<?php class User { protected $fillable = ["name", "email"]; }');
+
+        $this->assertTrue(EloquentModelHelper::hasFillable($class));
+        $this->assertTrue(EloquentModelHelper::hasFillableConfig($class));
+        $this->assertFalse(EloquentModelHelper::hasGuarded($class));
+    }
+
+    public function test_has_guarded_detects_property(): void
+    {
+        $class = $this->classFrom('<?php class User { protected $guarded = ["id"]; }');
+
+        $this->assertTrue(EloquentModelHelper::hasGuarded($class));
+        $this->assertTrue(EloquentModelHelper::hasFillableConfig($class));
+        $this->assertFalse(EloquentModelHelper::hasFillable($class));
+    }
+
+    public function test_has_fillable_detects_attribute(): void
+    {
+        $class = $this->classFrom('<?php use Illuminate\Database\Eloquent\Attributes\Fillable; #[Fillable(["name", "email"])] class User {}');
+
+        $this->assertTrue(EloquentModelHelper::hasFillable($class));
+        $this->assertTrue(EloquentModelHelper::hasFillableConfig($class));
+    }
+
+    public function test_has_guarded_detects_guarded_attribute(): void
+    {
+        $class = $this->classFrom('<?php #[Guarded(["id"])] class User {}');
+
+        $this->assertTrue(EloquentModelHelper::hasGuarded($class));
+        $this->assertTrue(EloquentModelHelper::hasFillableConfig($class));
+    }
+
+    public function test_has_guarded_detects_unguarded_attribute(): void
+    {
+        $class = $this->classFrom('<?php #[Unguarded] class User {}');
+
+        $this->assertTrue(EloquentModelHelper::hasGuarded($class));
+        $this->assertTrue(EloquentModelHelper::hasFillableConfig($class));
+    }
+
+    public function test_detects_fully_qualified_attribute(): void
+    {
+        $class = $this->classFrom('<?php #[\Illuminate\Database\Eloquent\Attributes\Fillable(["name"])] class User {}');
+
+        $this->assertTrue(EloquentModelHelper::hasFillable($class));
+    }
+
+    public function test_no_config_when_neither_property_nor_attribute(): void
+    {
+        $class = $this->classFrom('<?php class User { protected $table = "users"; }');
+
+        $this->assertFalse(EloquentModelHelper::hasFillable($class));
+        $this->assertFalse(EloquentModelHelper::hasGuarded($class));
+        $this->assertFalse(EloquentModelHelper::hasFillableConfig($class));
+    }
+
+    public function test_extract_fillable_fields_from_array_attribute(): void
+    {
+        $class = $this->classFrom('<?php #[Fillable(["name", "company_id"])] class User {}');
+
+        $this->assertSame(['name', 'company_id'], EloquentModelHelper::extractFillableFieldsFromAttribute($class));
+    }
+
+    public function test_extract_fillable_fields_from_variadic_attribute(): void
+    {
+        $class = $this->classFrom('<?php #[Fillable("title", "user_id")] class Post {}');
+
+        $this->assertSame(['title', 'user_id'], EloquentModelHelper::extractFillableFieldsFromAttribute($class));
+    }
+
+    public function test_extract_fillable_fields_returns_empty_without_attribute(): void
+    {
+        $class = $this->classFrom('<?php class User { protected $fillable = ["name"]; }');
+
+        $this->assertSame([], EloquentModelHelper::extractFillableFieldsFromAttribute($class));
+    }
+
+    public function test_has_hidden_detects_property_and_attribute(): void
+    {
+        $property = $this->classFrom('<?php class User { protected $hidden = ["password"]; }');
+        $attribute = $this->classFrom('<?php #[Hidden(["password"])] class User {}');
+        $neither = $this->classFrom('<?php class User {}');
+
+        $this->assertTrue(EloquentModelHelper::hasHidden($property));
+        $this->assertTrue(EloquentModelHelper::hasHidden($attribute));
+        $this->assertFalse(EloquentModelHelper::hasHidden($neither));
+    }
+
+    public function test_extract_fillable_fields_reads_property_or_attribute(): void
+    {
+        $property = $this->classFrom('<?php class User { protected $fillable = ["name", "email"]; }');
+        $attribute = $this->classFrom('<?php #[Fillable("name", "email")] class User {}');
+
+        $this->assertSame(['name', 'email'], EloquentModelHelper::extractFillableFields($property));
+        $this->assertSame(['name', 'email'], EloquentModelHelper::extractFillableFields($attribute));
+    }
+
+    public function test_extract_hidden_fields_reads_property_or_attribute(): void
+    {
+        $property = $this->classFrom('<?php class User { protected $hidden = ["password", "remember_token"]; }');
+        $attribute = $this->classFrom('<?php #[Hidden(["password", "remember_token"])] class User {}');
+
+        $this->assertSame(['password', 'remember_token'], EloquentModelHelper::extractHiddenFields($property));
+        $this->assertSame(['password', 'remember_token'], EloquentModelHelper::extractHiddenFields($attribute));
+    }
+
+    public function test_extract_guarded_fields_reads_property_or_attribute(): void
+    {
+        $property = $this->classFrom('<?php class User { protected $guarded = ["id"]; }');
+        $attribute = $this->classFrom('<?php #[Guarded(["id"])] class User {}');
+
+        $this->assertSame(['id'], EloquentModelHelper::extractGuardedFields($property));
+        $this->assertSame(['id'], EloquentModelHelper::extractGuardedFields($attribute));
+    }
+
+    public function test_extraction_skips_methods_and_unrelated_properties(): void
+    {
+        // The class mixes a non-target property ($table), a method, and the target
+        // $fillable so the property/has-property loops must skip non-matching members.
+        $class = $this->classFrom(<<<'PHP'
+<?php
+class User
+{
+    protected $table = 'users';
+
+    public function scopeActive($query)
+    {
+        return $query;
+    }
+
+    protected $fillable = ['name', 'email'];
+}
+PHP);
+
+        $this->assertTrue(EloquentModelHelper::hasFillable($class));
+        $this->assertSame(['name', 'email'], EloquentModelHelper::extractFillableFields($class));
+    }
+
+    public function test_extract_fillable_fields_from_attribute_skips_other_attributes(): void
+    {
+        // A non-Fillable attribute precedes the Fillable one, exercising the
+        // short-name mismatch skip in extractFieldsFromAttribute().
+        $class = $this->classFrom('<?php #[Guarded(["id"])] #[Fillable(["name"])] class User {}');
+
+        $this->assertSame(['name'], EloquentModelHelper::extractFillableFieldsFromAttribute($class));
+    }
+}


### PR DESCRIPTION
Part of ShieldCI/analyzers-core#53 (free-package step).

## What

`EloquentModelHelper` reads Eloquent mass-assignment configuration (`$fillable`/`$guarded`/`$hidden` properties and the Laravel 12 `#[Fillable]`/`#[Guarded]`/`#[Unguarded]`/`#[Hidden]` attributes) from an AST. That is Laravel-specific knowledge, which does not belong in the framework-agnostic `analyzers-core` (charter: "No Laravel, Symfony, or any framework code").

This PR ports the class to `laravel/src/Support/` (namespace `ShieldCI\Support`) with its test verbatim (16 tests), and points the two free-package consumers — `FillableForeignKeyAnalyzer` and `MassAssignmentAnalyzer` — at the local copy.

## Scope

Non-breaking, one repo. `analyzers-core` is untouched: `laravel-pro`'s `InertiaSecurityAnalyzer` still imports core's copy, so nothing downstream breaks. Removing the class from core is a separate breaking change (major bump) that lands once pro migrates too — tracked in analyzers-core#53.

## Verification

PHPStan level 9 clean, Pint clean. 16/16 helper tests pass against the local class; the two migrated analyzer suites pass unchanged.
