### PR TITLE
docs(changelog): add v1.12.0 entry for #282

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.12.0
+
+### Changed
+- Requires `shieldci/analyzers-core ^2.1` (was `^1.5`), which fixes a `TypeError` raised when `shieldci.environment_mapping` maps an environment to a non-string value (#282)
+
 ## v1.11.0
 
 ### Added


### PR DESCRIPTION
Adds the changelog entry for #282, which raised the `shieldci/analyzers-core` requirement from `^1.5` to `^2.1`.