### PR TITLE
fix(logic-in-blade): classify nested @foreach by loop source, not depth

### DIFF
--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
@@ -39,9 +40,13 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
 
     public const DEFAULT_MIN_ARITHMETIC_OPERATORS = 2;
 
+    public const DEFAULT_MAX_FOREACH_DEPTH = 2;
+
     private int $maxPhpBlockLines;
 
     private int $minArithmeticOperators;
+
+    private int $maxForeachDepth;
 
     /** @var array<int, true> Track reported lines to avoid duplicates */
     private array $reportedLines = [];
@@ -72,6 +77,7 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
 
         $this->maxPhpBlockLines = $analyzerConfig['max_php_block_lines'] ?? self::DEFAULT_MAX_PHP_BLOCK_LINES;
         $this->minArithmeticOperators = $analyzerConfig['min_arithmetic_operators'] ?? self::DEFAULT_MIN_ARITHMETIC_OPERATORS;
+        $this->maxForeachDepth = $analyzerConfig['max_foreach_depth'] ?? self::DEFAULT_MAX_FOREACH_DEPTH;
 
         $issues = [];
 
@@ -274,7 +280,7 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
             return;
         }
 
-        $visitor = new BladeLogicVisitor($this->minArithmeticOperators);
+        $visitor = new BladeLogicVisitor($this->minArithmeticOperators, $this->maxForeachDepth);
         $traverser = new NodeTraverser;
         $traverser->addVisitor($visitor);
         $traverser->traverse($ast);
@@ -321,18 +327,32 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
  * - Complex @if conditions (4+ boolean operators)
  * - Expensive computation (toArray, toJson, regex in loops)
  * - Complex calculations (multiple arithmetic operators, compound assignment)
