### PR TITLE
docs(changelog): add v1.10.1 entry for #274

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.10.1
+
+### Fixed
+- `EloquentModelDetector` now resolves an `extends` chain's parent by class name instead of collapsing the parent's whole file to a single verdict, so a class whose parent shares a file with a sibling or anonymous `class ... extends Model` is no longer detected as an Eloquent model — which produced false `MassAssignmentAnalyzer` and `FillableForeignKeyAnalyzer` findings and wrongly suppressed `ServiceContainerResolutionAnalyzer` ones (#274)
+
 ## v1.10.0
 
 ### Fixed


### PR DESCRIPTION
Adds a `v1.10.1` section for the `EloquentModelDetector` chain-walk fix merged in #274.

Only the correctness fix is listed. The performance changes that rode along in #274 (per-run detector reuse, shared detector across `shouldRun`/`runAnalysis`, `namespaceLooksLikeModels()` made static) are internal mechanism with no behavior change.