### PR TITLE
feat(eloquent-n-plus-one): detect N+1 queries in Blade templates

### DIFF
--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -236,6 +236,28 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
                 ],
             );
         }
+
+        // Process query-inside-loop issues (an actual query executed per iteration, as
+        // opposed to a lazy relationship access above) — the most severe N+1 shape, and it
+        // must be reported from a Blade template exactly like the plain-PHP path does.
+        foreach ($visitor->getQueryIssues() as $issue) {
+            $bladeLine = $compiled['lineMap'][$issue['line']] ?? null;
+            if ($bladeLine === null) {
+                continue;
+            }
+            $issues[] = $this->createIssueWithSnippet(
+                message: "N+1 query: executing '{$issue['query']}' inside loop",
+                filePath: $file,
+                lineNumber: $bladeLine,
+                severity: $this->metadata()->severity,
+                recommendation: $this->getQueryRecommendation($issue['query'], $issue['loop_type']),
+                metadata: [
+                    'query' => $issue['query'],
+                    'loop_type' => $issue['loop_type'],
+                    'file' => $file,
+                ]
+            );
+        }
     }
 }
 

--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -562,12 +562,22 @@ class NPlusOneVisitor extends NodeVisitorAbstract
 
     private AccessorRegistry $accessorRegistry;
 
-    public function __construct(ModelScanResult $scanResult)
+    /**
+     * Pre-known variable bindings (e.g. controller context carried into a Blade view) are
+     * applied to the model-variable scanner before traversal begins.
+     *
+     * @param  array<string, array{type: ?string, eagerLoads: list<string>}>  $seedBindings
+     */
+    public function __construct(ModelScanResult $scanResult, array $seedBindings = [])
     {
         $this->relationshipRegistry = $scanResult->relationships;
         $this->modelAttributesRegistry = $scanResult->attributes;
         $this->accessorRegistry = $scanResult->accessors;
         $this->modelVars = new ModelVariableScanner;
+
+        foreach ($seedBindings as $var => $binding) {
+            $this->modelVars->seed($var, $binding['type'], $binding['eagerLoads']);
+        }
     }
 
     public function enterNode(Node $node)

--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -15,8 +15,13 @@ use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
+use ShieldCI\Support\BladeCompilerFactory;
 use ShieldCI\Support\ModelVariableScanner;
+use ShieldCI\Support\ViewBindingRegistry;
+use ShieldCI\Support\ViewRenderScanner;
 
 /**
  * Identifies missing eager loading that causes N+1 query problems.
@@ -54,10 +59,19 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
         $scanner = new EloquentModelRelationshipScanner($this->parser);
         $scanResult = $scanner->scan($allFiles);
 
+        $viewsBase = rtrim((string) $this->basePath, '/').'/resources/views';
+        $bindingRegistry = (new ViewRenderScanner($this->parser))->scan(array_values($allFiles), $viewsBase);
+
         foreach ($allFiles as $file) {
             // N+1 is a request-path concern. One-time DB scaffolding (seeders, migrations,
             // factories) idiomatically loops upserts/lookups where query count is irrelevant.
             if ($this->shouldSkipFile($file)) {
+                continue;
+            }
+
+            if (str_ends_with($file, '.blade.php')) {
+                $this->analyzeBladeFile($file, $bindingRegistry, $scanResult, $issues);
+
                 continue;
             }
 
@@ -155,6 +169,73 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
     private function getQueryRecommendation(string $query, string $loopType): string
     {
         return "Executing '{$query}' inside a {$loopType} triggers a separate database query for each iteration. Consider fetching all required data before the loop using whereIn() or eager loading, then filter in-memory.";
+    }
+
+    /**
+     * Analyze a single Blade view, seeded with the controller-bound variable types and eager
+     * loads that a template cannot derive on its own.
+     *
+     * @param  array<int, Issue>  $issues
+     */
+    private function analyzeBladeFile(string $file, ViewBindingRegistry $bindingRegistry, ModelScanResult $scanResult, array &$issues): void
+    {
+        $normalized = strtolower(str_replace('\\', '/', $file));
+        if (str_contains($normalized, '/vendor/')) {
+            return;
+        }
+
+        $bindings = $bindingRegistry->resolve($file);
+        if ($bindings === null) {
+            return; // no resolvable render site → skip the view
+        }
+
+        $content = FileParser::readFile($file);
+        if ($content === null) {
+            return;
+        }
+        $compiled = BladeCompilerFactory::compile($content);
+        if ($compiled === null) {
+            return;
+        }
+
+        $ast = $this->parser->parseCode($compiled['compiledPhp']);
+        if ($ast === []) {
+            return;
+        }
+
+        $seed = [];
+        foreach ($bindings as $var => $binding) {
+            $seed[$var] = ['type' => $binding['type'], 'eagerLoads' => $binding['eagerLoads']];
+        }
+
+        $visitor = new NPlusOneVisitor($scanResult, $seed);
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        foreach ($visitor->getIssues() as $issue) {
+            $bladeLine = $compiled['lineMap'][$issue['line']] ?? null;
+            if ($bladeLine === null) {
+                continue;
+            }
+            // The visitor reports the loop variable (e.g. 'city'), but bindings are keyed by
+            // the render-bound variable (e.g. 'cities') — trace back through the loop var's
+            // origin to find the binding that actually carries a `source`.
+            $origin = $visitor->originOf($issue['variable']) ?? $issue['variable'];
+            $source = $bindings[$origin]['source'] ?? 'the controller';
+            $issues[] = $this->createIssueWithSnippet(
+                message: "Potential N+1 query: accessing '{$issue['relationship']}' inside loop",
+                filePath: $file,
+                lineNumber: $bladeLine,
+                severity: $this->metadata()->severity,
+                recommendation: "\${$issue['variable']} reaches this view from {$source}. Eager-load the '{$issue['relationship']}' relation there (with()) so the view iterates data already in memory.",
+                metadata: [
+                    'relationship' => $issue['relationship'],
+                    'source' => $source,
+                    'file' => $file,
+                ],
+            );
+        }
     }
 }
 
@@ -1465,5 +1546,15 @@ class NPlusOneVisitor extends NodeVisitorAbstract
         }
 
         return $unique;
+    }
+
+    /**
+     * The render-bound variable name a variable ultimately derives from (e.g. a Blade loop
+     * variable traced back to the controller-passed variable it was seeded from), or `null` if
+     * it was never seeded or aliased from a seeded variable.
+     */
+    public function originOf(string $var): ?string
+    {
+        return $this->modelVars->originOf($var);
     }
 }

--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -927,6 +927,10 @@ class NPlusOneVisitor extends NodeVisitorAbstract
     /**
      * Determine if a property/method name is a real or probable relationship.
      *
+     * An accessor or declared model attribute is never a relationship, so that check
+     * applies regardless of whether the model defines any relationships at all — it runs
+     * before the registry-membership gate, on both the precise-lookup and heuristic paths.
+     *
      * When the loop variable's model type is known (via registry), uses precise registry
      * lookup. Otherwise falls back to heuristics. Method-call context uses
      * looksLikeRelationshipMethod (stricter exclusions) to avoid false positives
@@ -937,17 +941,18 @@ class NPlusOneVisitor extends NodeVisitorAbstract
         $model = $this->modelVars->typeOf($loopVariable);
 
         if ($model !== null && ! str_starts_with($model, 'Collection<')) {
+            // An accessor or declared attribute is never a relationship — check this
+            // regardless of whether the model defines any relationships at all.
+            if ($this->modelAttributesRegistry->has($model, $name)) {
+                return false;
+            }
+            if ($this->accessorRegistry->has($model, $name)) {
+                return false;
+            }
+
             // Model type known from a static call (Post::get(), Post::all(), etc.)
             if (array_key_exists($model, $this->relationshipRegistry->all())) {
                 // Model IS in the registry — precise lookup only, no heuristics.
-                // Also exclude properties declared as attributes or accessors.
-                if ($this->modelAttributesRegistry->has($model, $name)) {
-                    return false;
-                }
-                if ($this->accessorRegistry->has($model, $name)) {
-                    return false;
-                }
-
                 return $this->relationshipRegistry->has($model, $name);
             }
 

--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -265,30 +265,6 @@ class RelationshipRegistry
 }
 
 /**
- * Tracks inferred variable types (e.g. $posts → Collection<Post>, $post → Post).
- */
-class VariableTypeRegistry
-{
-    /** @var array<string, string> */
-    private array $types = [];
-
-    public function set(string $var, string $type): void
-    {
-        $this->types[$var] = $type;
-    }
-
-    public function get(string $var): ?string
-    {
-        return $this->types[$var] ?? null;
-    }
-
-    public function has(string $var): bool
-    {
-        return isset($this->types[$var]);
-    }
-}
-
-/**
  * Tracks model attributes (from $fillable, $casts, $appends) per model class.
  *
  * Used to distinguish regular column access from relationship access.

--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -16,6 +16,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Support\ModelVariableScanner;
 
 /**
  * Identifies missing eager loading that causes N+1 query problems.
@@ -546,13 +547,6 @@ class NPlusOneVisitor extends NodeVisitorAbstract
     private array $uniquenessProbeNodes = [];
 
     /**
-     * Track variables and their eager loaded relationships.
-     *
-     * @var array<string, array<string>>
-     */
-    private array $eagerLoadedRelationships = [];
-
-    /**
      * Track relationships checked with relationLoaded() per loop variable.
      * Key format: "loopVariable:relationship"
      *
@@ -560,7 +554,7 @@ class NPlusOneVisitor extends NodeVisitorAbstract
      */
     private array $relationLoadedChecks = [];
 
-    private VariableTypeRegistry $variableTypes;
+    private ModelVariableScanner $modelVars;
 
     private RelationshipRegistry $relationshipRegistry;
 
@@ -573,46 +567,14 @@ class NPlusOneVisitor extends NodeVisitorAbstract
         $this->relationshipRegistry = $scanResult->relationships;
         $this->modelAttributesRegistry = $scanResult->attributes;
         $this->accessorRegistry = $scanResult->accessors;