- * - Nested @foreach loops
+ * - Nested @foreach loops that linearly search a collection per outer item
  * - Collection manipulation in @foreach expressions
  */
 class BladeLogicVisitor extends NodeVisitorAbstract
 {
-    private int $foreachDepth = 0;
+    /**
+     * Enclosing @foreach loops, outermost first. Populated on enter, popped on leave.
+     *
+     * @var list<array{value: string|null, key: string|null}>
+     */
+    private array $loopStack = [];
+
+    /**
+     * Right-hand side of the most recent $__currentLoopData assignment.
+     *
+     * Blade compiles @foreach($expr as $v) to `$__currentLoopData = $expr; foreach ($__currentLoopData as $v)`,
+     * so a loop's real source expression lives in the assignment immediately preceding it.
+     */
+    private ?Expr $lastLoopSource = null;
 
     /** @var list<array{message: string, severity: Severity, recommendation: string, code: string, line: int, metadata: array<string, mixed>}> */
     private array $issues = [];
 
     public function __construct(
         private int $minArithmeticOperators = LogicInBladeAnalyzer::DEFAULT_MIN_ARITHMETIC_OPERATORS,
+        private int $maxForeachDepth = LogicInBladeAnalyzer::DEFAULT_MAX_FOREACH_DEPTH,
     ) {}
 
     /** @var array<string> Non-Eloquent classes with DB-like method names */
@@ -425,24 +445,11 @@ class BladeLogicVisitor extends NodeVisitorAbstract
 
     public function enterNode(Node $node): ?int
     {
-        // Track foreach depth
         if ($node instanceof Stmt\Foreach_) {
-            $this->foreachDepth++;
-
-            // Check for nested @foreach (depth >= 2)
-            if ($this->foreachDepth >= 2) {
-                $this->addIssue(
-                    line: $node->getStartLine(),
-                    message: sprintf('Nested @foreach detected (depth: %d) - potential performance issue', $this->foreachDepth),
-                    severity: Severity::Medium,
-                    recommendation: 'Flatten nested data in the controller using eager loading or collection methods. Deeply nested loops in Blade can cause O(n²) or worse rendering performance',
-                    code: 'blade-nested-foreach',
-                    metadata: ['depth' => $this->foreachDepth],
-                );
-            }
-
-            // Check for collection manipulation in foreach expression
+            // Classify before pushing, so the stack holds only the *enclosing* loops.
+            $this->checkNestedLoop($node);
             $this->checkForeachExpression($node);
+            $this->pushLoop($node);
         }
 
         // Detect $__currentLoopData = $expr->collectionMethod() pattern
@@ -468,7 +475,7 @@ class BladeLogicVisitor extends NodeVisitorAbstract
         if ($node instanceof Expr\FuncCall) {
             $this->checkApiFuncCall($node);
             $this->checkBusinessLogicFunction($node);
-            if ($this->foreachDepth >= 1) {
+            if ($this->loopStack !== []) {
                 $this->checkExpensiveStringFunction($node);
             }
         }
@@ -494,10 +501,158 @@ class BladeLogicVisitor extends NodeVisitorAbstract
     public function leaveNode(Node $node): ?int
     {
         if ($node instanceof Stmt\Foreach_) {
-            $this->foreachDepth = max(0, $this->foreachDepth - 1);
+            array_pop($this->loopStack);
         }
 
         return null;
+    }
+
+    /**
+     * Record a loop's key/value variable names as the enclosing scope for any nested loop.
+     */
+    private function pushLoop(Stmt\Foreach_ $node): void
+    {
+        $this->loopStack[] = [
+            'value' => $this->variableName($node->valueVar),
+            'key' => $node->keyVar !== null ? $this->variableName($node->keyVar) : null,
+        ];
+    }
+
+    /**
+     * Report a nested @foreach only when it linearly searches a collection for each outer item.
+     *
+     * Nesting depth on its own measures nothing: iterating a partition ($groups as $k => $items /
+     * $items as $i), a relation ($category->products) or a keyed lookup ($data[$row->id]) visits each
+     * item exactly once — the sum of the group sizes is the total item count, so it is O(n), not O(n²).
+     * The wasteful shape is an inner loop that scans an *unrelated* collection to find the rows matching
+     * the outer item: O(n×m) work for O(n) of output, which a keyed lookup built in the controller removes.
+     */
+    private function checkNestedLoop(Stmt\Foreach_ $node): void
+    {
+        $depth = count($this->loopStack) + 1;
+
+        if ($depth < 2 || $depth < $this->maxForeachDepth) {
+            return;
+        }
+
+        $source = $this->resolveLoopSource($node);
+        if ($source === null) {
+            return;
+        }
+
+        // Source derived from an enclosing loop — each item is visited once. Not quadratic.
+        $enclosing = $this->enclosingLoopVariables();
+        if ($this->referencesAny($source, $enclosing)) {
+            return;
+        }
+
+        // An unrelated source is only wasteful if the body scans it for the outer item. Rendering
+        // every combination (a grid of rows × columns) costs what it outputs, so it is left alone.
+        $innerValue = $this->variableName($node->valueVar);
+        if ($innerValue === null || ! $this->searchesForEnclosingItem($node, $innerValue, $enclosing)) {
+            return;
+        }
+
+        $this->addIssue(
+            line: $node->getStartLine(),
+            message: sprintf('Nested @foreach scans a collection for each outer item (depth: %d) - O(n×m) rendering', $depth),
+            severity: Severity::Medium,
+            recommendation: 'Group the inner collection by the key it is matched on in the controller, then pass the grouped structure to the view so each outer item reads only its own rows instead of scanning the whole collection. Only the data shaping moves — the markup stays in Blade.',
+            code: 'blade-nested-foreach',
+            metadata: ['depth' => $depth],
+        );
+    }
+
+    /**
+     * Resolve the expression a loop actually iterates.
+     *
+     * Compiled Blade always iterates $__currentLoopData, so the real source is the assignment that
+     * precedes it. A raw `foreach` inside an @php block iterates its own expression directly.
+     */
+    private function resolveLoopSource(Stmt\Foreach_ $node): ?Expr
+    {
+        if ($node->expr instanceof Expr\Variable && $node->expr->name === '__currentLoopData') {
+            return $this->lastLoopSource;
+        }
+
+        return $node->expr;
+    }
+
+    /**
+     * @return list<string> Key and value variable names of every enclosing loop.
+     */
+    private function enclosingLoopVariables(): array
+    {
+        $names = [];
+
+        foreach ($this->loopStack as $loop) {
+            foreach ([$loop['value'], $loop['key']] as $name) {
+                if ($name !== null) {
+                    $names[] = $name;
+                }
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Does the inner loop compare one of its own values against an enclosing loop's value?
+     *
+     * This is the linear-search signature: a loop over every post nested inside a loop over every
+     * user, keeping only the posts where $post->user_id === $user->id.
+     *
+     * @param  list<string>  $enclosing
+     */
+    private function searchesForEnclosingItem(Stmt\Foreach_ $node, string $innerValue, array $enclosing): bool
+    {
+        $comparisons = (new NodeFinder)->find($node->stmts, fn (Node $found): bool => $found instanceof Expr\BinaryOp\Equal
+            || $found instanceof Expr\BinaryOp\Identical
+            || $found instanceof Expr\BinaryOp\NotEqual
+            || $found instanceof Expr\BinaryOp\NotIdentical);
+
+        foreach ($comparisons as $comparison) {
+            if (! $comparison instanceof Expr\BinaryOp) {
+                continue;
+            }
+
+            $matchesInner = fn (Expr $side): bool => $this->referencesAny($side, [$innerValue]);
+            $matchesOuter = fn (Expr $side): bool => $this->referencesAny($side, $enclosing);
+
+            if (($matchesInner($comparison->left) && $matchesOuter($comparison->right))
+                || ($matchesInner($comparison->right) && $matchesOuter($comparison->left))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Does any variable in this expression tree carry one of the given names?
+     *
+     * A whole-subtree scan (not just the root) so that a lookup keyed by the outer item —
+     * $cityData[$city->id]['rows'] — counts as derived from that item.
+     *
+     * @param  list<string>  $names
+     */
+    private function referencesAny(Node $node, array $names): bool
+    {
+        if ($names === []) {
+            return false;
+        }
+
+        return (new NodeFinder)->findFirst(
+            [$node],
+            fn (Node $found): bool => $found instanceof Expr\Variable
+                && is_string($found->name)
+                && in_array($found->name, $names, true)
+        ) !== null;
+    }
+
+    private function variableName(Node $node): ?string
+    {
+        return $node instanceof Expr\Variable && is_string($node->name) ? $node->name : null;
     }
 
     private function checkDbStaticCall(Expr\StaticCall $node): void
@@ -840,6 +995,10 @@ class BladeLogicVisitor extends NodeVisitorAbstract
             || $node->var->name !== '__currentLoopData') {
             return;
         }
+
+        // Remember what the upcoming foreach really iterates — the compiled loop itself only
+        // ever names $__currentLoopData. checkNestedLoop() reads this back.
+        $this->lastLoopSource = $node->expr;
 
         // Check if RHS is a method call with a collection manipulation method
         $rhs = $node->expr;

--- a/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/LogicInBladeAnalyzerTest.php
@@ -7,6 +7,7 @@ namespace ShieldCI\Tests\Unit\Analyzers\BestPractices;
 use Illuminate\Config\Repository;
 use ShieldCI\Analyzers\BestPractices\LogicInBladeAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\Tests\AnalyzerTestCase;
 
 class LogicInBladeAnalyzerTest extends AnalyzerTestCase
@@ -2289,8 +2290,130 @@ BLADE;
     // COMPUTATION COST TESTS (NEW)
     // =========================================================================
 
-    public function test_detects_nested_foreach(): void
+    /**
+     * Run the analyzer over a single Blade template and return only its nested-loop findings.
+     *
+     * Filtering by code (rather than asserting on the whole result) keeps these cases honest:
+     * an unrelated rule firing inside a fixture cannot make a "no nested-loop issue" test pass or fail.
+     *
+     * @param  array<string, mixed>  $config
+     * @return list<Issue>
+     */
+    private function nestedForeachIssues(string $blade, array $config = []): array
     {
+        $tempDir = $this->createTempDirectory(['views/nested.blade.php' => $blade]);
+
+        $analyzer = new LogicInBladeAnalyzer(new Repository([
+            'shieldci' => ['analyzers' => ['best-practices' => ['logic-in-blade' => $config]]],
+        ]));
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['views']);
+
+        return array_values(array_filter(
+            $analyzer->analyze()->getIssues(),
+            fn ($issue): bool => ($issue->metadata['code'] ?? null) === 'blade-nested-foreach'
+        ));
+    }
+
+    public function test_detects_nested_foreach_that_searches_for_the_outer_item(): void
+    {
+        // The inner loop scans every post to find the ones belonging to the current user:
+        // O(n×m) work for O(n) of output. Grouping posts by user_id in the controller removes it.
+        $blade = <<<'BLADE'
+<div>
+    @foreach($users as $user)
+        <h2>{{ $user->name }}</h2>
+        @foreach($allPosts as $post)
+            @if($post->user_id === $user->id)
+                <p>{{ $post->title }}</p>
+            @endif
+        @endforeach
+    @endforeach
+</div>
+BLADE;
+
+        $issues = $this->nestedForeachIssues($blade);
+
+        $this->assertCount(1, $issues);
+        $this->assertStringContainsString('scans a collection for each outer item', $issues[0]->message);
+    }
+
+    public function test_nested_foreach_has_medium_severity(): void
+    {
+        $blade = <<<'BLADE'
+<div>
+    @foreach($users as $user)
+        @foreach($allPosts as $post)
+            @if($post->user_id == $user->id)
+                <p>{{ $post->title }}</p>
+            @endif
+        @endforeach
+    @endforeach
+</div>
+BLADE;
+
+        $issues = $this->nestedForeachIssues($blade);
+
+        $this->assertCount(1, $issues);
+        $this->assertEquals('medium', $issues[0]->severity->value);
+    }
+
+    public function test_ignores_partition_iteration_over_a_grouped_array(): void
+    {
+        // The regression test for issue #276. Every option is rendered exactly once — the sum of the
+        // group sizes is the total option count — so this is O(n), not O(n²).
+        $blade = <<<'BLADE'
+<select name="city">
+    @foreach($cityOptions as $country => $options)
+        <optgroup label="{{ $country }}">
+            @foreach($options as $option)
+                <option value="{{ $option['value'] }}">{{ $option['label'] }}</option>
+            @endforeach
+        </optgroup>
+    @endforeach
+</select>
+BLADE;
+
+        $this->assertSame([], $this->nestedForeachIssues($blade));
+    }
+
+    public function test_ignores_iteration_over_an_array_key_of_the_outer_item(): void
+    {
+        $blade = <<<'BLADE'
+<div>
+    @foreach($records as $record)
+        @foreach($record['users'] as $user)
+            <p>{{ $user['name'] }}</p>
+        @endforeach
+    @endforeach
+</div>
+BLADE;
+
+        $this->assertSame([], $this->nestedForeachIssues($blade));
+    }
+
+    public function test_ignores_lookup_keyed_by_the_outer_item(): void
+    {
+        // An O(1) hash lookup returning only this city's own rows — per-item, so still O(n) overall.
+        $blade = <<<'BLADE'
+<div>
+    @foreach($cities as $city)
+        @forelse($membershipData[$city->id]['items'] as $item)
+            <p>{{ $item['label'] }}</p>
+        @empty
+            <p>None</p>
+        @endforelse
+    @endforeach
+</div>
+BLADE;
+
+        $this->assertSame([], $this->nestedForeachIssues($blade));
+    }
+
+    public function test_ignores_relationship_access_on_the_outer_item(): void
+    {
+        // Iterating a relation renders each product once. Whether it lazy-loads depends on the
+        // controller's with() call, which a Blade template cannot see — so this stays silent.
         $blade = <<<'BLADE'
 <div>
     @foreach($categories as $category)
@@ -2302,49 +2425,61 @@ BLADE;
 </div>
 BLADE;
 
-        $tempDir = $this->createTempDirectory(['views/nested.blade.php' => $blade]);
-
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['views']);
-
-        $result = $analyzer->analyze();
-
-        $this->assertWarning($result);
-        $this->assertHasIssueContaining('Nested @foreach', $result);
+        $this->assertSame([], $this->nestedForeachIssues($blade));
     }
 
-    public function test_nested_foreach_has_medium_severity(): void
+    public function test_ignores_grid_rendering(): void
+    {
+        // The inner collection is unrelated to the outer one, but nothing is searched: the loop
+        // renders one cell per row/column pair, so its cost is the size of its own output.
+        $blade = <<<'BLADE'
+<table>
+    @foreach($rows as $row)
+        <tr>
+            @foreach($columns as $column)
+                <td>{{ $row[$column] }}</td>
+            @endforeach
+        </tr>
+    @endforeach
+</table>
+BLADE;
+
+        $this->assertSame([], $this->nestedForeachIssues($blade));
+    }
+
+    public function test_ignores_triple_nested_partition_iteration(): void
     {
         $blade = <<<'BLADE'
 <div>
-    @foreach($categories as $category)
-        @foreach($category->products as $product)
-            <p>{{ $product->name }}</p>
+    @foreach($continents as $continent => $countries)
+        @foreach($countries as $country => $cities)
+            @foreach($cities as $city)
+                <p>{{ $city['name'] }}</p>
+            @endforeach
         @endforeach
     @endforeach
 </div>
 BLADE;
 
-        $tempDir = $this->createTempDirectory(['views/nested-sev.blade.php' => $blade]);
+        $this->assertSame([], $this->nestedForeachIssues($blade));
+    }
 
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['views']);
+    public function test_max_foreach_depth_is_configurable(): void
+    {
+        $blade = <<<'BLADE'
+<div>
+    @foreach($users as $user)
+        @foreach($allPosts as $post)
+            @if($post->user_id === $user->id)
+                <p>{{ $post->title }}</p>
+            @endif
+        @endforeach
+    @endforeach
+</div>
+BLADE;
 
-        $result = $analyzer->analyze();
-
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $nestedIssue = null;
-        foreach ($issues as $issue) {
-            if (($issue->metadata['code'] ?? null) === 'blade-nested-foreach') {
-                $nestedIssue = $issue;
-                break;
-            }
-        }
-        $this->assertNotNull($nestedIssue);
-        $this->assertEquals('medium', $nestedIssue->severity->value);
+        $this->assertCount(1, $this->nestedForeachIssues($blade));
+        $this->assertSame([], $this->nestedForeachIssues($blade, ['max_foreach_depth' => 3]));
     }
 
     public function test_passes_with_single_foreach(): void
@@ -2536,32 +2671,21 @@ BLADE;
     {
         $blade = <<<'BLADE'
 <div>
-    @foreach($categories as $category)
-        @foreach($category->products as $product)
-            <p>{{ $product->name }}</p>
+    @foreach($users as $user)
+        @foreach($allPosts as $post)
+            @if($post->user_id === $user->id)
+                <p>{{ $post->title }}</p>
+            @endif
         @endforeach
     @endforeach
 </div>
 BLADE;
 
-        $tempDir = $this->createTempDirectory(['views/nested-meta.blade.php' => $blade]);
+        $issues = $this->nestedForeachIssues($blade);
 
-        $analyzer = $this->createAnalyzer();
-        $analyzer->setBasePath($tempDir);
-        $analyzer->setPaths(['views']);
-
-        $result = $analyzer->analyze();
-
-        $nestedIssue = null;
-        foreach ($result->getIssues() as $issue) {
-            if (($issue->metadata['code'] ?? null) === 'blade-nested-foreach') {
-                $nestedIssue = $issue;
-                break;
-            }
-        }
-        $this->assertNotNull($nestedIssue);
-        $this->assertArrayHasKey('depth', $nestedIssue->metadata);
-        $this->assertEquals(2, $nestedIssue->metadata['depth']);
+        $this->assertCount(1, $issues);
+        $this->assertArrayHasKey('depth', $issues[0]->metadata);
+        $this->assertEquals(2, $issues[0]->metadata['depth']);
     }
 
     // =========================================================================


### PR DESCRIPTION
Closes #276.

`blade-nested-foreach` counted lexical `@foreach` depth and nothing else, so it reported every loop-inside-a-loop as *"O(n²) or worse"*. That is false for the ordinary shapes — partition iteration (`$groups as $k => $items` / `$items`), lookups keyed by the outer item, and relation access all visit each item exactly once. Worse, its recommendation to "flatten nested data in the controller" reads as *move markup into PHP*, and in a real app it produced exactly that: nested loops rebuilt as concatenated HTML strings, trading Blade's auto-escaping for hand-written `e()` and adding a `{!! !!}` sink per view.

Blade compiles `@foreach($expr as $v)` to `$__currentLoopData = $expr; foreach ($__currentLoopData as $v)`, so the inner loop's **source expression** is inspectable. It is now reported only when both hold:

1. its source references no enclosing loop variable anywhere in its subtree, and
2. its body compares an inner-loop value against an enclosing-loop value.

That is the linear-search shape (`@if($post->user_id === $user->id)`) — O(n×m) work for O(n) of output, whose fix is grouping data by key in the controller: data shaping, not markup. Grid rendering (`$rows` × `$columns`) stays silent because its cost equals its output.

Two deviations from the issue's suggested fix, both driven by the real corpus:

- **No N+1 branch.** Both `$city->airports` loops there are already eager-loaded (`City::with(['airports', ...])`), so flagging them would be a 2-for-2 false positive on correct code. Eager loading is invisible from inside a template — which is why `NPlusOneVisitor` already declines to flag when it cannot establish a type. Blade N+1 belongs to `eloquent-n-plus-one`, which currently parses raw `.blade.php` and so sees zero loop nodes; worth a separate issue.
- **No naive cross-product flag**, which would have hit legitimate table rendering.

Verified against the affected app: all 31 nested loops across 126 views (every one flagged today) are silent, while a synthetic search-in-loop probe is still reported. `max_foreach_depth` is now configurable, read with a code-level default like the analyzer's other two tunables.