### PR TITLE
chore: migrate static analysis to PHPStan 2.x infrastructure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,9 +148,7 @@ jobs:
           restore-keys: ${{ runner.os }}-phpstan-
 
       - name: Install Composer dependencies
-        run: |
-          composer require --dev "phpstan/phpstan:^1.10" "larastan/larastan:^2.0" --no-interaction --no-update
-          composer update --prefer-dist --no-interaction --no-progress
+        run: composer update --prefer-dist --no-interaction --no-progress
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse --no-progress

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "phpunit/phpunit": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.6",
-        "laravel/pint": "^1.13"
+        "laravel/pint": "^1.13",
+        "phpstan/phpstan-mockery": "^1.1|^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,9 @@
+includes:
+    # Laravel-aware types for facades, config, the container and Eloquent.
+    - vendor/larastan/larastan/extension.neon
+    # Types Mockery's fluent expectation chains, so they need no hand-written ignores.
+    - vendor/phpstan/phpstan-mockery/extension.neon
+
 parameters:
     level: 9
     paths:
@@ -7,9 +13,12 @@ parameters:
         - tests/Fixtures/inspects-code/syntax_error.php
         - tests/Fixtures/inspects-code/sample_functions.php
         - tests/Fixtures/inspects-code-config/syntax_error.php
+        # Stand-in for a consuming app's config/*.php. Its env() calls are the fixture's
+        # whole point, so Larastan's noEnvCallsOutsideOfConfig rule has nothing to say here.
+        - tests/Fixtures/inspects-code-config/config_standard.php
     tmpDir: build/phpstan
     treatPhpDocTypesAsCertain: false
-    reportUnmatchedIgnoredErrors: false
+    reportUnmatchedIgnoredErrors: true
     # Include analyzers-core base classes for proper inheritance analysis
     scanFiles:
         - vendor/shieldci/analyzers-core/src/Abstracts/AbstractFileAnalyzer.php
@@ -26,13 +35,6 @@ parameters:
         -
             message: '#has parameter \$analyzerClasses with no value type specified in iterable type array#'
             path: tests/Unit/AnalyzerManagerTest.php
-
-        # Mockery/PHPUnit test framework issues
-        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::andReturn\(\)#'
-        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::andReturnUsing\(\)#'
-        - '#Parameter \#[0-9]+ \$(config|container) of class ShieldCI\\AnalyzerManager constructor expects .*, Mockery\\MockInterface given#'
-        - '#Parameter \#2 \$array of method PHPUnit\\Framework\\Assert::assertArrayHasKey\(\) expects array\|ArrayAccess, mixed given#'
-        - '#Parameter \#1 \$array of function array_diff expects array, array<int, string>\|false given#'
 
         # AstParser has extended methods beyond ParserInterface
         - '#Call to an undefined method ShieldCI\\AnalyzersCore\\Contracts\\ParserInterface::findClasses\(\)#'
@@ -63,9 +65,6 @@ parameters:
         - '#Argument of an invalid type .*\|false supplied for foreach#'
         - '#Parameter .* of class .* constructor expects .*, mixed given#'
 
-        # Console command option/argument handling
-        - '#Parameter .* expects string, array\|string\|true given#'
-
         # Collection return types (generic type specifications not needed)
         - '#return type with generic class Illuminate\\Support\\Collection does not specify its types#'
 
@@ -76,13 +75,6 @@ parameters:
 
         # Test file specific ignores - artisan command testing returns int|PendingCommand
         - '#Cannot call method (assertSuccessful|assertFailed|expectsOutput|expectsOutputToContain)\(\) on Illuminate\\Testing\\PendingCommand\|int#'
-
-        # Mockery method chaining in tests
-        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::with\(\)#'
-        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::andThrow\(\)#'
-        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::andReturnSelf\(\)#'
-        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::times\(\)#'
-        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage\|Mockery\\MockInterface::with\(\)#'
 
         # Test files: PHPUnit assertions on already-narrowed types are intentional defensive checks
         - '#Call to method PHPUnit\\Framework\\Assert::(assertIsArray|assertIsString|assertIsBool|assertTrue|assertFalse)\(\) with .* will always evaluate to true#'
@@ -97,17 +89,9 @@ parameters:
         - '#Parameter \#1 \$dependencies of method ShieldCI\\Support\\SecurityAdvisories\\AdvisoryAnalyzer::analyze\(\) expects#'
         - '#Parameter \#2 \$advisories of method ShieldCI\\Support\\SecurityAdvisories\\AdvisoryAnalyzer::analyze\(\) expects#'
 
-        # Mockery mock interfaces
-        - '#Return type \(ShieldCI\\AnalyzersCore\\Contracts\\AnalyzerInterface\) of method .* should be compatible#'
-        - '#Method .* should return ShieldCI\\AnalyzersCore\\Contracts\\AnalyzerInterface but returns Mockery\\MockInterface#'
-
         # Test files: Orchestra Testbench guarantees $this->app is never null during tests
         - '#Cannot call method (make|singleton|forgetInstance|bind|offsetUnset)\(\) on Illuminate\\Foundation\\Application\|null#'
-        - '#Offset .* does not exist on Illuminate\\Foundation\\Application\|null#'
         - '#Parameter \#1 \$app of class ShieldCI\\ShieldCIServiceProvider constructor expects .*, Illuminate\\Foundation\\Application\|null given#'
-
-        # Test files: Mockery mock passed where concrete class expected (type-safe at runtime)
-        - '#Parameter \#1 \$manager of class ShieldCI\\Support\\DatabaseConnectionChecker constructor expects .*, Mockery\\MockInterface given#'
 
         # Test files: file_get_contents returns string|false, json_decode returns mixed (controlled in tests)
         - '#Parameter \#1 \$json of function json_decode expects string, string\|false given#'
@@ -117,19 +101,10 @@ parameters:
         # Test files: anonymous class method params with untyped arrays
         -
             message: '#has parameter \$(headers|options) with no value type specified in iterable type array#'
-            paths:
-                - tests/Unit/Concerns/AnalyzesHeadersTest.php
-                - tests/Unit/Concerns/FindsLoginRouteTest.php
+            path: tests/Unit/Concerns/AnalyzesHeadersTest.php
 
         # Test files: assertStringContainsString with nullable string from result objects
         - '#Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert::assertStringContainsString\(\) expects string, string\|null given#'
-
-        # Test files: helper methods with untyped arrays
-        -
-            message: '#has parameter .* with no value type specified in iterable type array#'
-            paths:
-                - tests/Unit/Commands/BaselineCommandTest.php
-                - tests/Unit/Concerns/ParsesPHPStanResultsTest.php
 
         # Test files: anonymous class helper methods return 'object' type, PHPStan can't resolve methods
         -
@@ -152,22 +127,10 @@ parameters:
                 - tests/Unit/Concerns/AnalyzesMiddlewareTest.php
                 - tests/Unit/Concerns/ParsesPHPStanAnalysisTest.php
 
-        # Test files: AnalyzesMiddleware trait template resolution in anonymous class context
-        -
-            message: '#Unable to resolve the template type#'
-            path: tests/Unit/Concerns/AnalyzesMiddlewareTest.php
-        -
-            message: '#Cannot cast mixed to string#'
-            path: tests/Unit/Concerns/AnalyzesMiddlewareTest.php
-
         # Test files: array offset access on empty initial array (passes by ref)
         -
             message: '#Offset 0 does not exist on array#'
             path: tests/Unit/Concerns/ParsesPHPStanAnalysisTest.php