-        $this->variableTypes = new VariableTypeRegistry;
+        $this->modelVars = new ModelVariableScanner;
     }
 
     public function enterNode(Node $node)
     {
-        // Track variable assignments to detect eager loading and model queries
-        if ($node instanceof Expr\Assign) {
-            if ($node->var instanceof Expr\Variable && is_string($node->var->name)) {
-                // Check if the assignment uses with() or load() for eager loading
-                $this->trackEagerLoading($node->expr, $node->var->name);
-                // Infer variable type from model query (e.g. $posts = Post::get())
-                $this->detectModelQuery($node);
-            }
-
-            return null;
-        }
-
-        // Track load() calls on existing variables: $posts->load('user')
-        if ($node instanceof Expr\MethodCall) {
-            if ($node->var instanceof Expr\Variable &&
-                is_string($node->var->name) &&
-                $node->name instanceof Node\Identifier &&
-                in_array($node->name->toString(), ['load', 'loadMissing'], true)) {
-
-                $varName = $node->var->name;
-                $relationships = $this->extractRelationshipsFromEagerLoadCall($node);
-
-                if (! empty($relationships)) {
-                    // Merge with existing eager loaded relationships
-                    if (isset($this->eagerLoadedRelationships[$varName])) {
-                        $this->eagerLoadedRelationships[$varName] = array_values(array_unique(array_merge(
-                            $this->eagerLoadedRelationships[$varName],
-                            $relationships
-                        )));
-                    } else {
-                        $this->eagerLoadedRelationships[$varName] = $relationships;
-                    }
-                }
-            }
-        }
+        // Feed every node to the model-variable scanner so it can infer variable
+        // types (e.g. $posts → Collection<Post>) and eager-loaded relationships.
+        $this->modelVars->enterNode($node);
 
         // Track loop entry
         if ($node instanceof Stmt\Foreach_) {
@@ -856,65 +818,6 @@ class NPlusOneVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * Detect model query assignments and record variable types.
-     *
-     * Handles: $posts = Post::get(), $posts = Post::with('user')->get(), $post = Post::find(1)
-     */
-    private function detectModelQuery(Expr\Assign $node): void
-    {
-        if (! ($node->var instanceof Expr\Variable) || ! is_string($node->var->name)) {
-            return;
-        }
-        $varName = $node->var->name;
-        $expr = $node->expr;
-
-        // Direct static call: Post::all(), Post::get(), Post::find(1)
-        if ($expr instanceof Expr\StaticCall &&
-            $expr->class instanceof Node\Name &&
-            $expr->name instanceof Node\Identifier) {
-            $className = $expr->class->getLast();
-            $lowerMethod = strtolower($expr->name->toString());
-            if (in_array($lowerMethod, ['get', 'all', 'paginate', 'simplepaginate'], true)) {
-                $this->variableTypes->set($varName, "Collection<{$className}>");
-            } elseif (in_array($lowerMethod, ['find', 'first', 'findorfail', 'firstorfail'], true)) {
-                $this->variableTypes->set($varName, $className);
-            }
-
-            return;
-        }
-
-        // Chained method calls: Post::where()->get(), Post::with('user')->get()
-        if ($expr instanceof Expr\MethodCall && $expr->name instanceof Node\Identifier) {
-            $lowerMethod = strtolower($expr->name->toString());
-            $className = $this->resolveModelFromChain($expr);
-            if ($className !== null) {
-                if (in_array($lowerMethod, ['get', 'all', 'paginate', 'simplepaginate'], true)) {
-                    $this->variableTypes->set($varName, "Collection<{$className}>");
-                } elseif (in_array($lowerMethod, ['find', 'first', 'findorfail', 'firstorfail'], true)) {
-                    $this->variableTypes->set($varName, $className);
-                }
-            }
-        }
-    }
-
-    /**
-     * Walk a MethodCall chain to find the root StaticCall class name.
-     */
-    private function resolveModelFromChain(Expr\MethodCall $node): ?string
-    {
-        $current = $node->var;
-        while ($current instanceof Expr\MethodCall) {
-            $current = $current->var;
-        }
-
-        if ($current instanceof Expr\StaticCall && $current->class instanceof Node\Name) {
-            return $current->class->getLast();
-        }
-
-        return null;
-    }
-
-    /**
      * Infer loop variable type from source collection type, and copy eager loading context.
      */
     private function inferLoopVariableType(Stmt\Foreach_ $node): void
@@ -929,17 +832,7 @@ class NPlusOneVisitor extends NodeVisitorAbstract
         }
         $sourceVar = $node->expr->name;
 
-        // Infer model type from Collection<Model> → Model
-        $collectionType = $this->variableTypes->get($sourceVar);
-        if ($collectionType !== null && str_starts_with($collectionType, 'Collection<')) {
-            $model = trim(str_replace(['Collection<', '>'], '', $collectionType));
-            $this->variableTypes->set($loopVar, $model);
-        }
-
-        // Copy eager loaded relationships from source variable to loop variable context
-        if (isset($this->eagerLoadedRelationships[$sourceVar])) {
-            $this->eagerLoadedRelationships[$loopVar] = $this->eagerLoadedRelationships[$sourceVar];
-        }
+        $this->modelVars->copyContext($sourceVar, $loopVar);
     }
 
     /**
@@ -952,7 +845,7 @@ class NPlusOneVisitor extends NodeVisitorAbstract
      */
     private function isActualOrProbableRelationship(string $loopVariable, string $name, bool $isMethodCall = false): bool
     {
-        $model = $this->variableTypes->get($loopVariable);
+        $model = $this->modelVars->typeOf($loopVariable);
 
         if ($model !== null && ! str_starts_with($model, 'Collection<')) {
             // Model type known from a static call (Post::get(), Post::all(), etc.)
@@ -1151,144 +1044,13 @@ class NPlusOneVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * Track eager loading from an expression.
-     */
-    private function trackEagerLoading(Node $expr, string $varName): void
-    {
-        // Look for chain like: Post::with(['user', 'comments'])->get()
-        // We need to recursively check the chain for with() calls
-        $relationships = $this->extractEagerLoadedRelationships($expr);
-
-        if (! empty($relationships)) {
-            $this->eagerLoadedRelationships[$varName] = $relationships;
-        }
-    }
-
-    /**
-     * Extract relationships from with() or load() calls in an expression chain.
-     *
-     * @return array<string>
-     */
-    private function extractEagerLoadedRelationships(Node $expr): array
-    {
-        $relationships = [];
-
-        // Check if this is a method call
-        if ($expr instanceof Expr\MethodCall) {
-            $relationships = $this->extractRelationshipsFromEagerLoadCall($expr);
-
-            // Recursively check the chain (e.g., Post::query()->with()->get())
-            $relationships = array_merge(
-                $relationships,
-                $this->extractEagerLoadedRelationships($expr->var)
-            );
-        }
-
-        // Check if this is a static call (e.g., Post::with())
-        if ($expr instanceof Expr\StaticCall) {
-            $relationships = $this->extractRelationshipsFromEagerLoadCall($expr);
-        }
-
-        return $relationships;
-    }
-
-    /**
-     * Extract relationships from a with() or load() method/static call.
-     *
-     * @return array<string>
-     */
-    private function extractRelationshipsFromEagerLoadCall(Expr\MethodCall|Expr\StaticCall $expr): array
-    {
-        // Check if the method is 'with' or 'load'
-        if (! ($expr->name instanceof Node\Identifier)) {
-            return [];
-        }
-
-        $methodName = $expr->name->toString();
-        if (! in_array($methodName, ['with', 'load', 'loadMissing'], true)) {
-            return [];
-        }
-
-        // Extract relationships from all arguments (Laravel supports variadic: with('user', 'comments'))
-        if (empty($expr->args)) {
-            return [];
-        }
-
-        $relationships = [];
-        foreach ($expr->args as $arg) {
-            $relationships = array_merge(
-                $relationships,
-                $this->parseRelationshipArgument($arg->value)
-            );
-        }
-
-        return array_unique($relationships);
-    }
-
-    /**
-     * Parse relationship argument (string or array).
-     *
-     * Expands dot notation so 'user.team' becomes ['user', 'user.team'].
-     *
-     * Handles both simple arrays and closure-keyed arrays:
-     * - with(['user', 'comments']) - relationship names as values
-     * - with(['user' => fn($q) => $q->select('id'), 'comments']) - relationship names as keys
-     *
-     * @return array<string>
-     */
-    private function parseRelationshipArgument(Node $arg): array
-    {
-        $rawRelationships = [];
-
-        // Handle array of relationships: with(['user', 'comments']) or with(['user' => fn() => ...])
-        if ($arg instanceof Expr\Array_) {
-            foreach ($arg->items as $item) {
-                if ($item === null) {
-                    continue;
-                }
-
-                // Check if relationship name is in the key (closure-keyed arrays)
-                // e.g., ['user' => fn($q) => $q->select('id')]
-                if ($item->key instanceof Node\Scalar\String_) {
-                    $rawRelationships[] = $item->key->value;
-                }
-                // Check if relationship name is in the value (simple arrays)
-                // e.g., ['user', 'comments']
-                elseif ($item->value instanceof Node\Scalar\String_) {
-                    $rawRelationships[] = $item->value->value;
-                }
-            }
-        }
-
-        // Handle single relationship: with('user')
-        if ($arg instanceof Node\Scalar\String_) {
-            $rawRelationships[] = $arg->value;
-        }
-
-        // Expand dot notation relationships
-        $expanded = [];
-        foreach ($rawRelationships as $relationship) {
-            // Strip Laravel's column-selection constraint: 'project:id,name' → 'project'
-            // 'comments.author:id,name' → 'comments.author'
-            $relationship = explode(':', $relationship, 2)[0];
-            $expanded = array_merge($expanded, $this->expandDotNotation($relationship));
-        }
-
-        return array_unique($expanded);
-    }
-
-    /**
      * Check if a relationship is eager loaded for a variable.
      *
      * Also matches prefix: if 'user.team' is loaded, then 'user' is considered covered.
      */
     private function isEagerLoaded(string $varName, string $relationship): bool
     {
-        if (! isset($this->eagerLoadedRelationships[$varName])) {
-            return false;
-        }
-
-        foreach ($this->eagerLoadedRelationships[$varName] as $loaded) {
+        foreach ($this->modelVars->eagerLoadsOf($varName) as $loaded) {
             if ($relationship === $loaded || str_starts_with($loaded, $relationship.'.')) {
                 return true;
             }
@@ -1338,27 +1100,6 @@ class NPlusOneVisitor extends NodeVisitorAbstract
         }
 
         return null;
-    }
-
-    /**
-     * Expand dot notation relationship into all intermediate paths.
-     *
-     * Example: 'user.team.company' returns ['user', 'user.team', 'user.team.company']
-     *
-     * @return array<string>
-     */
-    private function expandDotNotation(string $relationship): array
-    {
-        $parts = explode('.', $relationship);
-        $expanded = [];
-        $path = '';
-
-        foreach ($parts as $part) {
-            $path = $path === '' ? $part : $path.'.'.$part;
-            $expanded[] = $path;
-        }
-
-        return $expanded;
     }
 
     /**

--- a/src/Support/ModelVariableScanner.php
+++ b/src/Support/ModelVariableScanner.php
@@ -49,6 +49,23 @@ class ModelVariableScanner extends NodeVisitorAbstract
         return null;
     }
 
+    /**
+     * Pre-populate a variable's model type and eager loads from outside the scanner's own
+     * AST walk (e.g. controller context passed into a Blade view, which has no query
+     * assignment of its own to infer from).
+     *
+     * @param  list<string>  $eagerLoads
+     */
+    public function seed(string $var, ?string $type, array $eagerLoads): void
+    {
+        if ($type !== null) {
+            $this->types[$var] = $type;
+        }
+        if ($eagerLoads !== []) {
+            $this->eagerLoads[$var] = array_values($eagerLoads);
+        }
+    }
+
     public function typeOf(string $var): ?string
     {
         return $this->types[$var] ?? null;

--- a/src/Support/ModelVariableScanner.php
+++ b/src/Support/ModelVariableScanner.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Infers, for a single method or file body, each variable's Eloquent model type and its
+ * eager-loaded relations. Extracted from NPlusOneVisitor so a view can be seeded with the
+ * types and eager loads a controller established — knowledge a Blade template cannot derive
+ * on its own.
+ */
+class ModelVariableScanner extends NodeVisitorAbstract
+{
+    /** @var array<string, string> */
+    private array $types = [];
+
+    /** @var array<string, list<string>> */
+    private array $eagerLoads = [];
+
+    public function enterNode(Node $node): ?int
+    {
+        if ($node instanceof Expr\Assign
+            && $node->var instanceof Expr\Variable
+            && is_string($node->var->name)) {
+            $this->trackEagerLoading($node->expr, $node->var->name);
+            $this->detectModelQuery($node);
+
+            return null;
+        }
+
+        if ($node instanceof Expr\MethodCall
+            && $node->var instanceof Expr\Variable
+            && is_string($node->var->name)
+            && $node->name instanceof Node\Identifier
+            && in_array($node->name->toString(), ['load', 'loadMissing'], true)) {
+            $relationships = $this->extractRelationshipsFromEagerLoadCall($node);
+            if ($relationships !== []) {
+                $this->eagerLoads[$node->var->name] = array_values(array_unique(
+                    array_merge($this->eagerLoads[$node->var->name] ?? [], $relationships)
+                ));
+            }
+        }
+
+        return null;
+    }
+
+    public function typeOf(string $var): ?string
+    {
+        return $this->types[$var] ?? null;
+    }
+
+    public function modelOf(string $var): ?string
+    {
+        $type = $this->types[$var] ?? null;
+        if ($type === null) {
+            return null;
+        }
+
+        if (str_starts_with($type, 'Collection<')) {
+            return trim(str_replace(['Collection<', '>'], '', $type));
+        }
+
+        return $type;
+    }
+
+    /** @return list<string> */
+    public function eagerLoadsOf(string $var): array
+    {
+        return $this->eagerLoads[$var] ?? [];
+    }
+
+    /**
+     * Detect model query assignments and record variable types.
+     *
+     * Handles: $posts = Post::get(), $posts = Post::with('user')->get(), $post = Post::find(1)
+     */
+    private function detectModelQuery(Expr\Assign $node): void
+    {
+        if (! ($node->var instanceof Expr\Variable) || ! is_string($node->var->name)) {
+            return;
+        }
+        $varName = $node->var->name;
+        $expr = $node->expr;
+
+        // Direct static call: Post::all(), Post::get(), Post::find(1)
+        if ($expr instanceof Expr\StaticCall &&
+            $expr->class instanceof Node\Name &&
+            $expr->name instanceof Node\Identifier) {
+            $className = $expr->class->getLast();
+            $lowerMethod = strtolower($expr->name->toString());
+            if (in_array($lowerMethod, ['get', 'all', 'paginate', 'simplepaginate'], true)) {
+                $this->types[$varName] = "Collection<{$className}>";
+            } elseif (in_array($lowerMethod, ['find', 'first', 'findorfail', 'firstorfail'], true)) {
+                $this->types[$varName] = $className;
+            }
+
+            return;
+        }
+
+        // Chained method calls: Post::where()->get(), Post::with('user')->get()
+        if ($expr instanceof Expr\MethodCall && $expr->name instanceof Node\Identifier) {
+            $lowerMethod = strtolower($expr->name->toString());
+            $className = $this->resolveModelFromChain($expr);
+            if ($className !== null) {
+                if (in_array($lowerMethod, ['get', 'all', 'paginate', 'simplepaginate'], true)) {
+                    $this->types[$varName] = "Collection<{$className}>";
+                } elseif (in_array($lowerMethod, ['find', 'first', 'findorfail', 'firstorfail'], true)) {
+                    $this->types[$varName] = $className;
+                }
+            }
+        }
+    }
+
+    /**
+     * Walk a MethodCall chain to find the root StaticCall class name.
+     */
+    private function resolveModelFromChain(Expr\MethodCall $node): ?string
+    {
+        $current = $node->var;
+        while ($current instanceof Expr\MethodCall) {
+            $current = $current->var;
+        }
+
+        if ($current instanceof Expr\StaticCall && $current->class instanceof Node\Name) {
+            return $current->class->getLast();
+        }
+
+        return null;
+    }
+
+    /**
+     * Track eager loading from an expression.
+     */
+    private function trackEagerLoading(Node $expr, string $varName): void
+    {
+        // Look for chain like: Post::with(['user', 'comments'])->get()
+        // We need to recursively check the chain for with() calls
+        $relationships = $this->extractEagerLoadedRelationships($expr);
+
+        if (! empty($relationships)) {
+            $this->eagerLoads[$varName] = array_values($relationships);
+        }
+    }
+
+    /**
+     * Extract relationships from with() or load() calls in an expression chain.
+     *
+     * @return array<string>
+     */
+    private function extractEagerLoadedRelationships(Node $expr): array
+    {
+        $relationships = [];
+
+        // Check if this is a method call
+        if ($expr instanceof Expr\MethodCall) {
+            $relationships = $this->extractRelationshipsFromEagerLoadCall($expr);
+
+            // Recursively check the chain (e.g., Post::query()->with()->get())
+            $relationships = array_merge(
+                $relationships,
+                $this->extractEagerLoadedRelationships($expr->var)
+            );
+        }
+
+        // Check if this is a static call (e.g., Post::with())
+        if ($expr instanceof Expr\StaticCall) {
+            $relationships = $this->extractRelationshipsFromEagerLoadCall($expr);
+        }
+
+        return $relationships;
+    }
+
+    /**
+     * Extract relationships from a with() or load() method/static call.
+     *
+     * @return array<string>
+     */
+    private function extractRelationshipsFromEagerLoadCall(Expr\MethodCall|Expr\StaticCall $expr): array
+    {
+        // Check if the method is 'with' or 'load'
+        if (! ($expr->name instanceof Node\Identifier)) {
+            return [];
+        }
+
+        $methodName = $expr->name->toString();
+        if (! in_array($methodName, ['with', 'load', 'loadMissing'], true)) {
+            return [];
+        }
+
+        // Extract relationships from all arguments (Laravel supports variadic: with('user', 'comments'))
+        if (empty($expr->args)) {
+            return [];
+        }
+
+        $relationships = [];
+        foreach ($expr->args as $arg) {
+            $relationships = array_merge(
+                $relationships,
+                $this->parseRelationshipArgument($arg->value)
+            );
+        }
+
+        return array_unique($relationships);
+    }
+
+    /**
+     * Parse relationship argument (string or array).
+     *
+     * Expands dot notation so 'user.team' becomes ['user', 'user.team'].
+     *
+     * Handles both simple arrays and closure-keyed arrays:
+     * - with(['user', 'comments']) - relationship names as values
+     * - with(['user' => fn($q) => $q->select('id'), 'comments']) - relationship names as keys
+     *
+     * @return array<string>
+     */
+    private function parseRelationshipArgument(Node $arg): array
+    {
+        $rawRelationships = [];
+
+        // Handle array of relationships: with(['user', 'comments']) or with(['user' => fn() => ...])
+        if ($arg instanceof Expr\Array_) {
+            foreach ($arg->items as $item) {
+                if ($item === null) {
+                    continue;
+                }
+
+                // Check if relationship name is in the key (closure-keyed arrays)
+                // e.g., ['user' => fn($q) => $q->select('id')]
+                if ($item->key instanceof Node\Scalar\String_) {
+                    $rawRelationships[] = $item->key->value;
+                }
+                // Check if relationship name is in the value (simple arrays)
+                // e.g., ['user', 'comments']
+                elseif ($item->value instanceof Node\Scalar\String_) {
+                    $rawRelationships[] = $item->value->value;
+                }
+            }
+        }
+
+        // Handle single relationship: with('user')
+        if ($arg instanceof Node\Scalar\String_) {
+            $rawRelationships[] = $arg->value;
+        }
+
+        // Expand dot notation relationships
+        $expanded = [];
+        foreach ($rawRelationships as $relationship) {
+            // Strip Laravel's column-selection constraint: 'project:id,name' → 'project'
+            // 'comments.author:id,name' → 'comments.author'
+            $relationship = explode(':', $relationship, 2)[0];
+            $expanded = array_merge($expanded, $this->expandDotNotation($relationship));
+        }
+
+        return array_unique($expanded);
+    }
+
+    /**
+     * Expand dot notation so 'user.team' becomes ['user', 'user.team'].
+     *
+     * @return array<string>
+     */
+    private function expandDotNotation(string $relationship): array
+    {
+        $parts = explode('.', $relationship);
+        $expanded = [];
+        $path = '';
+
+        foreach ($parts as $part) {
+            $path = $path === '' ? $part : $path.'.'.$part;
+            $expanded[] = $path;
+        }
+
+        return $expanded;
+    }
+}

--- a/src/Support/ModelVariableScanner.php
+++ b/src/Support/ModelVariableScanner.php
@@ -60,7 +60,7 @@ class ModelVariableScanner extends NodeVisitorAbstract
             }
 
             $this->trackEagerLoading($expr, $varName);
-            $this->detectModelQuery($node);
+            $this->detectModelQuery($expr, $varName);
 
             if ($varName === self::BLADE_LOOP_SOURCE
                 && $expr instanceof Expr\Variable
@@ -203,14 +203,8 @@ class ModelVariableScanner extends NodeVisitorAbstract
      *
      * Handles: $posts = Post::get(), $posts = Post::with('user')->get(), $post = Post::find(1)
      */
-    private function detectModelQuery(Expr\Assign $node): void
+    private function detectModelQuery(Expr $expr, string $varName): void
     {
-        if (! ($node->var instanceof Expr\Variable) || ! is_string($node->var->name)) {
-            return;
-        }
-        $varName = $node->var->name;
-        $expr = $node->expr;
-
         // Direct static call: Post::all(), Post::get(), Post::find(1)
         if ($expr instanceof Expr\StaticCall &&
             $expr->class instanceof Node\Name &&
@@ -350,10 +344,6 @@ class ModelVariableScanner extends NodeVisitorAbstract
         // Handle array of relationships: with(['user', 'comments']) or with(['user' => fn() => ...])
         if ($arg instanceof Expr\Array_) {
             foreach ($arg->items as $item) {
-                if ($item === null) {
-                    continue;
-                }
-
                 // Check if relationship name is in the key (closure-keyed arrays)
                 // e.g., ['user' => fn($q) => $q->select('id')]
                 if ($item->key instanceof Node\Scalar\String_) {

--- a/src/Support/ModelVariableScanner.php
+++ b/src/Support/ModelVariableScanner.php
@@ -47,10 +47,21 @@ class ModelVariableScanner extends NodeVisitorAbstract
             && $node->var instanceof Expr\Variable
             && is_string($node->var->name)) {
             $varName = $node->var->name;
-            $this->trackEagerLoading($node->expr, $varName);
+            $expr = $node->expr;
+
+            // Compiled Blade reassigns this same synthetic variable at every nesting level
+            // (`$__currentLoopData = $post->comments;` for the inner loop of a nested
+            // `@foreach`). Clear whatever an earlier (outer) assignment left behind before
+            // reprocessing this one — otherwise, when this assignment's RHS isn't itself a
+            // recognized alias/query shape, the entry is left stale and the inner loop
+            // variable silently inherits the OUTER loop's model type and eager loads.
+            if ($varName === self::BLADE_LOOP_SOURCE) {
+                unset($this->types[$varName], $this->eagerLoads[$varName], $this->origins[$varName]);
+            }
+
+            $this->trackEagerLoading($expr, $varName);
             $this->detectModelQuery($node);
 
-            $expr = $node->expr;
             if ($varName === self::BLADE_LOOP_SOURCE
                 && $expr instanceof Expr\Variable
                 && is_string($expr->name)) {

--- a/src/Support/ModelVariableScanner.php
+++ b/src/Support/ModelVariableScanner.php
@@ -75,6 +75,28 @@ class ModelVariableScanner extends NodeVisitorAbstract
     }
 
     /**
+     * Copy inferred model type and eager-loaded relationships from one variable to another.
+     *
+     * Used when a variable's context derives from another (e.g. a `foreach` loop variable
+     * inheriting the model type and eager loads of the collection it iterates), rather than
+     * from an assignment the scanner observes directly.
+     */
+    public function copyContext(string $from, string $to): void
+    {
+        $type = $this->types[$from] ?? null;
+        if ($type !== null && str_starts_with($type, 'Collection<')) {
+            $model = $this->modelOf($from);
+            if ($model !== null) {
+                $this->types[$to] = $model;
+            }
+        }
+
+        if (isset($this->eagerLoads[$from])) {
+            $this->eagerLoads[$to] = $this->eagerLoads[$from];
+        }
+    }
+
+    /**
      * Detect model query assignments and record variable types.
      *
      * Handles: $posts = Post::get(), $posts = Post::with('user')->get(), $post = Post::find(1)

--- a/src/Support/ModelVariableScanner.php
+++ b/src/Support/ModelVariableScanner.php
@@ -16,6 +16,16 @@ use PhpParser\NodeVisitorAbstract;
  */
 class ModelVariableScanner extends NodeVisitorAbstract
 {
+    /**
+     * Compiled Blade rewrites `@foreach($cities as $city)` into
+     * `$__currentLoopData = $cities; foreach ($__currentLoopData as $city): ...`. This is the
+     * only bare `$to = $from;` assignment `enterNode()` treats as an alias — a plain user-level
+     * `$renamed = $posts;` in ordinary PHP must NOT propagate type/eager-load info, since this
+     * scanner also runs over plain `.php` files where no such synthetic variable exists and
+     * broadening detection there is out of scope for Blade support.
+     */
+    private const BLADE_LOOP_SOURCE = '__currentLoopData';
+
     /** @var array<string, string> */
     private array $types = [];
 
@@ -41,7 +51,9 @@ class ModelVariableScanner extends NodeVisitorAbstract
             $this->detectModelQuery($node);
 
             $expr = $node->expr;
-            if ($expr instanceof Expr\Variable && is_string($expr->name)) {
+            if ($varName === self::BLADE_LOOP_SOURCE
+                && $expr instanceof Expr\Variable
+                && is_string($expr->name)) {
                 $this->aliasVariable($expr->name, $varName);
             }
 
@@ -143,13 +155,16 @@ class ModelVariableScanner extends NodeVisitorAbstract
     }
 
     /**
-     * Propagate a variable's type and eager loads, unchanged, to a plain alias of it
-     * (`$to = $from;`).
+     * Propagate a variable's type and eager loads, unchanged, to the compiled Blade loop
+     * variable that aliases it (`$__currentLoopData = $from;`).
      *
      * Compiled Blade `@foreach` rewrites `foreach ($cities as $city)` into
      * `$__currentLoopData = $cities; foreach ($__currentLoopData as $city): ...` — without this,
      * the loop's actual source variable (`$__currentLoopData`) never resolves back to the
      * seeded/inferred type on `$cities`, so `copyContext()` on the loop var has nothing to read.
+     * The caller restricts this to that one synthetic target (see `BLADE_LOOP_SOURCE`) precisely
+     * because a real user assignment like `$renamed = $posts;` is not an alias in the same sense —
+     * propagating through it would widen plain-`.php` N+1 detection, which is unchanged by design.
      * Unlike `copyContext()`, this keeps a `Collection<Model>` type as-is (an alias holds the
      * same value, not its element).
      */

--- a/src/Support/ModelVariableScanner.php
+++ b/src/Support/ModelVariableScanner.php
@@ -22,13 +22,28 @@ class ModelVariableScanner extends NodeVisitorAbstract
     /** @var array<string, list<string>> */
     private array $eagerLoads = [];
 
+    /**
+     * Maps a variable to the name of the render-bound variable it ultimately derives from
+     * (itself, for a directly seeded variable). Lets a Blade N+1 finding on a loop variable
+     * trace back to the controller-passed variable a `ViewBindingRegistry` binding is keyed by.
+     *
+     * @var array<string, string>
+     */
+    private array $origins = [];
+
     public function enterNode(Node $node): ?int
     {
         if ($node instanceof Expr\Assign
             && $node->var instanceof Expr\Variable
             && is_string($node->var->name)) {
-            $this->trackEagerLoading($node->expr, $node->var->name);
+            $varName = $node->var->name;
+            $this->trackEagerLoading($node->expr, $varName);
             $this->detectModelQuery($node);
+
+            $expr = $node->expr;
+            if ($expr instanceof Expr\Variable && is_string($expr->name)) {
+                $this->aliasVariable($expr->name, $varName);
+            }
 
             return null;
         }
@@ -64,6 +79,7 @@ class ModelVariableScanner extends NodeVisitorAbstract
         if ($eagerLoads !== []) {
             $this->eagerLoads[$var] = array_values($eagerLoads);
         }
+        $this->origins[$var] = $var;
     }
 
     public function typeOf(string $var): ?string
@@ -92,6 +108,15 @@ class ModelVariableScanner extends NodeVisitorAbstract
     }
 
     /**
+     * The render-bound variable name a variable ultimately derives from (see `$origins`), or
+     * `null` if it was never seeded or aliased from a seeded variable.
+     */
+    public function originOf(string $var): ?string
+    {
+        return $this->origins[$var] ?? null;
+    }
+
+    /**
      * Copy inferred model type and eager-loaded relationships from one variable to another.
      *
      * Used when a variable's context derives from another (e.g. a `foreach` loop variable
@@ -110,6 +135,36 @@ class ModelVariableScanner extends NodeVisitorAbstract
 
         if (isset($this->eagerLoads[$from])) {
             $this->eagerLoads[$to] = $this->eagerLoads[$from];
+        }
+
+        if (isset($this->origins[$from])) {
+            $this->origins[$to] = $this->origins[$from];
+        }
+    }
+
+    /**
+     * Propagate a variable's type and eager loads, unchanged, to a plain alias of it
+     * (`$to = $from;`).
+     *
+     * Compiled Blade `@foreach` rewrites `foreach ($cities as $city)` into
+     * `$__currentLoopData = $cities; foreach ($__currentLoopData as $city): ...` — without this,
+     * the loop's actual source variable (`$__currentLoopData`) never resolves back to the
+     * seeded/inferred type on `$cities`, so `copyContext()` on the loop var has nothing to read.
+     * Unlike `copyContext()`, this keeps a `Collection<Model>` type as-is (an alias holds the
+     * same value, not its element).
+     */
+    private function aliasVariable(string $from, string $to): void
+    {
+        if (isset($this->types[$from])) {
+            $this->types[$to] = $this->types[$from];
+        }
+
+        if (isset($this->eagerLoads[$from])) {
+            $this->eagerLoads[$to] = $this->eagerLoads[$from];
+        }
+
+        if (isset($this->origins[$from])) {
+            $this->origins[$to] = $this->origins[$from];
         }
     }
 

--- a/src/Support/ModelVariableScanner.php
+++ b/src/Support/ModelVariableScanner.php
@@ -148,6 +148,10 @@ class ModelVariableScanner extends NodeVisitorAbstract
      */
     public function copyContext(string $from, string $to): void
     {
+        // Assignment, not merge: compiled Blade copies every loop from the same synthetic key, so a
+        // reused loop-variable name must not inherit the previous loop's type, eager loads, or origin.
+        unset($this->types[$to], $this->eagerLoads[$to], $this->origins[$to]);
+
         $type = $this->types[$from] ?? null;
         if ($type !== null && str_starts_with($type, 'Collection<')) {
             $model = $this->modelOf($from);

--- a/src/Support/ViewBinding.php
+++ b/src/Support/ViewBinding.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+final class ViewBinding
+{
+    /** @param list<string> $eagerLoads */
+    public function __construct(
+        public readonly ?string $type,
+        public readonly array $eagerLoads,
+        public readonly string $source,
+    ) {}
+}

--- a/src/Support/ViewBindingRegistry.php
+++ b/src/Support/ViewBindingRegistry.php
@@ -4,16 +4,6 @@ declare(strict_types=1);
 
 namespace ShieldCI\Support;
 
-final class ViewBinding
-{
-    /** @param list<string> $eagerLoads */
-    public function __construct(
-        public readonly ?string $type,
-        public readonly array $eagerLoads,
-        public readonly string $source,
-    ) {}
-}
-
 /**
  * Per-view, per-variable render bindings, with the merge policy that keeps Blade N+1 findings
  * conservative: a variable is analyzable only when every render site agrees on a known type, and

--- a/src/Support/ViewBindingRegistry.php
+++ b/src/Support/ViewBindingRegistry.php
@@ -36,7 +36,12 @@ class ViewBindingRegistry
             $unknown = false;
 
             foreach ($bindings as $binding) {
-                if ($binding->type === null) {
+                if ($binding->type === null || $binding->type !== $type) {
+                    // Either this site's type is unknown, or it disagrees with the first
+                    // site's type (e.g. two render sites bind the same view variable to
+                    // different models). Either way the variable can't be analyzed safely —
+                    // a wrong model type would drive a precise registry lookup that produces
+                    // confident false positives or negatives.
                     $unknown = true;
                     break;
                 }

--- a/src/Support/ViewBindingRegistry.php
+++ b/src/Support/ViewBindingRegistry.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+final class ViewBinding
+{
+    /** @param list<string> $eagerLoads */
+    public function __construct(
+        public readonly ?string $type,
+        public readonly array $eagerLoads,
+        public readonly string $source,
+    ) {}
+}
+
+/**
+ * Per-view, per-variable render bindings, with the merge policy that keeps Blade N+1 findings
+ * conservative: a variable is analyzable only when every render site agrees on a known type, and
+ * a relation eager-loaded on any path is treated as loaded on all.
+ */
+class ViewBindingRegistry
+{
+    /** @var array<string, array<string, list<ViewBinding>>> */
+    private array $map = [];
+
+    public function add(string $viewFile, string $var, ViewBinding $binding): void
+    {
+        $this->map[$viewFile][$var][] = $binding;
+    }
+
+    /**
+     * @return array<string, array{type: ?string, eagerLoads: list<string>, source: string}>|null
+     */
+    public function resolve(string $viewFile): ?array
+    {
+        if (! isset($this->map[$viewFile])) {
+            return null;
+        }
+
+        $result = [];
+        foreach ($this->map[$viewFile] as $var => $bindings) {
+            $type = $bindings[0]->type;
+            $eager = [];
+            $source = $bindings[0]->source;
+            $unknown = false;
+
+            foreach ($bindings as $binding) {
+                if ($binding->type === null) {
+                    $unknown = true;
+                    break;
+                }
+                $eager = array_merge($eager, $binding->eagerLoads);
+            }
+
+            if ($unknown) {
+                continue; // drop the variable — do not analyze it
+            }
+
+            $result[$var] = [
+                'type' => $type,
+                'eagerLoads' => array_values(array_unique($eager)),
+                'source' => $source,
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Support/ViewRenderScanner.php
+++ b/src/Support/ViewRenderScanner.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
+
+/**
+ * Walks controller PHP files for `view(...)` render sites, resolves each view name to its
+ * Blade file path, and records what each passed variable IS (its inferred Eloquent model
+ * type and eager-loaded relations) so a later Blade-side analysis pass can be seeded with
+ * the type information a template cannot derive on its own.
+ */
+class ViewRenderScanner
+{
+    public function __construct(private readonly ParserInterface $parser) {}
+
+    /**
+     * @param  list<string>  $phpFiles
+     */
+    public function scan(array $phpFiles, string $viewsBasePath): ViewBindingRegistry
+    {
+        $registry = new ViewBindingRegistry;
+        $finder = new NodeFinder;
+
+        foreach ($phpFiles as $file) {
+            $ast = $this->parser->parseFile($file);
+            if ($ast === []) {
+                continue;
+            }
+
+            $this->scanStatements($ast, basename($file), $viewsBasePath, $registry, $finder);
+        }
+
+        return $registry;
+    }
+
+    /**
+     * Two-level walk: recurse into namespaces, then handle each top-level class's methods
+     * and each top-level function as its own inference scope.
+     *
+     * @param  array<Node>  $stmts
+     */
+    private function scanStatements(array $stmts, string $fileBasename, string $viewsBasePath, ViewBindingRegistry $registry, NodeFinder $finder): void
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                $this->scanStatements($stmt->stmts, $fileBasename, $viewsBasePath, $registry, $finder);
+
+                continue;
+            }
+
+            if ($stmt instanceof Stmt\Class_) {
+                $className = $stmt->name?->toString() ?? $fileBasename;
+                foreach ($stmt->stmts as $classStmt) {
+                    if ($classStmt instanceof Stmt\ClassMethod && $classStmt->stmts !== null) {
+                        $source = $className.'::'.$classStmt->name->toString();
+                        $this->scanScope($classStmt->stmts, $source, $viewsBasePath, $registry, $finder);
+                    }
+                }
+
+                continue;
+            }
+
+            if ($stmt instanceof Stmt\Function_) {
+                $this->scanScope($stmt->stmts, $fileBasename, $viewsBasePath, $registry, $finder);
+            }
+        }
+    }
+
+    /**
+     * Run ModelVariableScanner over a single method/function body, then resolve every
+     * `view(...)` render site found within it.
+     *
+     * @param  array<Node>  $stmts
+     */
+    private function scanScope(array $stmts, string $source, string $viewsBasePath, ViewBindingRegistry $registry, NodeFinder $finder): void
+    {
+        $viewCalls = $finder->find($stmts, static fn (Node $n): bool => $n instanceof Expr\FuncCall
+            && $n->name instanceof Node\Name
+            && $n->name->toString() === 'view');
+
+        if ($viewCalls === []) {
+            return;
+        }
+
+        $scanner = new ModelVariableScanner;
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($scanner);
+        $traverser->traverse($stmts);
+
+        foreach ($viewCalls as $viewCall) {
+            if (! $viewCall instanceof Expr\FuncCall) {
+                continue; // @codeCoverageIgnore — guaranteed by the finder predicate above
+            }
+
+            $this->handleViewCall($viewCall, $stmts, $source, $viewsBasePath, $registry, $finder, $scanner);
+        }
+    }
+
+    /**
+     * @param  array<Node>  $scopeStmts
+     */
+    private function handleViewCall(
+        Expr\FuncCall $viewCall,
+        array $scopeStmts,
+        string $source,
+        string $viewsBasePath,
+        ViewBindingRegistry $registry,
+        NodeFinder $finder,
+        ModelVariableScanner $scanner,
+    ): void {
+        if (! isset($viewCall->args[0]) || ! $viewCall->args[0] instanceof Node\Arg) {
+            return;
+        }
+
+        $nameArg = $viewCall->args[0]->value;
+        if (! $nameArg instanceof Node\Scalar\String_) {
+            return; // dynamic view name — skip
+        }
+
+        $viewFile = $viewsBasePath.'/'.str_replace('.', '/', $nameArg->value).'.blade.php';
+
+        $bindings = [];
+        if (isset($viewCall->args[1]) && $viewCall->args[1] instanceof Node\Arg) {
+            $bindings = $this->extractBindings($viewCall->args[1]->value);
+        }
+
+        $withCalls = $finder->find($scopeStmts, fn (Node $n): bool => $n instanceof Expr\MethodCall
+            && $n->name instanceof Node\Identifier
+            && $n->name->toString() === 'with'
+            && $this->chainRoot($n) === $viewCall);
+
+        foreach ($withCalls as $withCall) {
+            if (! $withCall instanceof Expr\MethodCall) {
+                continue; // @codeCoverageIgnore — guaranteed by the finder predicate above
+            }
+
+            $bindings = array_merge($bindings, $this->extractWithBindings($withCall->args));
+        }
+
+        foreach ($bindings as $bladeVar => $phpVar) {
+            $type = $phpVar !== null ? $scanner->typeOf($phpVar) : null;
+            $eagerLoads = $phpVar !== null ? $scanner->eagerLoadsOf($phpVar) : [];
+            $registry->add($viewFile, $bladeVar, new ViewBinding($type, $eagerLoads, $source));
+        }
+    }
+
+    /**
+     * Walk a `->with(...)` call's object chain back to its root, so it can be matched
+     * against the specific `view(...)` FuncCall it was chained onto.
+     */
+    private function chainRoot(Expr\MethodCall $call): Node
+    {
+        $current = $call->var;
+        while ($current instanceof Expr\MethodCall) {
+            $current = $current->var;
+        }
+
+        return $current;
+    }
+
+    /**
+     * Extract variable bindings from a `view('x', <expr>)` second argument: either an array
+     * literal (`['cities' => $cities]`) or a `compact('a', 'b')` call.
+     *
+     * @return array<string, ?string>
+     */
+    private function extractBindings(Node $expr): array
+    {
+        if ($expr instanceof Expr\Array_) {
+            return $this->extractArrayBindings($expr);
+        }
+
+        if ($expr instanceof Expr\FuncCall && $expr->name instanceof Node\Name && $expr->name->toString() === 'compact') {
+            return $this->extractCompactBindings($expr);
+        }
+
+        return [];
+    }
+
+    /**
+     * @return array<string, ?string>
+     */
+    private function extractArrayBindings(Expr\Array_ $array): array
+    {
+        $bindings = [];
+        foreach ($array->items as $item) {
+            if ($item === null || ! $item->key instanceof Node\Scalar\String_) {
+                continue;
+            }
+
+            $bindings[$item->key->value] = ($item->value instanceof Expr\Variable && is_string($item->value->name))
+                ? $item->value->name
+                : null;
+        }
+
+        return $bindings;
+    }
+
+    /**
+     * @return array<string, ?string>
+     */
+    private function extractCompactBindings(Expr\FuncCall $call): array
+    {
+        $bindings = [];
+        foreach ($call->args as $arg) {
+            if ($arg instanceof Node\Arg && $arg->value instanceof Node\Scalar\String_) {
+                $bindings[$arg->value->value] = $arg->value->value;
+            }
+        }
+
+        return $bindings;
+    }
+
+    /**
+     * Extract variable bindings from `->with('key', $value)` or `->with(['key' => $value])`.
+     *
+     * @param  array<Node\Arg|Node\VariadicPlaceholder>  $args
+     * @return array<string, ?string>
+     */
+    private function extractWithBindings(array $args): array
+    {
+        $values = [];
+        foreach ($args as $arg) {
+            if ($arg instanceof Node\Arg) {
+                $values[] = $arg;
+            }
+        }
+
+        if (count($values) === 1 && $values[0]->value instanceof Expr\Array_) {
+            return $this->extractArrayBindings($values[0]->value);
+        }
+
+        if (count($values) === 2 && $values[0]->value instanceof Node\Scalar\String_) {
+            $valueExpr = $values[1]->value;
+
+            return [
+                $values[0]->value->value => ($valueExpr instanceof Expr\Variable && is_string($valueExpr->name))
+                    ? $valueExpr->name
+                    : null,
+            ];
+        }
+
+        return [];
+    }
+}

--- a/src/Support/ViewRenderScanner.php
+++ b/src/Support/ViewRenderScanner.php
@@ -188,7 +188,7 @@ class ViewRenderScanner
     {
         $bindings = [];
         foreach ($array->items as $item) {
-            if ($item === null || ! $item->key instanceof Node\Scalar\String_) {
+            if (! $item->key instanceof Node\Scalar\String_) {
                 continue;
             }
 

--- a/src/Support/ViewRenderScanner.php
+++ b/src/Support/ViewRenderScanner.php
@@ -82,9 +82,11 @@ class ViewRenderScanner
      */
     private function scanScope(array $stmts, string $source, string $viewsBasePath, ViewBindingRegistry $registry, NodeFinder $finder): void
     {
-        $viewCalls = $finder->find($stmts, static fn (Node $n): bool => $n instanceof Expr\FuncCall
-            && $n->name instanceof Node\Name
-            && $n->name->toString() === 'view');
+        $viewCalls = array_filter(
+            $finder->findInstanceOf($stmts, Expr\FuncCall::class),
+            static fn (Expr\FuncCall $n): bool => $n->name instanceof Node\Name
+                && $n->name->toString() === 'view',
+        );
 
         if ($viewCalls === []) {
             return;
@@ -96,10 +98,6 @@ class ViewRenderScanner
         $traverser->traverse($stmts);
 
         foreach ($viewCalls as $viewCall) {
-            if (! $viewCall instanceof Expr\FuncCall) {
-                continue; // @codeCoverageIgnore — guaranteed by the finder predicate above
-            }
-
             $this->handleViewCall($viewCall, $stmts, $source, $viewsBasePath, $registry, $finder, $scanner);
         }
     }
@@ -132,16 +130,14 @@ class ViewRenderScanner
             $bindings = $this->extractBindings($viewCall->args[1]->value);
         }
 
-        $withCalls = $finder->find($scopeStmts, fn (Node $n): bool => $n instanceof Expr\MethodCall
-            && $n->name instanceof Node\Identifier
-            && $n->name->toString() === 'with'
-            && $this->chainRoot($n) === $viewCall);
+        $withCalls = array_filter(
+            $finder->findInstanceOf($scopeStmts, Expr\MethodCall::class),
+            fn (Expr\MethodCall $n): bool => $n->name instanceof Node\Identifier
+                && $n->name->toString() === 'with'
+                && $this->chainRoot($n) === $viewCall,
+        );
 
         foreach ($withCalls as $withCall) {
-            if (! $withCall instanceof Expr\MethodCall) {
-                continue; // @codeCoverageIgnore — guaranteed by the finder predicate above
-            }
-
             $bindings = array_merge($bindings, $this->extractWithBindings($withCall->args));
         }
 

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace ShieldCI\Tests\Unit\Analyzers\BestPractices;
 
+use PhpParser\NodeTraverser;
+use ShieldCI\Analyzers\BestPractices\AccessorRegistry;
 use ShieldCI\Analyzers\BestPractices\EloquentNPlusOneAnalyzer;
+use ShieldCI\Analyzers\BestPractices\ModelAttributesRegistry;
+use ShieldCI\Analyzers\BestPractices\ModelScanResult;
+use ShieldCI\Analyzers\BestPractices\NPlusOneVisitor;
+use ShieldCI\Analyzers\BestPractices\RelationshipRegistry;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\Tests\AnalyzerTestCase;
 
 class EloquentNPlusOneAnalyzerTest extends AnalyzerTestCase
@@ -13,6 +20,63 @@ class EloquentNPlusOneAnalyzerTest extends AnalyzerTestCase
     protected function createAnalyzer(): AnalyzerInterface
     {
         return new EloquentNPlusOneAnalyzer($this->parser);
+    }
+
+    public function test_seeded_binding_flags_lazy_relation_in_a_loop(): void
+    {
+        // Force-load EloquentNPlusOneAnalyzer.php: ModelScanResult, RelationshipRegistry, etc.
+        // live in that file but aren't individually PSR-4 addressable, so referencing them
+        // directly (without ever instantiating the analyzer) needs an explicit autoload nudge.
+        class_exists(EloquentNPlusOneAnalyzer::class);
+
+        // A view-shaped snippet: $cities has no query assignment here — its type/eager-loads
+        // must come from the seed, exactly as a Blade template would receive them.
+        $code = <<<'PHP'
+        <?php
+        foreach ($cities as $city) {
+            echo $city->airports->count();
+        }
+        PHP;
+
+        $ast = (new AstParser)->parseCode($code);
+        $scanResult = new ModelScanResult(new RelationshipRegistry, new ModelAttributesRegistry, new AccessorRegistry);
+        // Register 'airports' as a real relationship on City so registry lookup succeeds.
+        $scanResult->relationships->add('City', 'airports');
+
+        $visitor = new NPlusOneVisitor($scanResult, [
+            'cities' => ['type' => 'Collection<City>', 'eagerLoads' => []],
+        ]);
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $this->assertNotEmpty($visitor->getIssues());
+        $this->assertSame('airports', $visitor->getIssues()[0]['relationship']);
+    }
+
+    public function test_seeded_eager_load_suppresses_the_finding(): void
+    {
+        class_exists(EloquentNPlusOneAnalyzer::class);
+
+        $code = <<<'PHP'
+        <?php
+        foreach ($cities as $city) {
+            echo $city->airports->count();
+        }
+        PHP;
+
+        $ast = (new AstParser)->parseCode($code);
+        $scanResult = new ModelScanResult(new RelationshipRegistry, new ModelAttributesRegistry, new AccessorRegistry);
+        $scanResult->relationships->add('City', 'airports');
+
+        $visitor = new NPlusOneVisitor($scanResult, [
+            'cities' => ['type' => 'Collection<City>', 'eagerLoads' => ['airports']],
+        ]);
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $this->assertSame([], $visitor->getIssues());
     }
 
     public function test_passes_uniqueness_probe_while_loop(): void

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
@@ -3165,4 +3165,62 @@ PHP;
 
         $this->assertPassed($result);
     }
+
+    public function test_does_not_flag_accessor_property_when_model_has_no_relationships(): void
+    {
+        // Regression test: Config defines zero relationships, so it never enters the
+        // relationshipRegistry (which is keyed only by models that define at least one
+        // relationship). That used to make isActualOrProbableRelationship() fall through
+        // to the heuristic path, which has no accessor/attribute awareness and flagged
+        // 'value_preview' as a probable relationship. Accessors must be suppressed
+        // regardless of whether their model defines any relationships.
+        $modelCode = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Config extends Model
+{
+    public function getValuePreviewAttribute(): string
+    {
+        return str($this->value)->limit(50)->toString();
+    }
+}
+PHP;
+
+        $controllerCode = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Config;
+
+class ConfigController
+{
+    public function index()
+    {
+        $configs = Config::all();
+
+        foreach ($configs as $config) {
+            echo $config->value_preview;
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/Config.php' => $modelCode,
+            'app/Http/Controllers/ConfigController.php' => $controllerCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
 }

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
@@ -8,10 +8,15 @@ use ShieldCI\Analyzers\BestPractices\EloquentNPlusOneAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Support\AstParser;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\Tests\AnalyzerTestCase;
 
 class EloquentNPlusOneBladeTest extends AnalyzerTestCase
 {
+    private const CITY_MODEL = "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass City extends Model { public function airports(){ return \$this->hasMany(Airport::class); } }";
+
+    private const AIRPORT_MODEL = "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Airport extends Model {}";
+
     protected function createAnalyzer(): AnalyzerInterface
     {
         return new EloquentNPlusOneAnalyzer($this->parser);
@@ -28,6 +33,12 @@ class EloquentNPlusOneBladeTest extends AnalyzerTestCase
         return $analyzer->analyze();
     }
 
+    /** @return list<Issue> */
+    private function airportIssues(ResultInterface $result): array
+    {
+        return array_values(array_filter($result->getIssues(), fn (Issue $i): bool => str_contains($i->message, 'airports')));
+    }
+
     public function test_flags_lazy_relation_when_controller_does_not_eager_load(): void
     {
         $result = $this->analyze([
@@ -36,7 +47,7 @@ class EloquentNPlusOneBladeTest extends AnalyzerTestCase
             'resources/views/cities/index.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports->count() }}\n@endforeach",
         ]);
 
-        $issues = array_values(array_filter($result->getIssues(), fn ($i) => str_contains($i->message, 'airports')));
+        $issues = $this->airportIssues($result);
         $this->assertCount(1, $issues);
         $location = $issues[0]->location;
         $this->assertNotNull($location);
@@ -52,7 +63,171 @@ class EloquentNPlusOneBladeTest extends AnalyzerTestCase
             'resources/views/cities/index.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports->count() }}\n@endforeach",
         ]);
 
-        $issues = array_values(array_filter($result->getIssues(), fn ($i) => str_contains($i->message, 'airports')));
-        $this->assertSame([], $issues);
+        $this->assertSame([], $this->airportIssues($result));
+    }
+
+    /**
+     * Merge policy: two controllers render the same view. Only one eager-loads the
+     * relationship the view reads — a relation eager-loaded on ANY render path must be
+     * treated as loaded on all, so the finding is suppressed even though the other
+     * controller does not eager-load it.
+     */
+    public function test_silent_when_only_one_of_two_render_sites_eager_loads(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => self::CITY_MODEL,
+            'app/Http/Controllers/CityIndexController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\City;\nclass CityIndexController { public function index(){ \$cities = City::all(); return view('cities.index', compact('cities')); } }",
+            'app/Http/Controllers/CityMembershipController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\City;\nclass CityMembershipController { public function membership(){ \$cities = City::with('airports')->get(); return view('cities.index', compact('cities')); } }",
+            'resources/views/cities/index.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports->count() }}\n@endforeach",
+        ]);
+
+        $this->assertSame([], $this->airportIssues($result));
+    }
+
+    /**
+     * Merge policy: a view with no resolvable render site (no controller anywhere in the
+     * project calls `view('partials._row', ...)`) must be skipped entirely — `resolve()`
+     * returns null and `analyzeBladeFile` bails before ever compiling or scanning it.
+     */
+    public function test_silent_when_partial_has_no_render_site(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => self::CITY_MODEL,
+            'resources/views/partials/_row.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports->count() }}\n@endforeach",
+        ]);
+
+        $this->assertSame([], $this->airportIssues($result));
+    }
+
+    /**
+     * Merge policy: when a render-bound variable's type is never inferred (built via
+     * `collect()` and populated inside a `chunk()` callback, rather than a direct model
+     * query assignment), the variable is dropped entirely rather than analyzed — false
+     * negatives are preferred to false positives on code the scanner cannot understand.
+     */
+    public function test_silent_when_variable_type_is_never_inferred(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => self::CITY_MODEL,
+            'app/Http/Controllers/CityChunkController.php' => <<<'PHP'
+                <?php
+                namespace App\Http\Controllers;
+                use App\Models\City;
+                class CityChunkController
+                {
+                    public function index()
+                    {
+                        $cities = collect();
+                        City::with('airports')->chunk(200, function ($c) use (&$cities) {
+                            foreach ($c as $x) {
+                                $cities->push($x);
+                            }
+                        });
+
+                        return view('cities.chunked', compact('cities'));
+                    }
+                }
+                PHP,
+            'resources/views/cities/chunked.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports->count() }}\n@endforeach",
+        ]);
+
+        $this->assertSame([], $this->airportIssues($result));
+    }
+
+    /**
+     * A relationship accessed via an explicit method call chain ending in a query-execution
+     * method (`$city->airports()->count()`, as opposed to the lazy-loading property access
+     * `$city->airports->count()` in the other fixtures) is caught by a distinct branch of
+     * the visitor and must be flagged the same way once the render-bound type is known.
+     */
+    public function test_flags_method_call_query_chain_inside_view_loop(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => self::CITY_MODEL,
+            'app/Http/Controllers/MethodChainController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\City;\nclass MethodChainController { public function index(){ \$cities = City::all(); return view('cities.methodchain', compact('cities')); } }",
+            'resources/views/cities/methodchain.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports()->count() }}\n@endforeach",
+        ]);
+
+        $issues = $this->airportIssues($result);
+        $this->assertCount(1, $issues);
+        $this->assertStringContainsString('MethodChainController::index', $issues[0]->recommendation);
+    }
+
+    /**
+     * Pins CURRENT behavior for a bare `view('cities.bare')` call that passes no data at
+     * all: no controller ever binds a type to `$cities` for this view, so the merge policy
+     * has nothing to seed and the variable is never analyzable — silent, not flagged. This
+     * differs from the task brief's expectation that this case is "flagged regardless of
+     * bindings" via the existing query-issue logic; see the task report for why that
+     * doesn't hold today (`analyzeBladeFile()` never reads `NPlusOneVisitor::getQueryIssues()`,
+     * and even the relationship-issue path requires a known type to fire).
+     */
+    public function test_silent_when_view_call_passes_no_data(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => self::CITY_MODEL,
+            'app/Http/Controllers/BareViewController.php' => "<?php\nnamespace App\\Http\\Controllers;\nclass BareViewController { public function index(){ return view('cities.bare'); } }",
+            'resources/views/cities/bare.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports()->count() }}\n@endforeach",
+        ]);
+
+        $this->assertSame([], $this->airportIssues($result));
+    }
+
+    /**
+     * A vendor-published view (e.g. from a Composer package) is always skipped, even when a
+     * controller renders it with a non-eager-loaded relationship that would otherwise be
+     * flagged in an application view.
+     */
+    public function test_vendor_view_is_skipped(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => self::CITY_MODEL,
+            'app/Http/Controllers/VendorViewController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\City;\nclass VendorViewController { public function index(){ \$cities = City::all(); return view('vendor.pkg.x', compact('cities')); } }",
+            'resources/views/vendor/pkg/x.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports->count() }}\n@endforeach",
+        ]);
+
+        $this->assertSame([], $this->airportIssues($result));
+    }
+
+    /**
+     * Part B (nested @foreach): Blade compiles nested loops by reassigning the SAME
+     * `$__currentLoopData` synthetic variable at each nesting level. The unresolved N+1
+     * access here is `$city->airports` — the data source of the inner loop, accessed while
+     * still inside the OUTER loop body — and it is caught before the inner loop's (buggy)
+     * type inference ever comes into play. See the task report for the mistyping this
+     * nested compilation causes on `$airport` itself, and why it doesn't produce a false
+     * positive for this fixture.
+     */
+    public function test_nested_foreach_not_eager_loaded_flags_outer_relationship_access(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => self::CITY_MODEL,
+            'app/Models/Airport.php' => self::AIRPORT_MODEL,
+            'app/Http/Controllers/NestedController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\City;\nclass NestedController { public function index(){ \$cities = City::all(); return view('cities.nested', compact('cities')); } }",
+            'resources/views/cities/nested.blade.php' => "@foreach(\$cities as \$city)\n  @foreach(\$city->airports as \$airport)\n    {{ \$airport->name }}\n  @endforeach\n@endforeach",
+        ]);
+
+        $issues = $this->airportIssues($result);
+        $this->assertCount(1, $issues);
+        $location = $issues[0]->location;
+        $this->assertNotNull($location);
+        $this->assertSame(2, $location->line);
+        $this->assertStringContainsString('NestedController::index', $issues[0]->recommendation);
+    }
+
+    /**
+     * Part B (nested @foreach), the design's core promise: eager-loading the relationship
+     * that seeds a nested loop must silence the finding, exactly like the single-loop case.
+     */
+    public function test_nested_foreach_eager_loaded_is_silent(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => self::CITY_MODEL,
+            'app/Models/Airport.php' => self::AIRPORT_MODEL,
+            'app/Http/Controllers/NestedController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\City;\nclass NestedController { public function index(){ \$cities = City::with('airports')->get(); return view('cities.nested', compact('cities')); } }",
+            'resources/views/cities/nested.blade.php' => "@foreach(\$cities as \$city)\n  @foreach(\$city->airports as \$airport)\n    {{ \$airport->name }}\n  @endforeach\n@endforeach",
+        ]);
+
+        $this->assertSame([], $this->airportIssues($result));
     }
 }

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
@@ -269,4 +269,51 @@ class EloquentNPlusOneBladeTest extends AnalyzerTestCase
         $issues = array_values(array_filter($result->getIssues(), fn (Issue $i): bool => str_contains($i->message, 'value_preview')));
         $this->assertSame([], $issues);
     }
