### PR TITLE
chore: require shieldci/analyzers-core ^2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "illuminate/view": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "larastan/larastan": "^2.0|^3.0",
         "phpstan/phpstan": "^1.10|^2.0",
-        "shieldci/analyzers-core": "^1.5"
+        "shieldci/analyzers-core": "^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0|^10.0|^11.0|^12.0|^13.0",


### PR DESCRIPTION
Moves off the `^1.5` pin, which had left this package on `analyzers-core` v1.6.0 while core is at v2.1.0.

## No code changes needed

`analyzers-core` v2.0.0's only breaking change was removing `EloquentModelHelper`. This package already ships its own `ShieldCI\Support\EloquentModelHelper`, and every call site (`MassAssignmentAnalyzer`, `FillableForeignKeyAnalyzer`, and its test) already imports that one. Nothing referenced the removed core class, so this is a constraint bump and nothing else.

## Why `^2.1` and not `^2.0`

`^2.0` would allow resolution to v2.0.0, which still carries a bug in `AbstractAnalyzer::getEnvironment()` — a non-string `shieldci.environment_mapping` value was returned straight from a `: string` method, throwing a `TypeError`. 21 analyzers here call `getEnvironment()`, so pinning `^2.1` guarantees they get the fix.

v2.1.0 also fixes `Issue::fromArray()`, which guarded deserialized input with `assert()` — stripped by PHP under the production default `zend.assertions=-1`.

## Verification

Pint clean, PHPStan level 9 clean, **4401 tests / 8350 assertions** green against `analyzers-core` v2.1.0.