### PR TITLE
fix(eloquent-detector): resolve chain-walk parent by name, not whole file

### DIFF
--- a/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
+++ b/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
@@ -378,7 +378,6 @@ class MixedQueryBuilderEloquentAnalyzer extends AbstractFileAnalyzer
                     $this->treatToBaseAsQueryBuilder,
                     $this->mixingThreshold,
                     $this->tableRegistry,
-                    new EloquentModelDetector($this->parser),
                 );
                 $traverser = new NodeTraverser;
                 $traverser->addVisitor(new NameResolver);
@@ -452,8 +451,6 @@ class MixedQueryVisitor extends NodeVisitorAbstract
         'delete', 'truncate', 'increment', 'decrement',
     ];
 
-    private EloquentModelDetector $detector;
-
     /**
      * @param  array<string>  $whitelist
      * @param  array<string, string|null>  $tableRegistry
@@ -462,14 +459,12 @@ class MixedQueryVisitor extends NodeVisitorAbstract
         array $whitelist,
         bool $treatToBaseAsQueryBuilder,
         int $mixingThreshold,
-        array $tableRegistry,
-        EloquentModelDetector $detector
+        array $tableRegistry
     ) {
         $this->whitelist = $whitelist;
         $this->treatToBaseAsQueryBuilder = $treatToBaseAsQueryBuilder;
         $this->mixingThreshold = $mixingThreshold;
         $this->tableRegistry = $tableRegistry;
-        $this->detector = $detector;
     }
 
     public function enterNode(Node $node): ?Node
@@ -881,7 +876,7 @@ class MixedQueryVisitor extends NodeVisitorAbstract
         // POSITIVE CHECK 1: any Models namespace segment — App\Models, App\Models\Admin,
         // Domain\Users\Models — excluding helper sub-namespaces such as Models\Scopes.
         $namespace = ($pos = strrpos($normalized, '\\')) !== false ? substr($normalized, 0, $pos) : '';
-        if ($this->detector->namespaceLooksLikeModels($namespace)) {
+        if (EloquentModelDetector::namespaceLooksLikeModels($namespace)) {
             return true;
         }
 

--- a/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
+++ b/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
@@ -101,6 +101,8 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
         'Illuminate\\Foundation\\Support\\Providers\\AuthServiceProvider',
     ];
 
+    private ?EloquentModelDetector $modelDetector = null;
+
     /** @var array<string> */
     private array $whitelistDirs = [];
 