+
+    /**
+     * FP-A (critical, real-corpus false positive): Blade compiles nested `@foreach` by
+     * reassigning the SAME synthetic `$__currentLoopData` variable at each nesting level. The
+     * inner reassignment (`$__currentLoopData = $post->comments;`) is a PropertyFetch, not a
+     * bare Variable, so before the fix it failed to invalidate the stale entry the OUTER loop
+     * left behind — `$comment` inherited `$post`'s type (`Post`) and eager-loaded relations
+     * (`['comments', 'comments.author']`). `Post` happens to declare its own `author()`
+     * relation, so the mistaken type made `$comment->author` look like an un-eager-loaded
+     * relationship on `Post`, even though `comments.author` IS eager-loaded — on `Comment`,
+     * the correct (but never-inferred, post-fix) model. This is the canonical nested-Blade
+     * shape and exactly the false-positive class this analyzer exists to prevent.
+     */
+    public function test_nested_foreach_relation_eager_loaded_via_dot_notation_is_silent(): void
+    {
+        $result = $this->analyze([
+            'app/Models/Post.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Post extends Model { public function comments(){ return \$this->hasMany(Comment::class); } public function author(){ return \$this->belongsTo(User::class); } }",
+            'app/Models/Comment.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Comment extends Model { public function author(){ return \$this->belongsTo(User::class); } }",
+            'app/Http/Controllers/PostController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\Post;\nclass PostController { public function index(){ \$posts = Post::with('comments.author')->get(); return view('posts.index', compact('posts')); } }",
+            'resources/views/posts/index.blade.php' => "@foreach(\$posts as \$post)\n  @foreach(\$post->comments as \$comment)\n    {{ \$comment->author->name }}\n  @endforeach\n@endforeach",
+        ]);
+
+        $issues = array_values(array_filter($result->getIssues(), fn (Issue $i): bool => str_contains($i->message, 'author')));
+        $this->assertSame([], $issues);
+    }
+
+    /**
+     * FP-C: two SEQUENTIAL, non-nested `@foreach` blocks. The first's source is a bare
+     * variable (`$cities`), which sets the synthetic `$__currentLoopData`'s type to `City`.
+     * The second's source is a property fetch (`$region->airports`) rather than a bare
+     * variable, so before the fix `$__currentLoopData` kept its STALE `City` type from the
+     * first loop, and `$airport` wrongly inherited it. `City` alone declares a `mayor()`
+     * relation, so `$airport->mayor` was wrongly flagged as an un-eager-loaded relationship
+     * even though the real (unrelated, never-typed) second-loop variable has nothing to do
+     * with `City` at all.
+     */
+    public function test_sequential_non_nested_foreach_does_not_leak_stale_type_to_second_loop_var(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass City extends Model { public function mayor(){ return \$this->belongsTo(Mayor::class); } }",
+            'app/Http/Controllers/RegionController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\City;\nclass RegionController { public function index(){ \$cities = City::all(); return view('regions.index', compact('cities')); } }",
+            'resources/views/regions/index.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->name }}\n@endforeach\n@foreach(\$region->airports as \$airport)\n  {{ \$airport->mayor }}\n@endforeach",
+        ]);
+
+        $issues = array_values(array_filter($result->getIssues(), fn (Issue $i): bool => str_contains($i->message, 'mayor')));
+        $this->assertSame([], $issues);
+    }
 }

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
@@ -251,4 +251,22 @@ class EloquentNPlusOneBladeTest extends AnalyzerTestCase
 
         $this->assertSame([], $this->airportIssues($result));
     }