-
-        # Test files: Mockery mocks for logger/fetcher constructors
-        - '#Parameter \#2 \$logger of class ShieldCI\\Support\\SecurityAdvisories\\HttpAdvisoryFetcher constructor expects .*, Mockery\\MockInterface given#'
-        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::once\(\)#'
 
         # Test files: json_encode returns string|false, passed to Response constructor
         -

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace ShieldCI\Tests;
 
 use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Support\Collection;
 use Orchestra\Testbench\TestCase as Orchestra;
+use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\ShieldCIServiceProvider;
 
 abstract class TestCase extends Orchestra
@@ -13,6 +15,18 @@ abstract class TestCase extends Orchestra
     protected function setUp(): void
     {
         parent::setUp();
+    }
+
+    /**
+     * Collection is invariant in its value type, so collect([AnalysisResult, ...]) infers
+     * Collection<int, AnalysisResult> and is rejected where Collection<int, ResultInterface>
+     * is declared. Widening once here beats annotating every call site.
+     *
+     * @return Collection<int, ResultInterface>
+     */
+    protected function resultsOf(ResultInterface ...$results): Collection
+    {
+        return (new Collection($results))->values();
     }
 
     protected function getPackageProviders($app): array

--- a/tests/Unit/Analyzers/Performance/CacheDriverAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/CacheDriverAnalyzerTest.php
@@ -39,7 +39,6 @@ class CacheDriverAnalyzerTest extends AnalyzerTestCase
 
         $configMap = array_replace_recursive($defaults, $configValues);
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->andReturnUsing(function ($key, $default = null) use ($configMap) {
                 // Handle dotted key access (e.g., 'cache.stores.redis.driver')

--- a/tests/Unit/Analyzers/Performance/CollectionCallAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/CollectionCallAnalyzerTest.php
@@ -25,15 +25,12 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         $phpStan = Mockery::mock(PHPStan::class);
 
         if ($phpstanResult !== null) {
-            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $phpStan->shouldReceive('setRootPath')
                 ->andReturnSelf();
 
-            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $phpStan->shouldReceive('start')
                 ->andReturnSelf();
 
-            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $phpStan->shouldReceive('pregMatch')
                 ->with('/could\s+have\s+been\s+retrieved\s+as\s+a\s+query|called\s+.*\s+on\s+.*collection/i')
                 ->andReturn($phpstanResult);
@@ -94,11 +91,9 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $phpStan->shouldReceive('start')
             ->andThrow(new \Exception('PHPStan failed'));
 
@@ -135,17 +130,14 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('start')
             ->with(['app'])  // Should default to ['app']
             ->once()
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('pregMatch')
             ->andReturn([]);
 
@@ -163,17 +155,14 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('start')
             ->with(['app'])  // Should default to ['app']
             ->once()
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('pregMatch')
             ->andReturn([]);
 
@@ -193,17 +182,14 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('start')
             ->with($paths)
             ->once()
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('pregMatch')
             ->andReturn([]);
 
@@ -221,15 +207,12 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('start')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('pregMatch')
             ->andReturn([]);
 
@@ -255,15 +238,12 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('start')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('pregMatch')
             ->andReturn($phpstanResult);
 
@@ -293,15 +273,12 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('start')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('pregMatch')
             ->andReturn($phpstanResult);
 
@@ -399,11 +376,9 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('start')
             ->andThrow(new \RuntimeException('PHPStan executable not found'));
 
@@ -422,15 +397,12 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('start')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('pregMatch')
             ->andThrow(new \RuntimeException('Failed to parse PHPStan output'));
 
@@ -662,18 +634,15 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('start')
             // Should filter out 'config' and 'database', keeping only code directories
             ->with(['app', 'packages', 'modules'])
             ->once()
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('pregMatch')
             ->andReturn([]);
 
@@ -694,18 +663,15 @@ class CollectionCallAnalyzerTest extends AnalyzerTestCase
         /** @var PHPStan&MockInterface $phpStan */
         $phpStan = Mockery::mock(PHPStan::class);
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('setRootPath')
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('start')
             // Should fallback to ['app'] when all config paths are filtered
             ->with(['app'])
             ->once()
             ->andReturnSelf();
 
-        /** @phpstan-ignore-next-line */
         $phpStan->shouldReceive('pregMatch')
             ->andReturn([]);
 

--- a/tests/Unit/Analyzers/Performance/ConfigCachingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/ConfigCachingAnalyzerTest.php
@@ -25,7 +25,6 @@ class ConfigCachingAnalyzerTest extends AnalyzerTestCase
         /** @var ConfigRepository&MockInterface $config */
         $config = Mockery::mock(ConfigRepository::class);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('app.env', Mockery::any())
             ->andReturn($environment);
@@ -35,7 +34,6 @@ class ConfigCachingAnalyzerTest extends AnalyzerTestCase
             /** @var Application&CachesConfiguration&MockInterface $app */
             $app = Mockery::mock(Application::class.', '.CachesConfiguration::class);
 
-            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $app->shouldReceive('configurationIsCached')
                 ->andReturn($configIsCached);
         } else {
@@ -113,7 +111,6 @@ class ConfigCachingAnalyzerTest extends AnalyzerTestCase
 
         /** @var ConfigRepository&MockInterface $config */
         $config = Mockery::mock(ConfigRepository::class);
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')->andReturn('production');
 
         $analyzer = new ConfigCachingAnalyzer($app, $config);
@@ -240,7 +237,6 @@ class ConfigCachingAnalyzerTest extends AnalyzerTestCase
         /** @var ConfigRepository&MockInterface $config */
         $config = Mockery::mock(ConfigRepository::class);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('app.env', Mockery::any())
             ->andReturn('production');
@@ -248,7 +244,6 @@ class ConfigCachingAnalyzerTest extends AnalyzerTestCase
         /** @var Application&CachesConfiguration&MockInterface $app */
         $app = Mockery::mock(Application::class.', '.CachesConfiguration::class);
 
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('configurationIsCached')
             ->andThrow(new \RuntimeException('Cache check failed'));
 
@@ -383,7 +378,6 @@ class ConfigCachingAnalyzerTest extends AnalyzerTestCase
 
         /** @var ConfigRepository&MockInterface $config */
         $config = Mockery::mock(ConfigRepository::class);
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')->andReturn('production');
 
         $analyzer = new ConfigCachingAnalyzer($app, $config);

--- a/tests/Unit/Analyzers/Performance/DebugLogAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/DebugLogAnalyzerTest.php
@@ -35,7 +35,6 @@ class DebugLogAnalyzerTest extends AnalyzerTestCase
 
         $configMap = array_merge($defaults, $configValues);
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->andReturnUsing(function ($key, $default = null) use ($configMap) {
                 return $configMap[$key] ?? $default;
@@ -744,7 +743,6 @@ class DebugLogAnalyzerTest extends AnalyzerTestCase
 
         /** @var ConfigRepository&MockInterface $config */
         $config = Mockery::mock(ConfigRepository::class);
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->andReturnUsing(function ($key, $default = null) use ($configValues) {
                 return $configValues[$key] ?? $default;

--- a/tests/Unit/Analyzers/Performance/HorizonSuggestionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/HorizonSuggestionAnalyzerTest.php
@@ -45,7 +45,6 @@ class HorizonSuggestionAnalyzerTest extends AnalyzerTestCase
 
         $configMap = array_replace_recursive($defaults, $configValues);
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->andReturnUsing(function ($key, $default = null) use ($configMap) {
                 // Handle dotted key access (e.g., 'queue.connections.redis.driver')

--- a/tests/Unit/Analyzers/Performance/MysqlSingleServerAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/MysqlSingleServerAnalyzerTest.php
@@ -42,7 +42,6 @@ class MysqlSingleServerAnalyzerTest extends AnalyzerTestCase
 
         $configMap = array_replace_recursive($defaults, $configValues);
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->andReturnUsing(function ($key, $default = null) use ($configMap) {
                 // Handle dotted key access (e.g., 'database.connections.mysql.driver')
@@ -1056,7 +1055,7 @@ class MysqlSingleServerAnalyzerTest extends AnalyzerTestCase
                         'host' => '127.0.0.1',
                         'database' => 'laravel',
                         'options' => [
-                            \PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA', '/path/to/rds-ca.pem'),
+                            \PDO::MYSQL_ATTR_SSL_CA => '/path/to/rds-ca.pem',
                         ],
                     ],
                 ],

--- a/tests/Unit/Analyzers/Performance/QueueDriverAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/QueueDriverAnalyzerTest.php
@@ -42,7 +42,6 @@ class QueueDriverAnalyzerTest extends AnalyzerTestCase
 
         $configMap = array_replace_recursive($defaults, $configValues);
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->andReturnUsing(function ($key, $default = null) use ($configMap) {
                 // Handle dotted key access (e.g., 'queue.connections.redis.driver')

--- a/tests/Unit/Analyzers/Performance/RouteCachingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/RouteCachingAnalyzerTest.php
@@ -37,7 +37,6 @@ class RouteCachingAnalyzerTest extends AnalyzerTestCase
 
         $configMap = array_replace_recursive($defaults, $configValues);
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->andReturnUsing(function ($key, $default = null) use ($configMap) {
                 // Handle dotted key access (e.g., 'app.env')
@@ -60,7 +59,6 @@ class RouteCachingAnalyzerTest extends AnalyzerTestCase
             /** @var Application&CachesRoutes&MockInterface $app */
             $app = Mockery::mock(Application::class.', '.CachesRoutes::class);
 
-            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $app->shouldReceive('routesAreCached')
                 ->andReturn($routesAreCached);
         } else {

--- a/tests/Unit/Analyzers/Performance/SessionDriverAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/SessionDriverAnalyzerTest.php
@@ -50,7 +50,6 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
 
         $configMap = array_replace_recursive($defaults, $configValues);
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->andReturnUsing(function ($key, $default = null) use ($configMap) {
                 // Handle dotted key access (e.g., 'session.driver', 'app.env')
@@ -79,7 +78,6 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
         }
 
         // Mock getMiddlewareGroups() for optimized detection
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $router->shouldReceive('getMiddlewareGroups')
             ->andReturn($middlewareGroups);
 
@@ -92,17 +90,14 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
         $mockRoutes = [];
         if ($routeMiddleware !== []) {
             $route = Mockery::mock(Route::class);
-            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $route->shouldReceive('middleware')
                 ->andReturn($routeMiddleware);
             // isVendorRoute() calls getAction('uses') — null means closure = app-defined route
-            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $route->shouldReceive('getAction')
                 ->andReturn(null);
             $mockRoutes[] = $route;
         }
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $router->shouldReceive('getRoutes')
             ->andReturn($mockRoutes);
 
@@ -120,7 +115,6 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
             }
         }
 
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $router->shouldReceive('gatherRouteMiddleware')
             ->andReturn($resolvedMiddleware);
 
@@ -131,7 +125,6 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
             $kernel = Mockery::mock(Kernel::class);
 
             // Mock kernel - return provided global middleware
-            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $kernel->shouldReceive('getGlobalMiddleware')
                 ->andReturn($globalMiddleware);
         }
@@ -852,7 +845,6 @@ class SessionDriverAnalyzerTest extends AnalyzerTestCase
     {
         /** @var Repository&MockInterface $config */
         $config = Mockery::mock(Repository::class);
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')->andReturn('redis');
 
         /** @var Router&MockInterface $router */

--- a/tests/Unit/Analyzers/Performance/SharedCacheLockAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/SharedCacheLockAnalyzerTest.php
@@ -23,25 +23,21 @@ class SharedCacheLockAnalyzerTest extends AnalyzerTestCase
         $config = Mockery::mock(ConfigRepository::class);
 
         // Mock cache.default
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->with('cache.default')
             ->andReturn($defaultStore);
 
         // Mock cache driver
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->with("cache.stores.$defaultStore.driver")
             ->andReturn($driver);
 
         // Mock lock_connection
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->with("cache.stores.$defaultStore.lock_connection")
             ->andReturn($lockConnection);
 
         // Mock cache connection
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->with("cache.stores.$defaultStore.connection")
             ->andReturn($cacheConnection);
@@ -341,25 +337,21 @@ PHP;
         $config = Mockery::mock(ConfigRepository::class);
 
         // Mock cache.default
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->with('cache.default')
             ->andReturn($defaultStore);
 
         // Mock cache driver for default store
-        /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
         $config->shouldReceive('get')
             ->with("cache.stores.$defaultStore.driver")
             ->andReturn($driver);
 
         // Mock each store's configuration
         foreach ($stores as $storeName => $storeConfig) {
-            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $config->shouldReceive('get')
                 ->with("cache.stores.$storeName.lock_connection")
                 ->andReturn($storeConfig['lock_connection']);
 
-            /** @phpstan-ignore-next-line Mockery methods are not recognized by PHPStan */
             $config->shouldReceive('get')
                 ->with("cache.stores.$storeName.connection")
                 ->andReturn($storeConfig['connection']);

--- a/tests/Unit/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/UnusedGlobalMiddlewareAnalyzerTest.php
@@ -48,7 +48,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
         // Mock config values
         foreach ($configValues as $key => $value) {
-            /** @phpstan-ignore-next-line */
             $config->shouldReceive('get')
                 ->with($key, Mockery::any())
                 ->andReturn($value);
@@ -56,21 +55,18 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
 
         // Set default config values if not provided
         if (! isset($configValues['trustedproxy.proxies'])) {
-            /** @phpstan-ignore-next-line */
             $config->shouldReceive('get')
                 ->with('trustedproxy.proxies')
                 ->andReturn(null);
         }
 
         if (! isset($configValues['cors.paths'])) {
-            /** @phpstan-ignore-next-line */
             $config->shouldReceive('get')
                 ->with('cors.paths', [])
                 ->andReturn([]);
         }
 
         // Mock app->make() for middleware instantiation
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->andReturnUsing(function ($class) {
                 if ($class === TrustProxies::class) {
@@ -165,12 +161,10 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             protected $middleware = [];
         };
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line Mockery mocks passed to constructor */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -199,7 +193,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
         };
 
         // Mock the TrustProxies middleware with null proxies
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -209,17 +202,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             });
 
         // Mock config to return null for trustedproxy.proxies
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line Mockery mocks passed to constructor */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -245,7 +235,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
         };
 
         // Mock TrustProxies with configured proxies
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -254,17 +243,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
                 protected $proxies = '*';
             });
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line Mockery mocks passed to constructor */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -288,12 +274,10 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line Mockery mocks passed to constructor */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -318,12 +302,10 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line Mockery mocks passed to constructor */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -350,7 +332,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -359,17 +340,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
                 protected $proxies = null;
             });
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line Mockery mocks passed to constructor */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -403,17 +381,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line Mockery mocks passed to constructor */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -442,12 +417,10 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn(['api/*', 'sanctum/csrf-cookie']);
 
-        /** @phpstan-ignore-next-line Mockery mocks passed to constructor */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -471,7 +444,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
         };
 
         // Mock TrustProxies with array of IPs
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -480,17 +452,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
                 protected $proxies = ['192.168.1.1', '10.0.0.0/8'];
             });
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -514,7 +483,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
         };
 
         // TrustProxies middleware has null proxies
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -524,17 +492,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             });
 
         // But config has proxies configured (Fideloper package pattern)
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(['192.168.1.1']);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -558,17 +523,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
         };
 
         // Mock app->make() to throw exception
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andThrow(new \Exception('Cannot instantiate'));
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -594,7 +556,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -604,17 +565,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             });
 
         // Return invalid types for config values
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(12345); // Invalid: should be string, array, or null
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn('not-an-array'); // Invalid: should be array
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -641,7 +599,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -650,17 +607,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
                 protected $proxies = null;
             });
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -689,7 +643,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -698,17 +651,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
                 protected $proxies = null;
             });
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -740,7 +690,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -749,17 +698,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
                 protected $proxies = null;
             });
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -790,7 +736,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -799,17 +744,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
                 protected $proxies = null;
             });
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -845,7 +787,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -854,17 +795,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
                 protected $proxies = null;
             });
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -888,7 +826,6 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -897,17 +834,14 @@ class UnusedGlobalMiddlewareAnalyzerTest extends AnalyzerTestCase
                 protected $proxies = null;
             });
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 
@@ -953,14 +887,12 @@ PHP;
             ];
         };
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
         // Use an anonymous subclass to override getBasePath() since AbstractAnalyzer
         // doesn't expose setBasePath() — only AbstractFileAnalyzer does.