@@ -477,10 +479,13 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
      */
     private function isEloquentModelFromAst(array $ast): bool
     {
-        $detector = new EloquentModelDetector($this->parser);
+        // One detector per run, not per file: its per-file parse cache lets a shared
+        // base class (e.g. App\Models\BaseModel) be parsed once for the whole scan
+        // instead of re-parsed for every file that chain-walks to it.
+        $this->modelDetector ??= new EloquentModelDetector($this->parser);
 
         foreach ($this->parser->findClasses($ast) as $class) {
-            if ($detector->isModel($class, $ast, $this->getBasePath(), unknownIs: false)) {
+            if ($this->modelDetector->isModel($class, $ast, $this->getBasePath(), unknownIs: false)) {
                 return true;
             }
         }

--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -33,10 +33,21 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
      */
     private array $dangerousPatterns = [];
 
+    private ?EloquentModelDetector $modelDetector = null;
+
     public function __construct(
         private ParserInterface $parser,
         private Config $config
     ) {}
+
+    /**
+     * Shared across shouldRun() and runAnalysis() so the model scan in shouldRun()
+     * warms the per-file parse cache that runAnalysis() then reuses.
+     */
+    private function modelDetector(): EloquentModelDetector
+    {
+        return $this->modelDetector ??= new EloquentModelDetector($this->parser);
+    }
 
     protected function metadata(): AnalyzerMetadata
     {
@@ -53,8 +64,6 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 
     public function shouldRun(): bool
     {
-        $detector = new EloquentModelDetector($this->parser);
-
         foreach ($this->getPhpFiles() as $file) {
             $ast = $this->parser->parseFile($file);
             if (empty($ast)) {
@@ -63,7 +72,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 
             $classes = $this->parser->findClasses($ast);
             foreach ($classes as $class) {
-                if ($detector->isModel($class, $ast, $this->getBasePath())) {
+                if ($this->modelDetector()->isModel($class, $ast, $this->getBasePath())) {
                     return true;
                 }
             }
@@ -82,7 +91,6 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
         $this->loadDangerousPatterns();
 
         $issues = [];
-        $detector = new EloquentModelDetector($this->parser);
 
         foreach ($this->getPhpFiles() as $file) {
             $ast = $this->parser->parseFile($file);
@@ -92,7 +100,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 
             $classes = $this->parser->findClasses($ast);
             foreach ($classes as $class) {
-                if ($detector->isModel($class, $ast, $this->getBasePath())) {
+                if ($this->modelDetector()->isModel($class, $ast, $this->getBasePath())) {
                     if (! $this->hasLocalFillable($class) && ! $this->hasLocalGuarded($class)) {
                         $issues[] = $this->createIssue(
                             message: sprintf('Model "%s" does not define a local $fillable property; inherited fillable fields cannot be analyzed', $class->name?->toString() ?? 'Unknown'),

--- a/src/Support/EloquentModelDetector.php
+++ b/src/Support/EloquentModelDetector.php
@@ -66,8 +66,11 @@ final class EloquentModelDetector
      * layouts such as Modules\Billing\Models — while excluding the helper sub-namespaces
      * that live alongside models. `App\ViewModels` never qualifies: the match is on a
      * whole segment, not a suffix.
+     *
+     * Pure string predicate, so it is static: callers that only classify a namespace
+     * (e.g. MixedQueryVisitor) need no parser-bound instance.
      */
-    public function namespaceLooksLikeModels(?string $namespace): bool
+    public static function namespaceLooksLikeModels(?string $namespace): bool
     {
         if ($namespace === null || $namespace === '') {
             return false;
@@ -182,7 +185,7 @@ final class EloquentModelDetector
         }
 
         // Step 4: the parent itself lives in a Models namespace.
-        if ($this->namespaceLooksLikeModels($this->namespaceOf($parentFqn))) {
+        if (self::namespaceLooksLikeModels($this->namespaceOf($parentFqn))) {
             return true;
         }
 
@@ -197,7 +200,7 @@ final class EloquentModelDetector
         }
 
         // Step 6: the analyzed class's own namespace is a Models namespace.
-        if ($this->namespaceLooksLikeModels($namespace)) {
+        if (self::namespaceLooksLikeModels($namespace)) {
             return true;
         }
 

--- a/src/Support/EloquentModelDetector.php
+++ b/src/Support/EloquentModelDetector.php
@@ -56,8 +56,8 @@ final class EloquentModelDetector
 
     public function __construct(private readonly ParserInterface $parser) {}
 
-    /** @var array<string, bool|null> File path => Eloquent verdict */
-    private array $fileVerdictCache = [];
+    /** @var array<string, bool|null> "path::ShortName" => Eloquent verdict */
+    private array $verdictCache = [];
 
     /**
      * Whether a namespace denotes Eloquent models.
@@ -111,44 +111,42 @@ final class EloquentModelDetector
     }
 
     /**
-     * Three-valued verdict for the classes declared in a file, memoized by path.
+     * Three-valued verdict for one named class declared in a file, memoized by
+     * path + short name.
+     *
+     * The parent is resolved by matching $shortName against the file's named class
+     * declarations. A sibling class or an anonymous class in the same file — both
+     * returned by findClasses() — is never allowed to stand in for the parent, so a
+     * file whose $shortName class is a plain class does not read as a model merely
+     * because some other class beside it extends an Eloquent base. Returns null when
+     * the file declares no class of that name (parse failure, or a mismatch).
      */
-    private function fileVerdict(string $filePath, string $basePath): ?bool
+    private function classVerdictInFile(string $filePath, string $shortName, string $basePath): ?bool
     {
-        if (array_key_exists($filePath, $this->fileVerdictCache)) {
-            return $this->fileVerdictCache[$filePath];
+        $cacheKey = $filePath.'::'.$shortName;
+
+        if (array_key_exists($cacheKey, $this->verdictCache)) {
+            return $this->verdictCache[$cacheKey];
         }
 
         // Reserve the slot before recursing so a cyclic chain resolves to null
         // instead of looping. This is the sole termination mechanism: acyclic
-        // `extends` chains are finite, and a cycle re-entering a file already
+        // `extends` chains are finite, and a cycle re-entering a class already
         // in progress hits this reserved cache entry and returns immediately.
-        $this->fileVerdictCache[$filePath] = null;
+        $this->verdictCache[$cacheKey] = null;
 
         $fileAst = $this->parser->parseFile($filePath);
         if ($fileAst === []) {
             return null;
         }
 
-        $verdict = false;
-
         foreach ($this->parser->findClasses($fileAst) as $class) {
-            $classVerdict = $this->classVerdict($class, $fileAst, $basePath);
-
-            if ($classVerdict === true) {
-                $verdict = true;
-
-                break;
-            }
-
-            if ($classVerdict === null) {
-                $verdict = null;
+            if ($class->name?->toString() === $shortName) {
+                return $this->verdictCache[$cacheKey] = $this->classVerdict($class, $fileAst, $basePath);
             }
         }
 
-        $this->fileVerdictCache[$filePath] = $verdict;
-
-        return $verdict;
+        return null;
     }
 
     /**
@@ -192,7 +190,7 @@ final class EloquentModelDetector
         //         A definite verdict from the chain outranks the convention below.
         $parentPath = $this->fqnToFilePath($parentFqn, $basePath);
         if ($parentPath !== null) {
-            $chainVerdict = $this->fileVerdict($parentPath, $basePath);
+            $chainVerdict = $this->classVerdictInFile($parentPath, $this->shortName($parentFqn), $basePath);
             if ($chainVerdict !== null) {
                 return $chainVerdict;
             }

--- a/tests/Unit/Support/EloquentModelDetectorTest.php
+++ b/tests/Unit/Support/EloquentModelDetectorTest.php
@@ -550,6 +550,29 @@ PHP);
         $this->assertNull($this->detector->verdictFor($class, $ast, $dir));
     }
 
+    public function test_chain_walk_into_a_file_without_the_named_class_yields_unknown(): void
+    {
+        // The parent resolves to a file that exists and parses to a non-empty AST, but
+        // (a PSR-4 mismatch) declares no class of the expected name. The chain walk finds
+        // no match and returns unknown rather than judging an unrelated class beside it.
+        $dir = $this->createTempDir([
+            'app/Support/Base.php' => <<<'PHP'
+<?php
+namespace App\Support;
+class Renamed {}
+PHP,
+        ]);
+
+        [$class, $ast] = $this->parseClass(<<<'PHP'
+<?php
+namespace App\Entities;
+use App\Support\Base;
+class Order extends Base {}
+PHP);
+
+        $this->assertNull($this->detector->verdictFor($class, $ast, $dir));
+    }
+
     public function test_global_class_extending_an_unresolvable_bare_name_is_unknown(): void
     {
         // No namespace, no import: the parent name "Bar" cannot be resolved to an FQN

--- a/tests/Unit/Support/EloquentModelDetectorTest.php
+++ b/tests/Unit/Support/EloquentModelDetectorTest.php
@@ -319,6 +319,99 @@ PHP);
         $this->assertNull($this->detector->verdictFor($class, $ast, '/nonexistent'));
     }
 
+    public function test_chain_walk_ignores_a_sibling_model_in_the_parent_file(): void
+    {
+        // The parent file declares two classes: the actual parent Bundle (a plain class)
+        // and an unrelated sibling that extends Model. The chain walk must judge Bundle,
+        // not the sibling — otherwise a class merely file-sharing with a model is misread
+        // as a model. PSR-4 makes such a file non-conformant, but ShieldCI runs on exactly
+        // the messy/legacy code that produces it.
+        $base = <<<'PHP'
+<?php
+namespace App\Support;
+use Illuminate\Database\Eloquent\Model;
+class Bundle {}
+class LegacyRow extends Model {}
+PHP;
+
+        $child = <<<'PHP'
+<?php
+namespace App\Reports;
+use App\Support\Bundle;
+class SalesReport extends Bundle {}
+PHP;
+
+        $dir = $this->createTempDir(['app/Support/Bundle.php' => $base]);
+        [$class, $ast] = $this->parseClass($child);
+
+        $this->assertFalse(
+            $this->detector->verdictFor($class, $ast, $dir),
+            'a sibling model in the parent file must not make the parent read as a model'
+        );
+    }
+
+    public function test_chain_walk_ignores_an_anonymous_model_in_the_parent_file(): void
+    {
+        // findClasses() also returns anonymous classes, so a plain parent whose method
+        // body returns `new class extends Model {}` must not read as a model. Anonymous
+        // Eloquent classes are idiomatic in tests and package code.
+        $base = <<<'PHP'
+<?php
+namespace App\Support;
+use Illuminate\Database\Eloquent\Model;
+class AnonHost
+{
+    public function make()
+    {
+        return new class extends Model {};
+    }
+}
+PHP;
+
+        $child = <<<'PHP'
+<?php
+namespace App\Reports;
+use App\Support\AnonHost;
+class SalesReport extends AnonHost {}
+PHP;
+
+        $dir = $this->createTempDir(['app/Support/AnonHost.php' => $base]);
+        [$class, $ast] = $this->parseClass($child);
+
+        $this->assertFalse(
+            $this->detector->verdictFor($class, $ast, $dir),
+            'an anonymous model in the parent file must not make the parent read as a model'
+        );
+    }
+
+    public function test_chain_walk_selects_the_parent_by_name_among_siblings(): void
+    {
+        // The positive counterpart: when the file-sharing sibling is the actual model
+        // base, selecting the parent by name still resolves it correctly.
+        $base = <<<'PHP'
+<?php
+namespace App\Support;
+use Illuminate\Database\Eloquent\Model;
+class UnrelatedHelper {}
+class RecordBase extends Model {}
+PHP;
+
+        $child = <<<'PHP'
+<?php
+namespace App\Reports;
+use App\Support\RecordBase;
+class Invoice extends RecordBase {}
+PHP;
+
+        $dir = $this->createTempDir(['app/Support/RecordBase.php' => $base]);
+        [$class, $ast] = $this->parseClass($child);
+
+        $this->assertTrue(
+            $this->detector->verdictFor($class, $ast, $dir),
+            'the named parent still resolves through a file it shares with a non-model'
+        );
+    }
+
     public function test_cyclic_extends_chain_terminates_with_unknown(): void
     {
         $a = <<<'PHP'
@@ -441,8 +534,8 @@ PHP);
     public function test_chain_walk_into_an_empty_parent_file_yields_unknown(): void
     {
         // The parent file exists (so the chain walk reads it) but parses to an empty
-        // AST — e.g. a stub containing only the opening tag. fileVerdict() returns null
-        // for that file, and with neither class in a Models namespace the verdict is unknown.
+        // AST — e.g. a stub containing only the opening tag. The chain walk finds no
+        // class of that name, and with neither class in a Models namespace the verdict is unknown.
         $dir = $this->createTempDir([
             'app/Support/EmptyBase.php' => "<?php\n",
         ]);


### PR DESCRIPTION
Follows up #271. The unified `EloquentModelDetector` had a chain-walk bug plus three call sites that discarded its parse cache.

## Correctness

`fileVerdict()` collapsed a parent file to *"does any class in it resolve to a model?"* But `findClasses()` also returns anonymous classes and file-mate siblings, so a plain parent that shared a file with `class X extends Model` — or whose method returned `new class extends Model {}` — was misread as a model. That produced false mass-assignment/fillable findings and false suppression in service-container-resolution, contradicting the detector's stated "never a wrong answer" contract.

`classVerdictInFile()` now selects the class whose short name matches the parent and judges only that one, skipping anonymous/sibling declarations. Cache keyed by `path::ShortName`; the reserve-before-recurse cycle guard is preserved. Three regression tests (sibling model, anonymous model, plus a positive control that a real base still resolves through a shared file).

## Performance (no behavior change)

- **ServiceContainerResolution** built a detector once per scanned file; now one lazily-memoized per-run instance so a shared base is parsed once.
- **FillableForeignKey** built separate detectors in `shouldRun()`/`runAnalysis()`; now shared, so the first scan warms the cache the second reuses.
- **MixedQueryVisitor** only called `namespaceLooksLikeModels()`, a pure predicate — now `static`, so the visitor drops its detector field, ctor param, and per-file construction.

## Verification

PHPStan level 9 clean, Pint clean, full suite green (4344 tests, 0 failures).