+
+    /**
+     * Regression test for the real-corpus false positive: Config defines zero
+     * relationships, so it never enters the relationship registry and previously fell
+     * through to the property-name heuristic, which has no accessor awareness and flagged
+     * `value_preview` (a `getValuePreviewAttribute()` accessor) as a probable relationship.
+     */
+    public function test_silent_when_property_is_an_accessor_on_a_model_with_no_relationships(): void
+    {
+        $result = $this->analyze([
+            'app/Models/Config.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Config extends Model { public function getValuePreviewAttribute(): string { return str(\$this->value)->limit(50)->toString(); } }",
+            'app/Http/Controllers/ConfigController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\Config;\nclass ConfigController { public function index(){ \$configs = Config::all(); return view('configs.index', compact('configs')); } }",
+            'resources/views/configs/index.blade.php' => "@foreach(\$configs as \$config)\n  {{ \$config->value_preview }}\n@endforeach",
+        ]);
+
+        $issues = array_values(array_filter($result->getIssues(), fn (Issue $i): bool => str_contains($i->message, 'value_preview')));
+        $this->assertSame([], $issues);
+    }
 }

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
@@ -316,4 +316,111 @@ class EloquentNPlusOneBladeTest extends AnalyzerTestCase
         $issues = array_values(array_filter($result->getIssues(), fn (Issue $i): bool => str_contains($i->message, 'mayor')));
         $this->assertSame([], $issues);
     }