-        /** @phpstan-ignore-next-line Anonymous class with dynamic base path */
         $analyzer = new class($app, $config, $router, $kernel, $tempDir) extends UnusedGlobalMiddlewareAnalyzer
         {
             public function __construct(
@@ -1017,7 +949,6 @@ PHP;
         };
 
         // TrustProxies is configured
-        /** @phpstan-ignore-next-line */
         $app->shouldReceive('make')
             ->with(TrustProxies::class)
             ->andReturn(new class
@@ -1026,18 +957,15 @@ PHP;
                 protected $proxies = '*';
             });
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('trustedproxy.proxies')
             ->andReturn(null);
 
         // CORS is not configured
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->with('cors.paths', [])
             ->andReturn([]);
 
-        /** @phpstan-ignore-next-line */
         $analyzer = new UnusedGlobalMiddlewareAnalyzer($app, $config, $router, $kernel);
         $result = $analyzer->analyze();
 

--- a/tests/Unit/Analyzers/Performance/ViewCachingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/ViewCachingAnalyzerTest.php
@@ -76,7 +76,6 @@ class ViewCachingAnalyzerTest extends AnalyzerTestCase
 
         $configMap = array_replace_recursive($defaults, $configValues);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')
             ->andReturnUsing(function ($key, $default = null) use ($configMap) {
                 $keys = explode('.', $key);
@@ -105,7 +104,6 @@ class ViewCachingAnalyzerTest extends AnalyzerTestCase
             $globReturn = is_array($actualFiles) ? $actualFiles : [];
         }
 
-        /** @phpstan-ignore-next-line */
         $files->allows('glob')
             ->with($compiledPathForGlob.'/*.php')
             ->andReturn($globReturn);

--- a/tests/Unit/Analyzers/Reliability/DatabaseStatusAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/DatabaseStatusAnalyzerTest.php
@@ -166,12 +166,10 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
 
         /** @var Mockery\ExpectationInterface $mysqlExpectation */
-        /** @phpstan-ignore-next-line Mockery expectation chaining */
         $mysqlExpectation = $checker->shouldReceive('check')->with('mysql');
         $mysqlExpectation->andReturn(new DatabaseConnectionResult(false, 'Connection refused', 'PDOException'));
 
         /** @var Mockery\ExpectationInterface $sqliteExpectation */
-        /** @phpstan-ignore-next-line Mockery expectation chaining */
         $sqliteExpectation = $checker->shouldReceive('check')->with('sqlite');
         $sqliteExpectation->andReturn(new DatabaseConnectionResult(false, 'Access denied', 'PDOException'));
 
@@ -204,9 +202,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $config->set('shieldci.analyzers.reliability.database-status.connections', 'mysql,sqlite');
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('mysql')->andReturn(new DatabaseConnectionResult(true));
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('sqlite')->andReturn(new DatabaseConnectionResult(true));
 
         $analyzer = $this->createAnalyzer($checker);
@@ -229,9 +225,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $config->set('shieldci.analyzers.reliability.database-status.connections', ['mysql', null, 123, '', 'valid']);
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('mysql')->times(1)->andReturn(new DatabaseConnectionResult(true));
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('valid')->times(1)->andReturn(new DatabaseConnectionResult(true));
 
         $analyzer = $this->createAnalyzer($checker);
@@ -254,9 +248,7 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $config->set('shieldci.analyzers.reliability.database-status.connections', 'mysql , sqlite ');
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('mysql')->andReturn(new DatabaseConnectionResult(true));
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('sqlite')->andReturn(new DatabaseConnectionResult(true));
 
         $analyzer = $this->createAnalyzer($checker);
@@ -484,7 +476,6 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
         // Should only be called once for mysql (deduplicated)
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('mysql')->once()->andReturn(new DatabaseConnectionResult(true));
 
         $analyzer = $this->createAnalyzer($checker);
@@ -871,10 +862,8 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $config->set('shieldci.analyzers.reliability.database-status.connections', ['sqlite']);
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('mysql')->andReturn(new DatabaseConnectionResult(true));
         // Persistent error on non-default connection
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('sqlite')->andReturn(new DatabaseConnectionResult(false, 'Unknown database'));
 
         $analyzer = $this->createAnalyzer($checker);
@@ -910,10 +899,8 @@ class DatabaseStatusAnalyzerTest extends AnalyzerTestCase
         $config->set('shieldci.analyzers.reliability.database-status.connections', ['sqlite']);
 
         $checker = Mockery::mock(DatabaseConnectionChecker::class);
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('mysql')->andReturn(new DatabaseConnectionResult(true));
         // Transient error on non-default connection
-        /** @phpstan-ignore-next-line */
         $checker->shouldReceive('check')->with('sqlite')->andReturn(new DatabaseConnectionResult(false, 'Connection timed out'));
 
         $analyzer = $this->createAnalyzer($checker);

--- a/tests/Unit/Analyzers/Security/EnvHttpAccessibilityAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/EnvHttpAccessibilityAnalyzerTest.php
@@ -36,7 +36,6 @@ class EnvHttpAccessibilityAnalyzerTest extends AnalyzerTestCase
         // configure the URL generator from app.url
         $appUrl = config('app.url');
         if ($appUrl && is_string($appUrl)) {
-            /** @phpstan-ignore-next-line */
             URL::forceRootUrl($appUrl);
         }
 

--- a/tests/Unit/Analyzers/Security/SqlInjectionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/SqlInjectionAnalyzerTest.php
@@ -18,7 +18,6 @@ class SqlInjectionAnalyzerTest extends AnalyzerTestCase
         /** @var Config&MockInterface $config */
         $config = Mockery::mock(Config::class);
 
-        /** @phpstan-ignore-next-line */
         $config->shouldReceive('get')->andReturn(null);
 
         return new SqlInjectionAnalyzer($this->parser, $config);

--- a/tests/Unit/Analyzers/Security/StableDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/StableDependencyAnalyzerTest.php
@@ -31,7 +31,6 @@ class StableDependencyAnalyzerTest extends AnalyzerTestCase
         $composer = Mockery::mock(Composer::class);
 
         if ($throwable !== null) {
-            /** @phpstan-ignore-next-line Mockery expectation chaining */
             $composer->shouldReceive('updateDryRun')->andThrow($throwable);
 
             return $composer;

--- a/tests/Unit/Analyzers/Security/UpToDateDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/UpToDateDependencyAnalyzerTest.php
@@ -49,10 +49,8 @@ class UpToDateDependencyAnalyzerTest extends AnalyzerTestCase
 
         // Mock installDryRun - now called only ONCE per analysis (performance optimization!)
         if ($installDryRunException !== null) {
-            /** @phpstan-ignore-next-line Mockery expectation chaining */
             $composer->shouldReceive('installDryRun')->andThrow($installDryRunException);
         } elseif ($allDepsOutput !== null) {
-            /** @phpstan-ignore-next-line Mockery's times() is not recognized by PHPStan */
             $composer->shouldReceive('installDryRun')
                 ->once()
                 ->andReturn($allDepsOutput);
@@ -400,7 +398,6 @@ OUTPUT;
 
         // OPTIMIZATION: Verify installDryRun is called only ONCE (not twice)
         // This cuts CI execution time in half for large projects
-        /** @phpstan-ignore-next-line Mockery expectation chaining */
         $composer->shouldReceive('installDryRun')
             ->once()
             ->andReturn("Nothing to install or update\n");
@@ -820,7 +817,6 @@ OUTPUT;
         $composer->shouldReceive('getJsonFile')->andReturn('/path/to/composer.json');
         $composer->shouldReceive('areDevPackagesInstalled')->andReturn(true);
 
-        /** @phpstan-ignore-next-line Mockery expectation chaining */
         $composer->shouldReceive('installDryRun')
             ->with(['--ignore-platform-reqs'])
             ->once()
@@ -844,7 +840,6 @@ OUTPUT;
         $composer->shouldReceive('areDevPackagesInstalled')->andReturn(true);
 
         // Verify that --ignore-platform-reqs is passed when running in Vapor
-        /** @phpstan-ignore-next-line Mockery expectation chaining */
         $composer->shouldReceive('installDryRun')
             ->with(['--ignore-platform-reqs'])
             ->once()
@@ -868,7 +863,6 @@ OUTPUT;
         $composer->shouldReceive('areDevPackagesInstalled')->andReturn(false);
 
         // When --no-dev mode is active, --ignore-platform-reqs is appended after it
-        /** @phpstan-ignore-next-line Mockery expectation chaining */
         $composer->shouldReceive('installDryRun')
             ->with(['--no-dev', '--ignore-platform-reqs'])
             ->once()
@@ -933,7 +927,6 @@ OUTPUT;
 
         // Output with a Lock file operations line but no parseable "- Verb Package" lines
         // so we reach the scope='unknown' branch where $dryRunFlag is recorded.
-        /** @phpstan-ignore-next-line Mockery expectation chaining */
         $composer->shouldReceive('installDryRun')
             ->with(['--ignore-platform-reqs'])
             ->once()

--- a/tests/Unit/Analyzers/Security/VulnerableDependencyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/VulnerableDependencyAnalyzerTest.php
@@ -79,7 +79,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')
             ->with($dependencies)
             ->andReturn(['vendor/package' => []]);
@@ -105,7 +104,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')
             ->andReturn($analysisOutput);
 
@@ -138,7 +136,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->never();
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -147,7 +144,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn([]);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -174,7 +170,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')
             ->with($dependencies)
             ->andThrow(new RuntimeException('network error'));
@@ -185,7 +180,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->never();
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -211,17 +205,14 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->never();
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
         $dependencyReader = Mockery::mock(ComposerDependencyReader::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $dependencyReader->shouldReceive('read')->andThrow(new RuntimeException('invalid file'));
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->never();
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -253,7 +244,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->never();
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -262,7 +252,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn([]);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -295,7 +284,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->never();
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -304,7 +292,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn([]);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -337,7 +324,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->andReturn(['vendor/package' => []]);
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -364,7 +350,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn($analysisOutput);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -410,7 +395,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->andReturn(['vendor/package' => []]);
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -432,7 +416,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn($analysisOutput);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -466,7 +449,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->andReturn(['vendor/package' => []]);
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -488,7 +470,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn($analysisOutput);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -518,7 +499,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->andReturn(['vendor/package' => []]);
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -539,7 +519,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn($analysisOutput);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -572,7 +551,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->andReturn(['vendor/package' => []]);
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -593,7 +571,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn($analysisOutput);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -623,12 +600,10 @@ JSON;
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
         $dependencyReader = Mockery::mock(ComposerDependencyReader::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $dependencyReader->shouldReceive('read')->andReturn([]);
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn([]);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -666,7 +641,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->andReturn(['vendor/vulnerable' => []]);
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -687,7 +661,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn($analysisOutput);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -732,7 +705,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->andReturn(['vendor/package' => []]);
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -750,7 +722,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn($analysisOutput);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -782,7 +753,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->never();
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -791,7 +761,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn([]);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -832,7 +801,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->andReturn(['vendor/package' => []]);
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -854,7 +822,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn($analysisOutput);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -895,7 +862,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->never();
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -904,7 +870,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn([]);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -944,7 +909,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->never();
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -953,7 +917,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn([]);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -985,7 +948,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->never();
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -994,7 +956,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn([]);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -1024,7 +985,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->andReturn(['vendor/package' => []]);
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -1045,7 +1005,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn($analysisOutput);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);
@@ -1073,7 +1032,6 @@ JSON;
 
         /** @var AdvisoryFetcherInterface&MockInterface $fetcher */
         $fetcher = Mockery::mock(AdvisoryFetcherInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $fetcher->shouldReceive('fetch')->andReturn(['vendor/package' => []]);
 
         /** @var ComposerDependencyReader&MockInterface $dependencyReader */
@@ -1091,7 +1049,6 @@ JSON;
 
         /** @var AdvisoryAnalyzerInterface&MockInterface $advisoryAnalyzer */
         $advisoryAnalyzer = Mockery::mock(AdvisoryAnalyzerInterface::class);
-        /** @phpstan-ignore-next-line Mockery fluent interface */
         $advisoryAnalyzer->shouldReceive('analyze')->andReturn($analysisOutput);
 
         $analyzer = $this->createAnalyzer($fetcher, $advisoryAnalyzer, $dependencyReader);

--- a/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
@@ -50,7 +50,6 @@ class XssAnalyzerTest extends AnalyzerTestCase
 
         $appUrl = config('app.url');
         if ($appUrl && is_string($appUrl)) {
-            /** @phpstan-ignore-next-line */
             URL::forceRootUrl($appUrl);
         }
 

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -1620,24 +1620,19 @@ class AnalyzeCommandTest extends TestCase
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -2030,28 +2025,20 @@ PHP);
         // Create a mock ResultInterface that is NOT an AnalysisResult
         /** @var ResultInterface&MockInterface $mockResult */
         $mockResult = Mockery::mock(ResultInterface::class);
-        /** @phpstan-ignore-next-line */
         $mockResult->shouldReceive('getAnalyzerId')->andReturn('mock-analyzer');
-        /** @phpstan-ignore-next-line */
         $mockResult->shouldReceive('getStatus')->andReturn(Status::Failed);
-        /** @phpstan-ignore-next-line */
         $mockResult->shouldReceive('getMessage')->andReturn('Mock failed');
-        /** @phpstan-ignore-next-line */
         $mockResult->shouldReceive('getIssues')->andReturn([]);
-        /** @phpstan-ignore-next-line */
         $mockResult->shouldReceive('getExecutionTime')->andReturn(0.1);
-        /** @phpstan-ignore-next-line */
         $mockResult->shouldReceive('getMetadata')->andReturn([]);
-        /** @phpstan-ignore-next-line */
         $mockResult->shouldReceive('isSuccess')->andReturn(false);
-        /** @phpstan-ignore-next-line */
         $mockResult->shouldReceive('toArray')->andReturn([]);
 
         $report = new AnalysisReport(
             projectId: 'test-project-id',
             laravelVersion: '11.0',
             packageVersion: '1.0.0',
-            results: collect([$mockResult]),
+            results: $this->resultsOf($mockResult),
             totalExecutionTime: 0.1,
             analyzedAt: new \DateTimeImmutable('2026-01-01T00:00:00Z'),
         );
@@ -2328,7 +2315,6 @@ PHP);
         // Mock the ClientInterface to throw an exception
         $this->app->singleton(ClientInterface::class, function () {
             $mock = Mockery::mock(ClientInterface::class);
-            /** @phpstan-ignore-next-line */
             $mock->shouldReceive('sendReport')
                 ->andThrow(new \Exception('Connection timed out'));
 
@@ -2695,34 +2681,27 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$failedAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with('test-security-failed')
                 ->andReturn($failedAnalyzer->analyze());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with(Mockery::any())
                 ->andReturn(null);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$failedAnalyzer->analyze()]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -2763,34 +2742,27 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$failedAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with('test-multi-issues')
                 ->andReturn($failedAnalyzer->analyze());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with(Mockery::any())
                 ->andReturn(null);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$failedAnalyzer->analyze()]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -2825,34 +2797,27 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$warningAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with('test-warning-analyzer')
                 ->andReturn($warningAnalyzer->analyze());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with(Mockery::any())
                 ->andReturn(null);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$warningAnalyzer->analyze()]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -2887,34 +2852,27 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$failedAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with('test-severity-failed')
                 ->andReturn($failedAnalyzer->analyze());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with(Mockery::any())
                 ->andReturn(null);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$failedAnalyzer->analyze()]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -2952,72 +2910,58 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$securityAnalyzer, $performanceAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with('security')
                 ->andReturn(collect([$securityAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with('performance')
                 ->andReturn(collect([$performanceAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategories')
                 ->with(['security'])
                 ->andReturn(collect([$securityAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategories')
                 ->with(['performance'])
                 ->andReturn(collect([$performanceAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategories')
                 ->with(['security', 'performance'])
                 ->andReturn(collect([$securityAnalyzer, $performanceAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategories')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with('test-security-analyzer')
                 ->andReturn($securityAnalyzer->analyze());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with('test-performance-analyzer')
                 ->andReturn($performanceAnalyzer->analyze());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with(Mockery::any())
                 ->andReturn(null);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([
                     $securityAnalyzer->analyze(),
                     $performanceAnalyzer->analyze(),
                 ]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -3052,34 +2996,27 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$warningAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with('test-warning-severity')
                 ->andReturn($warningAnalyzer->analyze());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with(Mockery::any())
                 ->andReturn(null);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$warningAnalyzer->analyze()]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -3120,49 +3057,39 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$passedAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with('security')
                 ->andReturn(collect([$passedAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategories')
                 ->with(['security'])
                 ->andReturn(collect([$passedAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategories')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect([$skippedResult]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with('test-security-passed')
                 ->andReturn($passedAnalyzer->analyze());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with(Mockery::any())
                 ->andReturn(null);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$passedAnalyzer->analyze()]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -3262,24 +3189,19 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect([$skipped]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$skipped]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -3319,34 +3241,27 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$passedAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect([$skippedResult]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with('test-passed-scs')
                 ->andReturn($passedAnalyzer->analyze());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with(Mockery::any())
                 ->andReturn(null);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect([$passedAnalyzer->analyze()]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -3368,12 +3283,10 @@ PHP);
 
             /** @var AnalyzerInterface&MockInterface $analyzer */
             $analyzer = Mockery::mock(AnalyzerInterface::class);
-            /** @phpstan-ignore-next-line */
             $analyzer->shouldReceive('getId')->andReturn($id);
             $categoryValue = $metadata['category'] ?? null;
             $severityValue = $metadata['severity'] ?? null;
 
-            /** @phpstan-ignore-next-line */
             $analyzer->shouldReceive('getMetadata')->andReturn(new AnalyzerMetadata(
                 id: $id,
                 name: is_string($metadata['name'] ?? null) ? $metadata['name'] : $id,
@@ -3381,11 +3294,8 @@ PHP);
                 category: $categoryValue instanceof Category ? $categoryValue : Category::Security,
                 severity: $severityValue instanceof Severity ? $severityValue : Severity::Low,
             ));
-            /** @phpstan-ignore-next-line */
             $analyzer->shouldReceive('analyze')->andReturn($result);
-            /** @phpstan-ignore-next-line */
             $analyzer->shouldReceive('shouldRun')->andReturn(true);
-            /** @phpstan-ignore-next-line */
             $analyzer->shouldReceive('getSkipReason')->andReturn('');
 
             $analyzers[] = $analyzer;
@@ -3396,36 +3306,29 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect($analyzers));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')
                 ->with(Mockery::any())
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')
                 ->andReturn(collect($results));
 
             foreach ($analyzers as $analyzer) {
-                /** @phpstan-ignore-next-line */
                 $manager->shouldReceive('run')
                     ->with($analyzer->getId())
                     ->andReturn($analyzer->analyze());
             }
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('run')
                 ->with(Mockery::any())
                 ->andReturn(null);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -3473,15 +3376,10 @@ PHP);
             ],
         );
 
-        /** @phpstan-ignore-next-line */
         $analyzer->shouldReceive('getId')->andReturn($id);
-        /** @phpstan-ignore-next-line */
         $analyzer->shouldReceive('getMetadata')->andReturn($metadata);
-        /** @phpstan-ignore-next-line */
         $analyzer->shouldReceive('analyze')->andReturn($result);
-        /** @phpstan-ignore-next-line */
         $analyzer->shouldReceive('shouldRun')->andReturn(true);
-        /** @phpstan-ignore-next-line */
         $analyzer->shouldReceive('getSkipReason')->andReturn('');
 
         return $analyzer;
@@ -3565,15 +3463,10 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')->andReturn(collect());
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')->with(Mockery::any())->andReturn(collect());
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')->andReturn(collect());
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('runAll')->andReturn(collect());
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')->andReturn(null);
 
             return $manager;
@@ -3599,9 +3492,7 @@ PHP);
         // Create an analyzer mock that throws during analyze()
         /** @var AnalyzerInterface&MockInterface $throwingAnalyzer */
         $throwingAnalyzer = Mockery::mock(AnalyzerInterface::class);
-        /** @phpstan-ignore-next-line */
         $throwingAnalyzer->shouldReceive('getId')->andReturn('throwing-analyzer');
-        /** @phpstan-ignore-next-line */
         $throwingAnalyzer->shouldReceive('getMetadata')->andReturn(new AnalyzerMetadata(
             id: 'throwing-analyzer',
             name: 'Throwing Analyzer',
@@ -3609,11 +3500,8 @@ PHP);
             category: Category::Security,
             severity: Severity::High,
         ));
-        /** @phpstan-ignore-next-line */
         $throwingAnalyzer->shouldReceive('analyze')->andThrow(new \RuntimeException('AST parser crashed'));
-        /** @phpstan-ignore-next-line */
         $throwingAnalyzer->shouldReceive('shouldRun')->andReturn(true);
-        /** @phpstan-ignore-next-line */
         $throwingAnalyzer->shouldReceive('getSkipReason')->andReturn('');
 
         /** @phpstan-ignore-next-line */
@@ -3621,13 +3509,9 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')->andReturn(collect([$throwingAnalyzer]));
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getByCategory')->with(Mockery::any())->andReturn(collect());
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')->andReturn(collect());
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')->andReturn(null);
 
             return $manager;
@@ -3658,7 +3542,6 @@ PHP);
         /** @phpstan-ignore-next-line */
         $this->app->singleton(ClientInterface::class, function () {
             $mock = Mockery::mock(ClientInterface::class);
-            /** @phpstan-ignore-next-line */
             $mock->shouldReceive('sendFailureNotification')
                 ->andThrow(new \Exception('Connection refused'));
 
@@ -4514,19 +4397,12 @@ PHP);
 
         /** @var MockInterface&AnalyzerManager $manager */
         $manager = Mockery::mock(AnalyzerManager::class);
-        /** @phpstan-ignore-next-line */
         $manager->shouldReceive('getAnalyzers')->andReturn(collect([$securityAnalyzer, $performanceAnalyzer]));
-        /** @phpstan-ignore-next-line */
         $manager->shouldReceive('getByCategories')->with(['security'])->andReturn(collect([$securityAnalyzer]));
-        /** @phpstan-ignore-next-line */
         $manager->shouldReceive('getSkippedAnalyzers')->andReturn(collect());
-        /** @phpstan-ignore-next-line */
         $manager->shouldReceive('run')->with('test-security-analyzer')->andReturn($securityAnalyzer->analyze());
-        /** @phpstan-ignore-next-line */
         $manager->shouldReceive('run')->with('test-performance-analyzer')->andReturn($performanceAnalyzer->analyze());
-        /** @phpstan-ignore-next-line */
         $manager->shouldReceive('resolveAnalyzerDisplayName')->andReturn('Test Security Analyzer');
-        /** @phpstan-ignore-next-line */
         $manager->shouldReceive('clearParserCache')->andReturn(null);
 
         return $manager;
@@ -4741,15 +4617,12 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$astCacheAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -4775,15 +4648,12 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$astCacheAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 
@@ -4807,15 +4677,12 @@ PHP);
             /** @var MockInterface&AnalyzerManager $manager */
             $manager = Mockery::mock(AnalyzerManager::class);
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getAnalyzers')
                 ->andReturn(collect([$astCacheAnalyzer]));
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('getSkippedAnalyzers')
                 ->andReturn(collect());
 
-            /** @phpstan-ignore-next-line */
             $manager->shouldReceive('clearParserCache')
                 ->andReturn(null);
 

--- a/tests/Unit/Support/ReporterTest.php
+++ b/tests/Unit/Support/ReporterTest.php
@@ -31,9 +31,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_generates_report_with_default_trigger_source(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
 
@@ -44,9 +44,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_generates_report_with_custom_trigger_source(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::CiCd);
 
@@ -57,9 +57,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function api_payload_includes_triggered_by(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::Scheduled);
         $payload = $this->reporter->toApi($report);
@@ -72,7 +72,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_can_generate_report_from_results(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
             AnalysisResult::failed('analyzer-2', 'Failed', [
                 new Issue(
@@ -82,7 +82,7 @@ class ReporterTest extends TestCase
                     recommendation: 'Fix it',
                 ),
             ]),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
 
@@ -94,9 +94,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_can_format_to_console(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('test-analyzer', 'All checks passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -110,9 +110,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_can_format_to_json(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('test-analyzer', 'All checks passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $json = $this->reporter->toJson($report);
@@ -132,9 +132,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_can_format_to_api(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('test-analyzer', 'All checks passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $apiPayload = $this->reporter->toApi($report);
@@ -152,7 +152,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function console_output_includes_failed_analyzers(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::failed('test-analyzer', 'Found issues', [
                 new Issue(
                     message: 'Security vulnerability detected',
@@ -161,7 +161,7 @@ class ReporterTest extends TestCase
                     recommendation: 'Sanitize user input',
                 ),
             ]),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -175,7 +175,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function console_output_includes_warnings(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::warning('test-analyzer', 'Warning issued', [
                 new Issue(
                     message: 'Potential performance issue',
@@ -184,7 +184,7 @@ class ReporterTest extends TestCase
                     recommendation: 'Consider caching',
                 ),
             ]),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -368,7 +368,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function console_output_includes_report_card_table(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'sec-1',
                 status: Status::Passed,
@@ -392,7 +392,7 @@ class ReporterTest extends TestCase
                 executionTime: 0.2,
                 metadata: ['category' => Category::Performance, 'name' => 'Perf 1'],
             ),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -486,10 +486,10 @@ class ReporterTest extends TestCase
     #[Test]
     public function console_output_handles_skipped_analyzers_in_report(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('pass-1', 'OK'),
             AnalysisResult::skipped('skip-1', 'Skipped'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -501,7 +501,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function console_output_shows_time_to_fix_in_report(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'test-analyzer',
                 status: Status::Failed,
@@ -521,7 +521,7 @@ class ReporterTest extends TestCase
                     'timeToFix' => 5,
                 ],
             ),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -533,7 +533,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function console_output_shows_docs_url_in_report(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'test-analyzer',
                 status: Status::Failed,
@@ -553,7 +553,7 @@ class ReporterTest extends TestCase
                     'docsUrl' => 'https://docs.shieldci.com/test-analyzer',
                 ],
             ),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -704,7 +704,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function console_output_only_shows_categories_with_non_skipped_analyzers(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'pass-1',
                 status: Status::Passed,
@@ -717,7 +717,7 @@ class ReporterTest extends TestCase
                 'category' => Category::Performance,
                 'name' => 'Perf Test',
             ]),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -731,7 +731,7 @@ class ReporterTest extends TestCase
     public function console_output_handles_null_location_issues_in_to_console(): void
     {
         // Exercises line 128 (null location in toConsole issue display)
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'test-analyzer',
                 status: Status::Failed,
@@ -750,7 +750,7 @@ class ReporterTest extends TestCase
                     'category' => Category::Security,
                 ],
             ),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -765,7 +765,7 @@ class ReporterTest extends TestCase
         // Exercises lines 140-141 (truncated issues in toConsole)
         config(['shieldci.report.max_issues_per_check' => 1]);
 
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'test-analyzer',
                 status: Status::Failed,
@@ -781,7 +781,7 @@ class ReporterTest extends TestCase
                     'category' => Category::Security,
                 ],
             ),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -796,7 +796,7 @@ class ReporterTest extends TestCase
         // Exercises line 216 (italic recommendation in toConsole)
         config(['shieldci.report.show_recommendations' => true]);
 
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'test-analyzer',
                 status: Status::Failed,
@@ -815,7 +815,7 @@ class ReporterTest extends TestCase
                     'category' => Category::Security,
                 ],
             ),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -828,7 +828,7 @@ class ReporterTest extends TestCase
     public function console_output_shows_docs_url_in_to_console(): void
     {
         // Exercises line 239 (documentation URL in toConsole)
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'test-analyzer',
                 status: Status::Failed,
@@ -848,7 +848,7 @@ class ReporterTest extends TestCase
                     'docsUrl' => 'https://docs.shieldci.com/test',
                 ],
             ),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -861,12 +861,12 @@ class ReporterTest extends TestCase
     public function console_report_card_falls_back_when_all_skipped(): void
     {
         // Exercises line 377 (all categories only have skipped analyzers)
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::skipped('skip-1', 'Not applicable', 0.0, [
                 'category' => Category::Security,
                 'name' => 'Skipped Analyzer',
             ]),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -879,7 +879,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function json_output_contains_all_required_fields(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'test-analyzer',
                 status: Status::Failed,
@@ -895,7 +895,7 @@ class ReporterTest extends TestCase
                 executionTime: 0.5,
                 metadata: ['name' => 'Test Analyzer', 'category' => Category::Security],
             ),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $json = $this->reporter->toJson($report);
@@ -915,7 +915,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function console_output_shows_error_status_label(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'test-error-analyzer',
                 status: Status::Error,
@@ -927,7 +927,7 @@ class ReporterTest extends TestCase
                     'category' => Category::Security,
                 ],
             ),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -1000,7 +1000,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function console_output_shows_unknown_category_for_non_string_category(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             new AnalysisResult(
                 analyzerId: 'test-analyzer',
                 status: Status::Passed,
@@ -1009,7 +1009,7 @@ class ReporterTest extends TestCase
                 executionTime: 0.1,
                 metadata: ['name' => 'Test Analyzer', 'category' => 42],
             ),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
         $output = $this->reporter->toConsole($report);
@@ -1021,9 +1021,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_generates_analyzed_at_in_utc(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
 
@@ -1035,9 +1035,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_populates_auto_collected_metadata(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
 
@@ -1055,9 +1055,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_includes_git_context_in_metadata_when_provided(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::Manual, [
             'branch' => 'feature/test',
@@ -1072,9 +1072,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_excludes_git_context_from_metadata_when_empty(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::Manual, []);
 
@@ -1086,9 +1086,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_excludes_git_context_when_values_are_empty_strings(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::Manual, [
             'branch' => '',
@@ -1103,9 +1103,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function metadata_appears_in_json_output(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::Manual, [
             'branch' => 'main',
@@ -1125,9 +1125,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function metadata_appears_in_api_payload(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::CiCd, [
             'branch' => 'develop',
@@ -1152,9 +1152,9 @@ class ReporterTest extends TestCase
             'staging-preview' => 'staging',
         ]]);
 
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
 
@@ -1168,9 +1168,9 @@ class ReporterTest extends TestCase
         config(['app.env' => 'staging']);
         config(['shieldci.environment_mapping' => []]);
 
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
 
@@ -1183,9 +1183,9 @@ class ReporterTest extends TestCase
     {
         config(['app.env' => null]);
 
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results);
 
@@ -1196,9 +1196,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_includes_ci_provider_in_metadata_when_provided(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::CiCd, [
             'branch' => 'main',
@@ -1213,9 +1213,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_excludes_ci_provider_from_metadata_when_not_in_context(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::Manual, [
             'branch' => 'main',
@@ -1229,9 +1229,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function ci_provider_appears_in_json_output(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::CiCd, [
             'ci_provider' => 'gitlab_ci',
@@ -1247,9 +1247,9 @@ class ReporterTest extends TestCase
     #[Test]
     public function ci_provider_appears_in_api_payload(): void
     {
-        $results = collect([
+        $results = $this->resultsOf(
             AnalysisResult::passed('analyzer-1', 'Passed'),
-        ]);
+        );
 
         $report = $this->reporter->generate($results, TriggerSource::CiCd, [
             'branch' => 'develop',
@@ -1268,7 +1268,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_includes_pr_number_in_metadata_when_provided(): void
     {
-        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed'));
 
         $report = $this->reporter->generate($results, TriggerSource::Manual, [
             'pr_number' => '42',
@@ -1281,7 +1281,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_includes_repository_in_metadata_when_provided(): void
     {
-        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed'));
 
         $report = $this->reporter->generate($results, TriggerSource::Manual, [
             'repository' => 'owner/repo',
@@ -1294,7 +1294,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_includes_base_branch_in_metadata_when_provided(): void
     {
-        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed'));
 
         $report = $this->reporter->generate($results, TriggerSource::Manual, [
             'base_branch' => 'main',
@@ -1307,7 +1307,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_excludes_pr_fields_from_metadata_when_not_in_context(): void
     {
-        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed'));
 
         $report = $this->reporter->generate($results, TriggerSource::Manual, []);
 
@@ -1320,7 +1320,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function pr_fields_appear_in_json_output(): void
     {
-        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed'));
 
         $report = $this->reporter->generate($results, TriggerSource::Manual, [
             'pr_number' => '7',
@@ -1339,7 +1339,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function pr_fields_appear_in_api_payload(): void
     {
-        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed'));
 
         $report = $this->reporter->generate($results, TriggerSource::CiCd, [
             'pr_number' => '15',
@@ -1596,7 +1596,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function it_includes_configuration_in_generated_report(): void
     {
-        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed'));
 
         $report = $this->reporter->generate($results);
 
@@ -1635,7 +1635,7 @@ class ReporterTest extends TestCase
             'shieldci.fail_threshold' => null,
         ]);
 
-        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed'));
         $report = $this->reporter->generate($results);
         $payload = $this->reporter->toApi($report);
 
@@ -1661,7 +1661,7 @@ class ReporterTest extends TestCase
     #[Test]
     public function json_output_includes_configuration(): void
     {
-        $results = collect([AnalysisResult::passed('analyzer-1', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed'));
         $report = $this->reporter->generate($results);
 
         $decoded = json_decode($this->reporter->toJson($report), true);

--- a/tests/Unit/ValueObjects/AnalysisReportTest.php
+++ b/tests/Unit/ValueObjects/AnalysisReportTest.php
@@ -532,7 +532,7 @@ class AnalysisReportTest extends TestCase
             projectId: 'test-project-id',
             laravelVersion: app()->version(),
             packageVersion: '1.0.0',
-            results: collect([AnalysisResult::passed('analyzer-1', 'Passed')]),
+            results: $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed')),
             totalExecutionTime: 1.0,
             analyzedAt: new DateTimeImmutable,
             suppressedIssues: [
@@ -582,7 +582,7 @@ class AnalysisReportTest extends TestCase
             projectId: 'test-project-id',
             laravelVersion: app()->version(),
             packageVersion: '1.0.0',
-            results: collect([AnalysisResult::passed('analyzer-1', 'Passed')]),
+            results: $this->resultsOf(AnalysisResult::passed('analyzer-1', 'Passed')),
             totalExecutionTime: 1.0,
             analyzedAt: new DateTimeImmutable,
             suppressedIssues: [
@@ -610,7 +610,7 @@ class AnalysisReportTest extends TestCase
             recommendation: 'Use prepared statements',
         );
 
-        $results = collect([AnalysisResult::passed('xss-detection', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('xss-detection', 'Passed'));
         $report = new AnalysisReport(
             projectId: 'test-project-id',
             laravelVersion: app()->version(),
@@ -640,7 +640,7 @@ class AnalysisReportTest extends TestCase
     #[Test]
     public function to_array_includes_empty_suppressed_issues_when_none_for_result(): void
     {
-        $results = collect([AnalysisResult::passed('xss-detection', 'Passed')]);
+        $results = $this->resultsOf(AnalysisResult::passed('xss-detection', 'Passed'));
         $report = $this->createReport($results);
 
         $arr = $report->toArray();


### PR DESCRIPTION
First of a stacked series for #284.

CI pinned phpstan `^1.10` / larastan `^2.0` while `composer.lock` is gitignored, so a fresh checkout ran 2.x/3.x and CI ran 1.x/2.x against the same level-9 config. The phpstan job has no matrix, so the pin only ever forced a downgrade — deleting it lets `composer update` resolve from `composer.json`, and the drift cannot recur when the constraint next widens.

Larastan and phpstan-mockery were never loaded for self-analysis; this wires both into `phpstan.neon`, flips `reportUnmatchedIgnoredErrors` to `true`, and removes the 21 now-dead ignore patterns (11 hand-written Mockery ones the extension replaces) plus 338 dead `@phpstan-ignore-next-line` comments. phpstan-mockery is ranged `^1.1|^2.0` so Laravel 9/10 on PHP 8.1 can fall back to the 1.x line.

Test-side fallout from the now-active extensions: a `TestCase::resultsOf()` helper for the invariant `Collection<int, ResultInterface>` generic, one stray `env()` dropped, and the config fixture excluded from the env-outside-config rule.

No `src/` changes — `src/` still reports 202 level-9 errors behind the remaining broad patterns, dismantled by identifier in follow-up PRs.