+
+    /**
+     * Regression for `ModelVariableScanner::copyContext()`'s merge-vs-assignment bug: compiled
+     * Blade copies every `@foreach` from the SAME synthetic `$__currentLoopData` key, so when a
+     * template reuses a loop-variable name (`$item`) across two loops and the second loop's
+     * source is a relation property fetch (`$user->posts`, not type-inferable), the freshly
+     * cleared `$__currentLoopData` has nothing to copy — `copyContext()` must still clear
+     * `$item`'s OWN previous (first-loop) type/eager-loads/origin rather than leaving them in
+     * place. `User` declares its own `author()` relation purely so the stale `User` type — if
+     * it leaks through — passes the registry's precise-lookup check exactly like the real
+     * `Post::author()` would, making the false positive this test guards against reproducible:
+     * pre-fix, `$item` keeps loop one's `User` type and its eager-load list (`['posts',
+     * 'posts.author']`), which does not contain the bare `'author'` entry, so `$item->author`
+     * (really a `Post`, reached via `$user->posts`, and genuinely eager-loaded through
+     * `posts.author`) is wrongly flagged.
+     */
+    public function test_reused_loop_variable_name_across_two_loops_stays_silent_when_eager_loaded(): void
+    {
+        $result = $this->analyze([
+            'app/Models/User.php' => <<<'PHP'
+                <?php
+                namespace App\Models;
+                use Illuminate\Database\Eloquent\Model;
+                class User extends Model
+                {
+                    public function posts(){ return $this->hasMany(Post::class); }
+                    public function author(){ return $this->belongsTo(User::class, 'created_by'); }
+                }
+                PHP,
+            'app/Models/Post.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Post extends Model { public function author(){ return \$this->belongsTo(User::class); } }",
+            'app/Http/Controllers/FeedController.php' => <<<'PHP'
+                <?php
+                namespace App\Http\Controllers;
+                use App\Models\User;
+                class FeedController
+                {
+                    public function index()
+                    {
+                        $users = User::with('posts.author')->get();
+
+                        return view('feed.index', compact('users'));
+                    }
+                }
+                PHP,
+            'resources/views/feed/index.blade.php' => <<<'BLADE'
+                @foreach($users as $item)
+                  {{ $item->name }}
+                @endforeach
+
+                @foreach($users as $user)
+                  @foreach($user->posts as $item)
+                    {{ $item->author->name }}
+                  @endforeach
+                @endforeach
+                BLADE,
+        ]);
+
+        $issues = array_values(array_filter($result->getIssues(), fn (Issue $i): bool => str_contains($i->message, 'author')));
+        $this->assertSame([], $issues);
+    }
+
+    /**
+     * The other side of the merge-vs-assignment bug: a stale eager-load list must not
+     * SUPPRESS a genuine finding either. Loop one's `$item` (`User::with('author')`) leaves
+     * eager loads `['author']` behind; loop two reuses `$item` for a DIFFERENT, non-eager-loaded
+     * `Post` collection. Pre-fix, `$item`'s type is correctly overwritten to `Post` (its source,
+     * `$posts`, IS a bare, type-inferable variable), but the STALE `['author']` eager-load list
+     * survives because `copyContext()` only overwrites `eagerLoads[$to]` when the source has an
+     * entry — and here the source (`$posts`, never eager-loaded) has none. That stale, coincidentally
+     * matching list wrongly suppresses a real N+1 on `$item->author`.
+     */
+    public function test_reused_loop_variable_name_flags_genuine_lazy_relation_not_masked_by_stale_eager_loads(): void
+    {
+        $result = $this->analyze([
+            'app/Models/User.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass User extends Model { public function author(){ return \$this->belongsTo(User::class, 'created_by'); } }",
+            'app/Models/Post.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Post extends Model { public function author(){ return \$this->belongsTo(User::class); } }",
+            'app/Http/Controllers/FeedController.php' => <<<'PHP'
+                <?php
+                namespace App\Http\Controllers;
+                use App\Models\User;
+                use App\Models\Post;
+                class FeedController
+                {
+                    public function index()
+                    {
+                        $users = User::with('author')->get();
+                        $posts = Post::all();
+
+                        return view('feed.mixed', compact('users', 'posts'));
+                    }
+                }
+                PHP,
+            'resources/views/feed/mixed.blade.php' => <<<'BLADE'
+                @foreach($users as $item)
+                  {{ $item->name }}
+                @endforeach
+
+                @foreach($posts as $item)
+                  {{ $item->author->name }}
+                @endforeach
+                BLADE,
+        ]);
+
+        $issues = array_values(array_filter($result->getIssues(), fn (Issue $i): bool => str_contains($i->message, 'author')));
+        $this->assertCount(1, $issues);
+        $this->assertStringContainsString('FeedController::index', $issues[0]->recommendation);
+    }
 }

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Analyzers\BestPractices;
+
+use ShieldCI\Analyzers\BestPractices\EloquentNPlusOneAnalyzer;
+use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
+use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
+use ShieldCI\AnalyzersCore\Support\AstParser;
+use ShieldCI\Tests\AnalyzerTestCase;
+
+class EloquentNPlusOneBladeTest extends AnalyzerTestCase
+{
+    protected function createAnalyzer(): AnalyzerInterface
+    {
+        return new EloquentNPlusOneAnalyzer($this->parser);
+    }
+
+    /** @param array<string,string> $files */
+    private function analyze(array $files): ResultInterface
+    {
+        $dir = $this->createTempDirectory($files);
+        $analyzer = new EloquentNPlusOneAnalyzer(new AstParser);
+        $analyzer->setBasePath($dir);
+        $analyzer->setPaths(['app', 'resources/views']);
+
+        return $analyzer->analyze();
+    }
+
+    public function test_flags_lazy_relation_when_controller_does_not_eager_load(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass City extends Model { public function airports(){ return \$this->hasMany(Airport::class); } }",
+            'app/Http/Controllers/CityController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\City;\nclass CityController { public function index(){ \$cities = City::all(); return view('cities.index', compact('cities')); } }",
+            'resources/views/cities/index.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports->count() }}\n@endforeach",
+        ]);
+
+        $issues = array_values(array_filter($result->getIssues(), fn ($i) => str_contains($i->message, 'airports')));
+        $this->assertCount(1, $issues);
+        $location = $issues[0]->location;
+        $this->assertNotNull($location);
+        $this->assertStringEndsWith('index.blade.php', $location->file);
+        $this->assertStringContainsString('CityController::index', $issues[0]->recommendation);
+    }
+
+    public function test_silent_when_controller_eager_loads(): void
+    {
+        $result = $this->analyze([
+            'app/Models/City.php' => "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass City extends Model { public function airports(){ return \$this->hasMany(Airport::class); } }",
+            'app/Http/Controllers/CityController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\City;\nclass CityController { public function index(){ \$cities = City::with('airports')->get(); return view('cities.index', compact('cities')); } }",
+            'resources/views/cities/index.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports->count() }}\n@endforeach",
+        ]);
+
+        $issues = array_values(array_filter($result->getIssues(), fn ($i) => str_contains($i->message, 'airports')));
+        $this->assertSame([], $issues);
+    }
+}

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneBladeTest.php
@@ -39,6 +39,18 @@ class EloquentNPlusOneBladeTest extends AnalyzerTestCase
         return array_values(array_filter($result->getIssues(), fn (Issue $i): bool => str_contains($i->message, 'airports')));
     }
 
+    /**
+     * Findings produced from `NPlusOneVisitor::getQueryIssues()` — an actual query executed
+     * per loop iteration, as opposed to a lazy relationship access. Filtered by the `query`
+     * metadata key rather than message content, since it is set only on this finding kind.
+     *
+     * @return list<Issue>
+     */
+    private function queryExecutionIssues(ResultInterface $result): array
+    {
+        return array_values(array_filter($result->getIssues(), fn (Issue $i): bool => array_key_exists('query', $i->metadata)));
+    }
+
     public function test_flags_lazy_relation_when_controller_does_not_eager_load(): void
     {
         $result = $this->analyze([
@@ -137,8 +149,10 @@ class EloquentNPlusOneBladeTest extends AnalyzerTestCase
     /**
      * A relationship accessed via an explicit method call chain ending in a query-execution
      * method (`$city->airports()->count()`, as opposed to the lazy-loading property access
-     * `$city->airports->count()` in the other fixtures) is caught by a distinct branch of
-     * the visitor and must be flagged the same way once the render-bound type is known.
+     * `$city->airports->count()` in the other fixtures) is caught by two distinct branches of
+     * the visitor once the render-bound type is known: the inner `airports()` call itself
+     * reads as a lazy relationship access (`getIssues()`), and the full `->count()` chain
+     * reads as an executed query (`getQueryIssues()`) — both now surface from a Blade view.
      */
     public function test_flags_method_call_query_chain_inside_view_loop(): void
     {
@@ -149,28 +163,35 @@ class EloquentNPlusOneBladeTest extends AnalyzerTestCase
         ]);
 
         $issues = $this->airportIssues($result);
-        $this->assertCount(1, $issues);
+        $this->assertCount(2, $issues);
         $this->assertStringContainsString('MethodChainController::index', $issues[0]->recommendation);
     }
 
     /**
-     * Pins CURRENT behavior for a bare `view('cities.bare')` call that passes no data at
-     * all: no controller ever binds a type to `$cities` for this view, so the merge policy
-     * has nothing to seed and the variable is never analyzable — silent, not flagged. This
-     * differs from the task brief's expectation that this case is "flagged regardless of
-     * bindings" via the existing query-issue logic; see the task report for why that
-     * doesn't hold today (`analyzeBladeFile()` never reads `NPlusOneVisitor::getQueryIssues()`,
-     * and even the relationship-issue path requires a known type to fire).
+     * A query executed inside a Blade loop (`$city->airports()->count()`) is the most severe
+     * shape of N+1 — an actual query per iteration, not just a lazy access — and must be
+     * flagged from a Blade view exactly like the plain-PHP path already does. This requires
+     * the controller to actually bind `$cities` (`compact('cities')`): a bare `view('x')` call
+     * with no data leaves the render-bound variable's type unknown, and `analyzeBladeFile()`
+     * skips a view with no resolvable render site entirely — neither `getIssues()` nor
+     * `getQueryIssues()` can fire without a known type, so that variant would stay silent
+     * regardless of this wiring.
      */
-    public function test_silent_when_view_call_passes_no_data(): void
+    public function test_flags_query_executed_inside_blade_loop(): void
     {
         $result = $this->analyze([
             'app/Models/City.php' => self::CITY_MODEL,
-            'app/Http/Controllers/BareViewController.php' => "<?php\nnamespace App\\Http\\Controllers;\nclass BareViewController { public function index(){ return view('cities.bare'); } }",
-            'resources/views/cities/bare.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports()->count() }}\n@endforeach",
+            'app/Http/Controllers/CityController.php' => "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\City;\nclass CityController { public function index(){ \$cities = City::all(); return view('cities.index', compact('cities')); } }",
+            'resources/views/cities/index.blade.php' => "@foreach(\$cities as \$city)\n  {{ \$city->airports()->count() }}\n@endforeach",
         ]);
 
-        $this->assertSame([], $this->airportIssues($result));
+        $issues = $this->queryExecutionIssues($result);
+        $this->assertCount(1, $issues);
+        $this->assertStringContainsString('executing', $issues[0]->message);
+        $this->assertSame('$city->airports()->count()', $issues[0]->metadata['query']);
+        $location = $issues[0]->location;
+        $this->assertNotNull($location);
+        $this->assertStringEndsWith('index.blade.php', $location->file);
     }
 
     /**

--- a/tests/Unit/Support/ModelVariableScannerTest.php
+++ b/tests/Unit/Support/ModelVariableScannerTest.php
@@ -73,4 +73,18 @@ class ModelVariableScannerTest extends TestCase
         $this->assertNull($s->typeOf('other'));
         $this->assertSame([], $s->eagerLoadsOf('other'));
     }
+
+    public function test_blade_synthetic_loop_alias_propagates_type_and_eager_loads(): void
+    {
+        $s = $this->scan("\$cities = City::with('airports')->get();\n\$__currentLoopData = \$cities;");
+        $this->assertSame('Collection<City>', $s->typeOf('__currentLoopData'));
+        $this->assertEqualsCanonicalizing(['airports'], $s->eagerLoadsOf('__currentLoopData'));
+    }
+
+    public function test_plain_user_alias_does_not_propagate(): void
+    {
+        $s = $this->scan("\$posts = Post::all();\n\$renamed = \$posts;");
+        $this->assertNull($s->typeOf('renamed'));
+        $this->assertSame([], $s->eagerLoadsOf('renamed'));
+    }
 }

--- a/tests/Unit/Support/ModelVariableScannerTest.php
+++ b/tests/Unit/Support/ModelVariableScannerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use PhpParser\NodeTraverser;
+use PHPUnit\Framework\TestCase;
+use ShieldCI\AnalyzersCore\Support\AstParser;
+use ShieldCI\Support\ModelVariableScanner;
+
+class ModelVariableScannerTest extends TestCase
+{
+    private function scan(string $code): ModelVariableScanner
+    {
+        $ast = (new AstParser)->parseCode("<?php\n".$code);
+        $scanner = new ModelVariableScanner;
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($scanner);
+        $traverser->traverse($ast);
+
+        return $scanner;
+    }
+
+    public function test_infers_collection_type_from_get(): void
+    {
+        $s = $this->scan('$cities = City::all();');
+        $this->assertSame('Collection<City>', $s->typeOf('cities'));
+        $this->assertSame('City', $s->modelOf('cities'));
+        $this->assertSame([], $s->eagerLoadsOf('cities'));
+    }
+
+    public function test_infers_single_model_from_find(): void
+    {
+        $s = $this->scan('$city = City::find(1);');
+        $this->assertSame('City', $s->typeOf('city'));
+        $this->assertSame('City', $s->modelOf('city'));
+    }
+
+    public function test_tracks_eager_loads_from_with_chain(): void
+    {
+        $s = $this->scan("\$cities = City::with(['airports', 'region'])->get();");
+        $this->assertSame('Collection<City>', $s->typeOf('cities'));
+        $this->assertEqualsCanonicalizing(['airports', 'region'], $s->eagerLoadsOf('cities'));
+    }
+
+    public function test_tracks_load_on_existing_variable(): void
+    {
+        $s = $this->scan("\$cities = City::all();\n\$cities->load('airports');");
+        $this->assertEqualsCanonicalizing(['airports'], $s->eagerLoadsOf('cities'));
+    }
+
+    public function test_unknown_variable_returns_null(): void
+    {
+        $s = $this->scan('$x = someHelper();');
+        $this->assertNull($s->typeOf('x'));
+        $this->assertNull($s->modelOf('x'));
+        $this->assertSame([], $s->eagerLoadsOf('x'));
+    }
+}

--- a/tests/Unit/Support/ModelVariableScannerTest.php
+++ b/tests/Unit/Support/ModelVariableScannerTest.php
@@ -57,4 +57,20 @@ class ModelVariableScannerTest extends TestCase
         $this->assertNull($s->modelOf('x'));
         $this->assertSame([], $s->eagerLoadsOf('x'));
     }
+
+    public function test_copy_context_transfers_model_and_eager_loads(): void
+    {
+        $s = $this->scan("\$cities = City::with('airports')->get();");
+        $s->copyContext('cities', 'city');
+        $this->assertSame('City', $s->typeOf('city'));
+        $this->assertEqualsCanonicalizing(['airports'], $s->eagerLoadsOf('city'));
+    }
+
+    public function test_copy_context_does_not_transfer_from_non_collection_type(): void
+    {
+        $s = $this->scan('$city = City::find(1);');
+        $s->copyContext('city', 'other');
+        $this->assertNull($s->typeOf('other'));
+        $this->assertSame([], $s->eagerLoadsOf('other'));
+    }
 }

--- a/tests/Unit/Support/ModelVariableScannerTest.php
+++ b/tests/Unit/Support/ModelVariableScannerTest.php
@@ -87,4 +87,40 @@ class ModelVariableScannerTest extends TestCase
         $this->assertNull($s->typeOf('renamed'));
         $this->assertSame([], $s->eagerLoadsOf('renamed'));
     }
+
+    public function test_chained_query_ending_in_first_infers_single_model(): void
+    {
+        $s = $this->scan("\$post = Post::where('id', 1)->first();");
+        $this->assertSame('Post', $s->typeOf('post'));
+    }
+
+    public function test_deep_chain_resolves_model_through_multiple_method_calls(): void
+    {
+        $s = $this->scan("\$posts = Post::query()->where('a', 1)->orderBy('b')->get();");
+        $this->assertSame('Collection<Post>', $s->typeOf('posts'));
+    }
+
+    public function test_with_call_with_no_arguments_yields_no_eager_loads(): void
+    {
+        $s = $this->scan('$posts = Post::with()->get();');
+        $this->assertSame([], $s->eagerLoadsOf('posts'));
+    }
+
+    public function test_dynamic_method_name_on_eager_load_chain_is_ignored(): void
+    {
+        // A standalone `$posts->$m('author');` statement never reaches
+        // extractRelationshipsFromEagerLoadCall(), because enterNode()'s load/loadMissing
+        // branch already requires `$node->name instanceof Node\Identifier` before calling it.
+        // The dynamic-name guard inside extractRelationshipsFromEagerLoadCall is only reachable
+        // via trackEagerLoading()'s chain walk, which checks `instanceof Expr\MethodCall` without
+        // that extra Identifier check — so the dynamic call must be the assigned expression itself.
+        $s = $this->scan("\$m = 'with';\n\$posts = Post::all()->\$m('author');");
+        $this->assertSame([], $s->eagerLoadsOf('posts'));
+    }
+
+    public function test_closure_keyed_eager_load_array_reads_relationship_from_key(): void
+    {
+        $s = $this->scan("\$posts = Post::with(['author' => fn (\$q) => \$q->select('id'), 'comments'])->get();");
+        $this->assertEqualsCanonicalizing(['author', 'comments'], $s->eagerLoadsOf('posts'));
+    }
 }

--- a/tests/Unit/Support/ViewBindingRegistryTest.php
+++ b/tests/Unit/Support/ViewBindingRegistryTest.php
@@ -44,4 +44,20 @@ class ViewBindingRegistryTest extends TestCase
         $this->assertNotNull($resolved);
         $this->assertArrayNotHasKey('cities', $resolved);
     }
+
+    /**
+     * Merge policy: two render sites bind the same view variable to DIFFERENT models (e.g.
+     * one passes a Collection<City>, another a Collection<Airport>). Picking either type
+     * would be a guess that drives a precise registry lookup — the variable must be dropped
+     * entirely, exactly like the unknown-type case.
+     */
+    public function test_disagreeing_types_across_sites_drops_the_variable(): void
+    {
+        $r = new ViewBindingRegistry;
+        $r->add('/v/i.blade.php', 'items', new ViewBinding('Collection<City>', [], 'A::index'));
+        $r->add('/v/i.blade.php', 'items', new ViewBinding('Collection<Airport>', [], 'B::index'));
+        $resolved = $r->resolve('/v/i.blade.php');
+        $this->assertNotNull($resolved);
+        $this->assertArrayNotHasKey('items', $resolved);
+    }
 }

--- a/tests/Unit/Support/ViewBindingRegistryTest.php
+++ b/tests/Unit/Support/ViewBindingRegistryTest.php
@@ -20,6 +20,7 @@ class ViewBindingRegistryTest extends TestCase
         $r = new ViewBindingRegistry;
         $r->add('/v/index.blade.php', 'cities', new ViewBinding('Collection<City>', [], 'CityController::index'));
         $resolved = $r->resolve('/v/index.blade.php');
+        $this->assertNotNull($resolved);
         $this->assertSame('Collection<City>', $resolved['cities']['type']);
         $this->assertSame('CityController::index', $resolved['cities']['source']);
     }
@@ -29,7 +30,9 @@ class ViewBindingRegistryTest extends TestCase
         $r = new ViewBindingRegistry;
         $r->add('/v/i.blade.php', 'cities', new ViewBinding('Collection<City>', ['airports'], 'A::index'));
         $r->add('/v/i.blade.php', 'cities', new ViewBinding('Collection<City>', [], 'B::index'));
-        $this->assertEqualsCanonicalizing(['airports'], $r->resolve('/v/i.blade.php')['cities']['eagerLoads']);
+        $resolved = $r->resolve('/v/i.blade.php');
+        $this->assertNotNull($resolved);
+        $this->assertEqualsCanonicalizing(['airports'], $resolved['cities']['eagerLoads']);
     }
 
     public function test_unknown_type_at_any_site_drops_the_variable(): void
@@ -37,6 +40,8 @@ class ViewBindingRegistryTest extends TestCase
         $r = new ViewBindingRegistry;
         $r->add('/v/i.blade.php', 'cities', new ViewBinding('Collection<City>', [], 'A::index'));
         $r->add('/v/i.blade.php', 'cities', new ViewBinding(null, [], 'B::index'));
-        $this->assertArrayNotHasKey('cities', $r->resolve('/v/i.blade.php'));
+        $resolved = $r->resolve('/v/i.blade.php');
+        $this->assertNotNull($resolved);
+        $this->assertArrayNotHasKey('cities', $resolved);
     }
 }

--- a/tests/Unit/Support/ViewBindingRegistryTest.php
+++ b/tests/Unit/Support/ViewBindingRegistryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use PHPUnit\Framework\TestCase;
+use ShieldCI\Support\ViewBinding;
+use ShieldCI\Support\ViewBindingRegistry;
+
+class ViewBindingRegistryTest extends TestCase
+{
+    public function test_unregistered_view_resolves_to_null(): void
+    {
+        $this->assertNull((new ViewBindingRegistry)->resolve('/views/x.blade.php'));
+    }
+
+    public function test_single_site_passes_through(): void
+    {
+        $r = new ViewBindingRegistry;
+        $r->add('/v/index.blade.php', 'cities', new ViewBinding('Collection<City>', [], 'CityController::index'));
+        $resolved = $r->resolve('/v/index.blade.php');
+        $this->assertSame('Collection<City>', $resolved['cities']['type']);
+        $this->assertSame('CityController::index', $resolved['cities']['source']);
+    }
+
+    public function test_any_eager_load_across_sites_marks_relation_loaded(): void
+    {
+        $r = new ViewBindingRegistry;
+        $r->add('/v/i.blade.php', 'cities', new ViewBinding('Collection<City>', ['airports'], 'A::index'));
+        $r->add('/v/i.blade.php', 'cities', new ViewBinding('Collection<City>', [], 'B::index'));
+        $this->assertEqualsCanonicalizing(['airports'], $r->resolve('/v/i.blade.php')['cities']['eagerLoads']);
+    }
+
+    public function test_unknown_type_at_any_site_drops_the_variable(): void
+    {
+        $r = new ViewBindingRegistry;
+        $r->add('/v/i.blade.php', 'cities', new ViewBinding('Collection<City>', [], 'A::index'));
+        $r->add('/v/i.blade.php', 'cities', new ViewBinding(null, [], 'B::index'));
+        $this->assertArrayNotHasKey('cities', $r->resolve('/v/i.blade.php'));
+    }
+}

--- a/tests/Unit/Support/ViewRenderScannerTest.php
+++ b/tests/Unit/Support/ViewRenderScannerTest.php
@@ -63,6 +63,28 @@ class ViewRenderScannerTest extends TestCase
         $this->assertSame('City', $resolved['city']['type']);
     }
 
+    public function test_with_chain_binding_to_a_non_variable_has_no_type(): void
+    {
+        // A literal or expression cannot be traced back to a typed variable, so the binding
+        // records no type — which makes the merge policy drop it rather than guess.
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $controller = $this->write($dir, 'C.php', <<<'PHP'
+        <?php
+        class C {
+            public function show() {
+                return view('cities.show')->with('total', 5);
+            }
+        }
+        PHP);
+
+        $resolved = (new ViewRenderScanner(new AstParser))
+            ->scan([$controller], $dir.'/resources/views')
+            ->resolve($dir.'/resources/views/cities/show.blade.php');
+
+        $this->assertNotNull($resolved);
+        $this->assertArrayNotHasKey('total', $resolved);
+    }
+
     public function test_dynamic_view_name_is_skipped(): void
     {
         $dir = sys_get_temp_dir().'/vrs_'.uniqid();

--- a/tests/Unit/Support/ViewRenderScannerTest.php
+++ b/tests/Unit/Support/ViewRenderScannerTest.php
@@ -74,4 +74,162 @@ class ViewRenderScannerTest extends TestCase
         $registry = (new ViewRenderScanner(new AstParser))->scan([$controller], $dir.'/resources/views');
         $this->assertNull($registry->resolve($dir.'/resources/views/a/b.blade.php'));
     }
+
+    public function test_file_the_parser_returns_no_ast_for_is_skipped_without_error(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $empty = $this->write($dir, 'Empty.php', "<?php\n");
+
+        $registry = (new ViewRenderScanner(new AstParser))->scan([$empty], $dir.'/resources/views');
+
+        $this->assertNull($registry->resolve($dir.'/resources/views/anything.blade.php'));
+    }
+
+    public function test_view_call_inside_top_level_function_uses_file_basename_as_source(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $file = $this->write($dir, 'helpers.php', <<<'PHP'
+        <?php
+        function renderCity() {
+            $city = City::find(1);
+            return view('cities.show', ['city' => $city]);
+        }
+        PHP);
+
+        $resolved = (new ViewRenderScanner(new AstParser))
+            ->scan([$file], $dir.'/resources/views')
+            ->resolve($dir.'/resources/views/cities/show.blade.php');
+
+        $this->assertNotNull($resolved);
+        $this->assertSame('City', $resolved['city']['type']);
+        $this->assertSame('helpers.php', $resolved['city']['source']);
+    }
+
+    public function test_view_call_with_no_arguments_is_skipped(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $file = $this->write($dir, 'C.php', <<<'PHP'
+        <?php
+        class C {
+            public function x() {
+                return view();
+            }
+        }
+        PHP);
+
+        $registry = (new ViewRenderScanner(new AstParser))->scan([$file], $dir.'/resources/views');
+
+        $this->assertNull($registry->resolve($dir.'/resources/views/anything.blade.php'));
+    }
+
+    public function test_doubly_chained_with_calls_are_both_recorded(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $file = $this->write($dir, 'C.php', <<<'PHP'
+        <?php
+        class C {
+            public function x() {
+                $a = City::find(1);
+                $b = Airport::find(2);
+                return view('v')->with('a', $a)->with('b', $b);
+            }
+        }
+        PHP);
+
+        $resolved = (new ViewRenderScanner(new AstParser))
+            ->scan([$file], $dir.'/resources/views')
+            ->resolve($dir.'/resources/views/v.blade.php');
+
+        $this->assertNotNull($resolved);
+        $this->assertSame('City', $resolved['a']['type']);
+        $this->assertSame('Airport', $resolved['b']['type']);
+    }
+
+    public function test_array_literal_second_argument_records_bindings(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $file = $this->write($dir, 'C.php', <<<'PHP'
+        <?php
+        class C {
+            public function index() {
+                $cities = City::all();
+                $k = 'dynamic';
+                return view('cities.index', [
+                    'cities' => $cities,
+                    'count' => 5,
+                    $k => 'ignored',
+                ]);
+            }
+        }
+        PHP);
+
+        $resolved = (new ViewRenderScanner(new AstParser))
+            ->scan([$file], $dir.'/resources/views')
+            ->resolve($dir.'/resources/views/cities/index.blade.php');
+
+        $this->assertNotNull($resolved);
+        $this->assertSame('Collection<City>', $resolved['cities']['type']);
+        // 'count' has a non-variable value (an int literal): a binding is recorded with a null
+        // type, which the registry then drops as unanalyzable (ViewBindingRegistry::resolve()
+        // only surfaces variables every render site agrees have a known type).
+        $this->assertArrayNotHasKey('count', $resolved);
+        // $k is a dynamic (non-string) array key: skipped entirely, never becomes a binding.
+        $this->assertArrayNotHasKey('dynamic', $resolved);
+    }
+
+    public function test_second_argument_that_is_neither_array_nor_compact_yields_no_bindings(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $file = $this->write($dir, 'C.php', <<<'PHP'
+        <?php
+        class C {
+            public function x() {
+                $data = ['a' => 1];
+                return view('v', $data);
+            }
+        }
+        PHP);
+
+        $registry = (new ViewRenderScanner(new AstParser))->scan([$file], $dir.'/resources/views');
+
+        $this->assertNull($registry->resolve($dir.'/resources/views/v.blade.php'));
+    }
+
+    public function test_with_array_form_records_binding(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $file = $this->write($dir, 'C.php', <<<'PHP'
+        <?php
+        class C {
+            public function x() {
+                $cities = City::all();
+                return view('cities.index')->with(['cities' => $cities]);
+            }
+        }
+        PHP);
+
+        $resolved = (new ViewRenderScanner(new AstParser))
+            ->scan([$file], $dir.'/resources/views')
+            ->resolve($dir.'/resources/views/cities/index.blade.php');
+
+        $this->assertNotNull($resolved);
+        $this->assertSame('Collection<City>', $resolved['cities']['type']);
+    }
+
+    public function test_with_call_with_unrecognized_arity_yields_no_bindings(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $file = $this->write($dir, 'C.php', <<<'PHP'
+        <?php
+        class C {
+            public function x() {
+                return view('v')->with();
+            }
+        }
+        PHP);
+
+        $registry = (new ViewRenderScanner(new AstParser))->scan([$file], $dir.'/resources/views');
+
+        $this->assertNull($registry->resolve($dir.'/resources/views/v.blade.php'));
+    }
 }

--- a/tests/Unit/Support/ViewRenderScannerTest.php
+++ b/tests/Unit/Support/ViewRenderScannerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use PHPUnit\Framework\TestCase;
+use ShieldCI\AnalyzersCore\Support\AstParser;
+use ShieldCI\Support\ViewRenderScanner;
+
+class ViewRenderScannerTest extends TestCase
+{
+    private function write(string $dir, string $rel, string $php): string
+    {
+        $path = $dir.'/'.$rel;
+        @mkdir(dirname($path), 0777, true);
+        file_put_contents($path, $php);
+
+        return $path;
+    }
+
+    public function test_records_binding_with_type_and_eager_loads(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $controller = $this->write($dir, 'Controller.php', <<<'PHP'
+        <?php
+        class CityController {
+            public function index() {
+                $cities = City::with(['airports'])->get();
+                return view('admin.cities.index', compact('cities'));
+            }
+        }
+        PHP);
+
+        $registry = (new ViewRenderScanner(new AstParser))->scan([$controller], $dir.'/resources/views');
+        $viewFile = $dir.'/resources/views/admin/cities/index.blade.php';
+        $resolved = $registry->resolve($viewFile);
+
+        $this->assertNotNull($resolved);
+        $this->assertSame('Collection<City>', $resolved['cities']['type']);
+        $this->assertEqualsCanonicalizing(['airports'], $resolved['cities']['eagerLoads']);
+        $this->assertSame('CityController::index', $resolved['cities']['source']);
+    }
+
+    public function test_with_chain_form_is_recognized(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $controller = $this->write($dir, 'C.php', <<<'PHP'
+        <?php
+        class C {
+            public function show() {
+                $city = City::find(1);
+                return view('cities.show')->with('city', $city);
+            }
+        }
+        PHP);
+
+        $resolved = (new ViewRenderScanner(new AstParser))
+            ->scan([$controller], $dir.'/resources/views')
+            ->resolve($dir.'/resources/views/cities/show.blade.php');
+
+        $this->assertSame('City', $resolved['city']['type']);
+    }
+
+    public function test_dynamic_view_name_is_skipped(): void
+    {
+        $dir = sys_get_temp_dir().'/vrs_'.uniqid();
+        $controller = $this->write($dir, 'C.php', <<<'PHP'
+        <?php
+        class C { public function x() { $t = 'a.b'; return view($t, ['u' => $u]); } }
+        PHP);
+
+        $registry = (new ViewRenderScanner(new AstParser))->scan([$controller], $dir.'/resources/views');
+        $this->assertNull($registry->resolve($dir.'/resources/views/a/b.blade.php'));
+    }
+}

--- a/tests/Unit/Support/ViewRenderScannerTest.php
+++ b/tests/Unit/Support/ViewRenderScannerTest.php
@@ -59,6 +59,7 @@ class ViewRenderScannerTest extends TestCase
             ->scan([$controller], $dir.'/resources/views')
             ->resolve($dir.'/resources/views/cities/show.blade.php');
 
+        $this->assertNotNull($resolved);
         $this->assertSame('City', $resolved['city']['type']);
     }
 


### PR DESCRIPTION
Follow-up to #276/#277. `eloquent-n-plus-one` was silently blind to Blade: it already walked `resources/views` (`.blade.php` passes the `php` extension check) but parsed the **raw** template, where `@foreach` is plain text — so the file became one `InlineHTML` node with zero loop nodes and it always reported success.

Compiling Blade alone would still find nothing. `NPlusOneVisitor` can only flag a relation when it knows the loop variable's model type, and it learns types from same-file assignments (`$posts = Post::all()`) that a view doesn't have. Seeding types *without* also carrying the controller's eager-loads would then flag every eager-loaded relation — recreating the false-positive class #276 was filed to remove.

So the feature is **cross-file propagation: controller → view**, carrying model type *and* eager-loaded relations.

- **`ViewRenderScanner`** resolves each `view(...)` call to a Blade file and records what each passed variable is.
- **`ViewBindingRegistry`** merges the render sites: any site's type unknown → drop the variable; any site eager-loads relation R → treat R as loaded; no resolvable render site → skip the view. Everything bends toward silence.
- **`ModelVariableScanner`** (extracted from `NPlusOneVisitor`, which now delegates to it) does the type/eager-load inference for both paths.
- The analyzer compiles each `.blade.php`, seeds the visitor with that view's bindings, and maps compiled lines back to Blade lines.

Findings land on the Blade line at High severity and name the controller to fix:

> `$posts reaches this view from PostController::index. Eager-load the 'user' relation there…`

Validated against a real production Laravel 12 app: a single finding, and a true positive — a `BelongsTo` relation read inside a `@foreach`, whose controller fetched the collection with no matching `with()`. Relations that app *had* eager-loaded stayed silent.

Also fixes a latent bug this exposed in the PHP path: an accessor on a model that defines **no** relationships was reported as an N+1, because accessor suppression sat inside the relationship-registry branch.

4401 tests, 0 failures. PHPStan Level 9 clean. Plain `.php` analysis is unchanged, pinned by a boundary test.

**Known limitations** (follow-ups; both fail safe as false negatives): a `view()` call in a top-level route closure isn't scanned, so the view is skipped; and inner loops of a nested `@foreach` aren't type-inferable, so only the outer relation access is flagged.