### PR TITLE
refactor: type array shapes to satisfy missingType.iterableValue

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -39,13 +39,6 @@ parameters:
         # AstParser has extended methods beyond ParserInterface
         - '#Call to an undefined method ShieldCI\\AnalyzersCore\\Contracts\\ParserInterface::findClasses\(\)#'
 
-        # Allow untyped arrays in analyzer private helper methods - these are internal implementation
-        - '#has parameter \$issues with no value type specified in iterable type array#'
-        - '#has parameter \$lines with no value type specified in iterable type array#'
-        - '#has parameter \$results with no value type specified in iterable type array#'
-        - '#return type has no value type specified in iterable type array#'
-        - '#Property .* type has no value type specified in iterable type array#'
-
         # PHPParser node property access (false positives)
         - '#Access to an undefined property PhpParser\\Node\\Arg\|PhpParser\\Node\\VariadicPlaceholder::\$value#'
 
@@ -67,11 +60,6 @@ parameters:
 
         # Collection return types (generic type specifications not needed)
         - '#return type with generic class Illuminate\\Support\\Collection does not specify its types#'
-
-        # Private helper methods with untyped arrays (internal implementation details)
-        - '#has parameter \$packages with no value type specified in iterable type array#'
-        - '#has parameter \$metadata with no value type specified in iterable type array#'
-        - '#has parameter \$ast with no value type specified in iterable type array#'
 
         # Test file specific ignores - artisan command testing returns int|PendingCommand
         - '#Cannot call method (assertSuccessful|assertFailed|expectsOutput|expectsOutputToContain)\(\) on Illuminate\\Testing\\PendingCommand\|int#'

--- a/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
+++ b/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
@@ -96,6 +96,7 @@ class ChunkMissingAnalyzer extends AbstractFileAnalyzer
 
 class ChunkMissingVisitor extends NodeVisitorAbstract
 {
+    /** @var array<int, array{message: string, line: int, severity: Severity, recommendation: string, code: string|null}> */
     private array $issues = [];
 
     /** @var array<string, Node\Expr> Track variable assignments */
@@ -367,6 +368,9 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
         return $value instanceof Node\Scalar\String_ ? $value->value : null;
     }
 
+    /**
+     * @return list<string>
+     */
     private function getMethodChain(Node\Expr $expr): array
     {
         $chain = [];
@@ -404,6 +408,9 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
         return $printer->prettyPrintExpr($expr);
     }
 
+    /**
+     * @return array<int, array{message: string, line: int, severity: Severity, recommendation: string, code: string|null}>
+     */
     public function getIssues(): array
     {
         return $this->issues;

--- a/src/Analyzers/BestPractices/ConfigOutsideConfigAnalyzer.php
+++ b/src/Analyzers/BestPractices/ConfigOutsideConfigAnalyzer.php
@@ -160,6 +160,7 @@ class ConfigOutsideConfigAnalyzer extends AbstractFileAnalyzer
 
 class ConfigHardcodeVisitor extends NodeVisitorAbstract
 {
+    /** @var array<int, array{message: string, line: int, severity: Severity, recommendation: string, code: string|null}> */
     private array $issues = [];
 
     /** @var int Minimum length for API key detection */
@@ -504,6 +505,9 @@ class ConfigHardcodeVisitor extends NodeVisitorAbstract
         return false;
     }
 
+    /**
+     * @return array<int, array{message: string, line: int, severity: Severity, recommendation: string, code: string|null}>
+     */
     public function getIssues(): array
     {
         return $this->issues;

--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -110,6 +110,9 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
         );
     }
 
+    /**
+     * @return list<string>
+     */
     private function getBladeFiles(): array
     {
         $files = [];

--- a/src/Analyzers/BestPractices/SilentFailureAnalyzer.php
+++ b/src/Analyzers/BestPractices/SilentFailureAnalyzer.php
@@ -183,6 +183,7 @@ class SilentFailureAnalyzer extends AbstractFileAnalyzer
 
 class SilentFailureVisitor extends NodeVisitorAbstract
 {
+    /** @var array<int, array{message: string, line: int, severity: Severity, recommendation: string, code: string|null}> */
     private array $issues = [];
 
     private ?string $currentClass = null;
@@ -1126,6 +1127,9 @@ class SilentFailureVisitor extends NodeVisitorAbstract
         return 'Error suppression operator (@) hides errors';
     }
 
+    /**
+     * @return array<int, array{message: string, line: int, severity: Severity, recommendation: string, code: string|null}>
+     */
     public function getIssues(): array
     {
         return $this->issues;

--- a/src/Analyzers/Performance/CacheDriverAnalyzer.php
+++ b/src/Analyzers/Performance/CacheDriverAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
 /**
@@ -137,6 +138,8 @@ class CacheDriverAnalyzer extends AbstractAnalyzer
     /**
      * Assess the 'null' cache driver.
      * The null driver disables caching completely.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function assessNullDriver(array &$issues, string $configFile, int $lineNumber, string $defaultStore, string $environment): void
     {
@@ -157,6 +160,8 @@ class CacheDriverAnalyzer extends AbstractAnalyzer
     /**
      * Assess the 'array' cache driver.
      * The array driver only caches within a single request.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function assessArrayDriver(array &$issues, string $configFile, int $lineNumber, string $defaultStore, string $environment): void
     {
@@ -177,6 +182,8 @@ class CacheDriverAnalyzer extends AbstractAnalyzer
     /**
      * Assess the 'file' cache driver.
      * The file driver is only suitable for single-server setups.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function assessFileDriver(array &$issues, string $configFile, int $lineNumber, string $defaultStore, string $environment): void
     {
@@ -197,6 +204,8 @@ class CacheDriverAnalyzer extends AbstractAnalyzer
     /**
      * Assess the 'database' cache driver.
      * The database driver works but has performance issues in production.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function assessDatabaseDriver(array &$issues, string $configFile, int $lineNumber, string $defaultStore, string $environment): void
     {
@@ -217,6 +226,8 @@ class CacheDriverAnalyzer extends AbstractAnalyzer
     /**
      * Assess other cache drivers (redis, memcached, dynamodb, etc.).
      * These are generally acceptable.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function assessOtherDriver(string $driver, array &$issues, string $configFile, int $lineNumber, string $defaultStore, string $environment): void
     {
@@ -229,11 +240,17 @@ class CacheDriverAnalyzer extends AbstractAnalyzer
         );
     }
 
+    /**
+     * @param  array<int, Issue>  &$issues
+     */
     private function assessPreferredDriver(string $driver, array &$issues, string $configFile, int $lineNumber, string $defaultStore, string $environment): void
     {
         // Redis/Memcached are ideal choices; no action needed.
     }
 
+    /**
+     * @param  array<int, Issue>  &$issues
+     */
     private function assessApcDriver(array &$issues, string $configFile, int $lineNumber, string $defaultStore, string $environment): void
     {
         if (! $this->isProductionOrStaging($environment)) {
@@ -249,6 +266,9 @@ class CacheDriverAnalyzer extends AbstractAnalyzer
         );
     }
 
+    /**
+     * @param  array<int, Issue>  &$issues
+     */
     private function assessDynamoDbDriver(array &$issues, string $configFile, int $lineNumber, string $defaultStore, string $environment): void
     {
         $table = $this->config->get("cache.stores.{$defaultStore}.table");
@@ -266,6 +286,9 @@ class CacheDriverAnalyzer extends AbstractAnalyzer
         }
     }
 
+    /**
+     * @param  array<int, Issue>  &$issues
+     */
     private function assessOctaneDriver(array &$issues, string $configFile, int $lineNumber, string $defaultStore, string $environment): void
     {
         if ($this->hasOctaneSupport()) {

--- a/src/Analyzers/Performance/EnvCallAnalyzer.php
+++ b/src/Analyzers/Performance/EnvCallAnalyzer.php
@@ -226,11 +226,9 @@ class EnvCallAnalyzer extends AbstractFileAnalyzer
     /**
      * Find Env::get() static calls in AST.
      *
-     * @param  array<Node>  $ast
-     * @return array<int, StaticCall>
-     */
-    /**
+     * @param  array<int, Node>  $ast
      * @param  array<int, string>  $envClasses
+     * @return array<int, StaticCall>
      */
     private function findEnvStaticCallsInAst(array $ast, array $envClasses): array
     {
@@ -299,8 +297,7 @@ class EnvCallAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if file should be excluded for env() detection.
-     */
-    /**
+     *
      * @param  array<int, string>|null  $excludePaths
      */
     protected function shouldExcludeEnvFile(string $filePath, ?array $excludePaths = null): bool

--- a/src/Analyzers/Performance/MinificationAnalyzer.php
+++ b/src/Analyzers/Performance/MinificationAnalyzer.php
@@ -10,6 +10,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
@@ -176,6 +177,9 @@ class MinificationAnalyzer extends AbstractFileAnalyzer
         );
     }
 
+    /**
+     * @param  array<int, Issue>  &$issues
+     */
     private function checkStandaloneAssets(string $publicPath, array &$issues): void
     {
         $unminifiedFiles = [];
@@ -223,6 +227,9 @@ class MinificationAnalyzer extends AbstractFileAnalyzer
         }
     }
 
+    /**
+     * @param  array<int, Issue>  &$issues
+     */
     private function checkMixAssets(string $publicPath, array &$issues): void
     {
         $manifestPath = $this->joinPaths($publicPath, 'mix-manifest.json');
@@ -302,6 +309,9 @@ class MinificationAnalyzer extends AbstractFileAnalyzer
         }
     }
 
+    /**
+     * @param  array<int, Issue>  &$issues
+     */
     private function checkViteAssets(string $buildPath, array &$issues): void
     {
         if (! is_dir($buildPath)) {

--- a/src/Analyzers/Performance/QueueDriverAnalyzer.php
+++ b/src/Analyzers/Performance/QueueDriverAnalyzer.php
@@ -142,6 +142,8 @@ class QueueDriverAnalyzer extends AbstractAnalyzer
     /**
      * Assess the 'null' queue driver.
      * The null driver silently discards all queued jobs, which is dangerous.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function assessNullDriver(string $driver, array &$issues, string $configFile, string $defaultConnection): void
     {
@@ -164,6 +166,8 @@ class QueueDriverAnalyzer extends AbstractAnalyzer
     /**
      * Assess the 'sync' queue driver.
      * The sync driver processes jobs immediately, blocking the request.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function assessSyncDriver(string $driver, array &$issues, string $configFile, string $defaultConnection): void
     {
@@ -207,6 +211,8 @@ class QueueDriverAnalyzer extends AbstractAnalyzer
     /**
      * Assess the 'database' queue driver.
      * The database driver works but has performance issues in production.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function assessDatabaseDriver(string $driver, array &$issues, string $configFile, string $defaultConnection): void
     {

--- a/src/Analyzers/Security/CookieSecurityAnalyzer.php
+++ b/src/Analyzers/Security/CookieSecurityAnalyzer.php
@@ -14,6 +14,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\Concerns\AnalyzesMiddleware;
 use ShieldCI\Concerns\InspectsCode;
 
@@ -80,6 +81,8 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check session configuration file using AST parsing.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkSessionConfig(array &$issues): void
     {
@@ -172,6 +175,8 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check for EncryptCookies middleware.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkEncryptCookiesMiddleware(array &$issues): void
     {
@@ -247,6 +252,8 @@ class CookieSecurityAnalyzer extends AbstractFileAnalyzer
      * This method is conservative - it only uses runtime checks when we're confident
      * the app is fully bootstrapped with the actual application code. In test scenarios
      * or when the app path doesn't match, it falls back to file-based checks.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkRuntimeMiddleware(array &$issues): bool
     {

--- a/src/Analyzers/Security/CsrfAnalyzer.php
+++ b/src/Analyzers/Security/CsrfAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\Support\BootstrapRouteParser;
 
 /**
@@ -122,6 +123,8 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
      * - <input name="_token" ... /> - Manual token input
      *
      * Scans until </form> is found (no hardcoded line limit).
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkBladeFormsForCsrf(string $file, array &$issues): void
     {
@@ -187,6 +190,8 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
      *
      * Scans until natural boundary (closing parenthesis + semicolon) instead of hardcoded line limit.
      * Uses parenthesis depth tracking to find the end of AJAX call.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkAjaxRequestsForCsrf(string $file, array &$issues): void
     {
@@ -272,6 +277,8 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
      * - $.ajax({method: 'POST'}) - checks for method property
      *
      * GET requests (fetch(url) without method, or method: 'GET') are not flagged.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkJavaScriptAjaxForCsrf(string $file, array &$issues): void
     {
@@ -339,6 +346,8 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
     /**
      * Check CSRF middleware for overly broad exceptions.
      * Supports both VerifyCsrfToken (Laravel 10) and ValidateCsrfToken (Laravel 11+).
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkCsrfMiddlewareExceptions(array &$issues): void
     {
@@ -467,6 +476,8 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
     /**
      * Check if CSRF middleware is registered in Kernel.php.
      * Supports both VerifyCsrfToken (Laravel 10) and ValidateCsrfToken (Laravel 11+).
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkCsrfMiddlewareRegistration(array &$issues): void
     {
@@ -541,6 +552,8 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
      * Users can:
      * 1. Manually manage middleware with withMiddleware() - check if CSRF is disabled
      * 2. Exclude URIs using validateCsrfTokens() method - check for overly broad patterns
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkBootstrapApp(string $file, array &$issues): void
     {
@@ -564,6 +577,9 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if CSRF protection is explicitly disabled in bootstrap/app.php.
+     *
+     * @param  array<int, Issue>  &$issues
+     * @param  array<int, string>  $lines
      */
     private function checkCsrfDisabledInBootstrap(array $lines, string $file, array &$issues): void
     {
@@ -684,6 +700,9 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check for overly broad CSRF exception patterns in validateCsrfTokens() calls.
+     *
+     * @param  array<int, Issue>  &$issues
+     * @param  array<int, string>  $lines
      */
     private function checkBootstrapCsrfExceptions(array $lines, string $file, array &$issues): void
     {
@@ -768,6 +787,7 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
      *
      * @param  array<string>  $webProtectedFiles  Files covered by 'web' middleware via external registration
      * @param  array<string>  $apiRegisteredFiles  Files registered under 'api' middleware via external registration
+     * @param  array<int, Issue>  $issues
      */
     private function checkRoutesForCsrfMiddleware(
         string $file,
@@ -905,6 +925,8 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Get all Blade template files.
+     *
+     * @return list<string>
      */
     private function getBladeFiles(): array
     {
@@ -921,6 +943,8 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Get all JavaScript files.
+     *
+     * @return list<string>
      */
     private function getJavaScriptFiles(): array
     {
@@ -937,6 +961,8 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Get route files.
+     *
+     * @return array<int, string>
      */
     private function getRouteFiles(): array
     {

--- a/src/Analyzers/Security/DebugModeAnalyzer.php
+++ b/src/Analyzers/Security/DebugModeAnalyzer.php
@@ -20,6 +20,7 @@ use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Concerns\ClassifiesFiles;
 
@@ -39,6 +40,7 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
 
     private const HIGH_SEVERITY_FUNCTIONS = ['dd', 'dump', 'var_dump', 'print_r'];
 
+    /** @var list<string> */
     private array $debugFunctions = [
         'dd',
         'dump',
@@ -106,6 +108,8 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check .env files for debug mode enabled.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkEnvFiles(array &$issues): void
     {
@@ -197,6 +201,8 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check config files for debug settings.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkConfigFiles(array &$issues): void
     {
@@ -236,6 +242,8 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check for debug functions and exit/die in code using AST parsing.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkDebugFunctions(array &$issues): void
     {
@@ -338,6 +346,8 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check an error_reporting() call for verbose settings (E_ALL or -1).
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkErrorReportingCall(FuncCall $funcCall, string $file, array &$issues): void
     {
@@ -381,6 +391,8 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check an ini_set() call for display_errors or display_startup_errors with truthy values.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkIniSetCall(FuncCall $funcCall, string $file, array &$issues): void
     {
@@ -438,6 +450,8 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check for debug packages that shouldn't be in production.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkDebugPackages(array &$issues): void
     {

--- a/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
+++ b/src/Analyzers/Security/EnvFileSecurityAnalyzer.php
@@ -10,6 +10,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
@@ -29,6 +30,7 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
     public static bool $runInCI = false;
 
+    /** @var list<string> */
     private array $sensitiveKeys = [
         'APP_KEY',
         'DB_PASSWORD',
@@ -46,6 +48,7 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
         'OAUTH_CLIENT_SECRET',
     ];
 
+    /** @var list<string> */
     private array $placeholderKeywords = [
         'null', '""', "''", 'your-', 'change-', 'example',
         // Stripe test key prefixes (test mode only, can't process real payments)
@@ -137,6 +140,8 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check for .env file in public directory.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkPublicEnvFile(array &$issues): void
     {
@@ -162,6 +167,8 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check .env.example for sensitive data.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkEnvExample(array &$issues): void
     {
@@ -248,6 +255,8 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if .env is properly excluded in .gitignore.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkGitignore(array &$issues): void
     {
@@ -287,6 +296,8 @@ class EnvFileSecurityAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if .env file was committed to git.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkIfEnvCommitted(array &$issues): void
     {

--- a/src/Analyzers/Security/EnvHttpAccessibilityAnalyzer.php
+++ b/src/Analyzers/Security/EnvHttpAccessibilityAnalyzer.php
@@ -45,6 +45,8 @@ class EnvHttpAccessibilityAnalyzer extends AbstractAnalyzer
 
     /**
      * Sensitive keys that indicate .env file content.
+     *
+     * @var list<string>
      */
     private array $envIndicators = [
         'APP_NAME=',

--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -12,6 +12,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Support\EloquentModelDetector;
 use ShieldCI\Support\EloquentModelHelper;
@@ -145,6 +146,8 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check fillable property for foreign keys.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkFillableProperty(string $file, Node\Stmt\Class_ $class, array &$issues): void
     {
@@ -195,6 +198,8 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
      *
      * Reuses the same curated-pattern detection (checkField) as the property path so an
      * attribute-based model is analyzed identically to a property-based one.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkFillableAttribute(string $file, Node\Stmt\Class_ $class, array &$issues): void
     {
@@ -231,6 +236,8 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check a single field for foreign key patterns.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkField(string $file, int $itemLine, string $modelName, string $fieldName, array &$issues): void
     {

--- a/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
@@ -10,6 +10,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
@@ -175,6 +176,8 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Run audit command (npm or yarn) with timeout protection.
+     *
+     * @return array<array-key, mixed>|null
      */
     private function runAuditCommand(string $basePath, string $tool): ?array
     {
@@ -269,6 +272,8 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Parse npm output (JSON or plain text fallback).
+     *
+     * @return array<array-key, mixed>|null
      */
     private function parseNpmOutput(string $output): ?array
     {
@@ -285,6 +290,8 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Parse yarn output (newline-delimited JSON).
+     *
+     * @return array<array-key, mixed>|null
      */
     private function parseYarnOutput(string $output): ?array
     {
@@ -313,6 +320,8 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Parse plain text npm audit output as fallback.
+     *
+     * @return array<array-key, mixed>|null
      */
     private function parseNpmPlainTextAudit(string $output): ?array
     {
@@ -335,6 +344,9 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Parse npm audit results.
+     *
+     * @param  array<int, Issue>  &$issues
+     * @param  array<array-key, mixed>  $results
      */
     private function parseNpmAuditResults(array $results, array &$issues, string $packageLock): void
     {
@@ -415,6 +427,9 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Parse yarn audit results.
+     *
+     * @param  array<int, Issue>  &$issues
+     * @param  array<array-key, mixed>  $results
      */
     private function parseYarnAuditResults(array $results, array &$issues, string $yarnLock): void
     {
@@ -534,6 +549,8 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Create vulnerability issue from advisory data.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function createFrontendVulnerabilityIssue(string $package, mixed $advisory, array &$issues, string $lockFile): void
     {

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -15,6 +15,7 @@ use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Concerns\InspectsCode;
 
@@ -195,6 +196,8 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check middleware configuration for HSTS headers.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkMiddlewareConfiguration(array &$issues): void
     {
@@ -269,6 +272,8 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Validate HSTS configuration in middleware.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function validateHSTSConfiguration(string $file, string $content, array &$issues): void
     {
@@ -346,6 +351,8 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check session configuration for HTTPS using AST.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkSessionConfiguration(array &$issues): void
     {

--- a/src/Analyzers/Security/LicenseAnalyzer.php
+++ b/src/Analyzers/Security/LicenseAnalyzer.php
@@ -10,6 +10,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 
 /**
@@ -23,12 +24,15 @@ use ShieldCI\AnalyzersCore\ValueObjects\Location;
  */
 class LicenseAnalyzer extends AbstractFileAnalyzer
 {
+    /** @var list<string> */
     private array $excludedPackages = [
         'shieldci/*',
     ];
 
     /**
      * Default whitelisted licenses for commercial/proprietary use.
+     *
+     * @var list<string>
      */
     private array $whitelistedLicenses = [
         'Apache-2.0',
@@ -50,6 +54,8 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Restrictive licenses that require scrutiny.
+     *
+     * @var list<string>
      */
     private array $restrictiveLicenses = [
         'GPL-2.0',
@@ -106,6 +112,8 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check licenses in composer.lock.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkComposerLicenses(string $composerLock, array &$issues): void
     {
@@ -156,6 +164,7 @@ class LicenseAnalyzer extends AbstractFileAnalyzer
      *
      * @param  array<int, mixed>  $packages
      * @param  array<string, mixed>  $config
+     * @param  array<int, Issue>  $issues
      */
     private function checkPackageLicenses(
         array $packages,

--- a/src/Analyzers/Security/LoginThrottlingAnalyzer.php
+++ b/src/Analyzers/Security/LoginThrottlingAnalyzer.php
@@ -12,6 +12,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\Concerns\DetectsLaravelVersion;
 use ShieldCI\Support\BootstrapRouteParser;
 
@@ -618,6 +619,8 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check route files for login routes without throttling.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkRouteFiles(array &$issues, bool $hasGlobalThrottling): void
     {
@@ -755,6 +758,8 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if a route has throttling in nearby lines or on the same line (before/after).
+     *
+     * @param  array<int, string>  $lines
      */
     private function checkRouteHasThrottling(array $lines, int $lineNumber): bool
     {
@@ -821,6 +826,8 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check authentication controllers for throttling logic.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkAuthControllers(array &$issues): void
     {
@@ -899,6 +906,8 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check Fortify/Breeze/Jetstream configuration for throttling.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkAuthenticationPackages(array &$issues): void
     {
@@ -937,6 +946,8 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check Fortify-specific throttling configuration.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkFortifyThrottling(array &$issues): void
     {
@@ -1033,6 +1044,8 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
      * NOTE: Both Breeze and Jetstream rely on Fortify for authentication by default,
      * and Fortify includes throttling out of the box. This method only flags issues
      * if the default throttling has been explicitly disabled or misconfigured.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkBreezeJetstreamThrottling(array &$issues, bool $hasBreeze, bool $hasJetstream): void
     {

--- a/src/Analyzers/Security/MassAssignmentAnalyzer.php
+++ b/src/Analyzers/Security/MassAssignmentAnalyzer.php
@@ -12,6 +12,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\Support\EloquentModelDetector;
 use ShieldCI\Support\EloquentModelHelper;
 
@@ -190,6 +191,8 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if model has proper mass assignment protection.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkModelProtection(string $file, Node\Stmt\Class_ $class, array &$issues): void
     {
@@ -255,6 +258,9 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check for dangerous Eloquent method calls with request data.
+     *
+     * @param  array<int, Node>  $ast
+     * @param  array<int, Issue>  &$issues
      */
     private function checkDangerousMethodCalls(string $file, array $ast, array &$issues): void
     {
@@ -438,6 +444,9 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check for dangerous query builder calls with request data.
+     *
+     * @param  array<int, Node>  $ast
+     * @param  array<int, Issue>  &$issues
      */
     private function checkQueryBuilderCalls(string $file, array $ast, array &$issues): void
     {
@@ -456,6 +465,9 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Find static method calls in AST.
+     *
+     * @param  array<int, Node>  $ast
+     * @return array<int, Node\Expr\StaticCall>
      */
     private function findStaticMethodCalls(array $ast, string $methodName): array
     {
@@ -648,6 +660,8 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if a call contains request data in its arguments.
+     *
+     * @param  array<int, Issue>  $issues
      */
     private function checkCallForRequestData(
         Node\Expr\MethodCall|Node\Expr\StaticCall $call,
@@ -1040,6 +1054,8 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if model has proper $hidden attributes for sensitive data.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkHiddenAttributes(string $file, Node\Stmt\Class_ $class, array &$issues): void
     {
@@ -1106,6 +1122,8 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
      * NOTE: This check is intentionally conservative to avoid false positives.
      * It only warns when there's evidence of actual mass assignment usage
      * with relationships in the codebase.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkRelationshipSecurity(string $file, Node\Stmt\Class_ $class, array &$issues): void
     {
@@ -1116,6 +1134,9 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check for dangerous relationship fill operations with request data.
+     *
+     * @param  array<int, Node>  $ast
+     * @param  array<int, Issue>  &$issues
      */
     private function checkRelationshipOperations(string $file, array $ast, array &$issues): void
     {
@@ -1160,6 +1181,9 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
      * Check for nested mass assignment patterns.
      *
      * Detects patterns like: $request->input('user.profile.bio')
+     *
+     * @param  array<int, Node>  $ast
+     * @param  array<int, Issue>  &$issues
      */
     private function checkNestedMassAssignment(string $file, array $ast, array &$issues): void
     {

--- a/src/Analyzers/Security/SqlInjectionAnalyzer.php
+++ b/src/Analyzers/Security/SqlInjectionAnalyzer.php
@@ -34,6 +34,8 @@ class SqlInjectionAnalyzer extends AbstractFileAnalyzer
      * - checkInstance: Check instance calls like ->method()
      * - severity: Severity level (Critical for full query control, High for fragments)
      * - recommendation: Custom recommendation message (optional)
+     *
+     * @var array<string, array{alwaysFlag: bool, checkStatic: bool, checkInstance: bool, strictConcatenation: bool, severity: Severity, recommendation: string}>
      */
     private array $dbMethods = [
         'raw' => [
@@ -121,6 +123,8 @@ class SqlInjectionAnalyzer extends AbstractFileAnalyzer
     /**
      * Native MySQLi functions that execute queries (not connection, prepare, or fetch).
      * Only these can have SQL injection vulnerabilities through concatenation.
+     *
+     * @var list<string>
      */
     private array $nativeMysqliFunctions = [
         'mysqli_query',       // Executes a query (most common)
@@ -131,6 +135,8 @@ class SqlInjectionAnalyzer extends AbstractFileAnalyzer
     /**
      * Native PostgreSQL functions that execute queries.
      * Only these can have SQL injection vulnerabilities through concatenation.
+     *
+     * @var list<string>
      */
     private array $nativePostgresFunctions = [
         'pg_query',       // Executes a query

--- a/src/Analyzers/Security/StableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/StableDependencyAnalyzer.php
@@ -10,6 +10,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Support\Composer;
 use Throwable;
@@ -136,6 +137,8 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check composer.json configuration.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkComposerConfiguration(string $composerJson, array &$issues): void
     {
@@ -267,6 +270,9 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
      * Severity is risk-based:
      * - require-dev + stable minimum-stability: Low (isolated to dev environment)
      * - require OR non-stable minimum-stability: Medium (can affect production)
+     *
+     * @param  array<array-key, mixed>  $packages
+     * @param  array<int, Issue>  &$issues
      */
     private function checkVersionConstraints(array $packages, string $section, array &$issues, string $composerJson, string $minimumStability): void
     {
@@ -318,6 +324,8 @@ class StableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check composer.lock for unstable installed versions.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkComposerLock(string $composerLock, array &$issues): void
     {

--- a/src/Analyzers/Security/UnguardedModelsAnalyzer.php
+++ b/src/Analyzers/Security/UnguardedModelsAnalyzer.php
@@ -12,6 +12,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 
 /**
  * Detects Model::unguard() calls that disable mass assignment protection.
@@ -68,6 +69,8 @@ class UnguardedModelsAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check a file for unguard() usage.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkFileForUnguard(string $file, string $relativePath, array &$issues): void
     {
@@ -189,6 +192,10 @@ class UnguardedModelsAnalyzer extends AbstractFileAnalyzer
         return str_starts_with($normalized, 'vendor/') || str_contains($normalized, '/vendor/');
     }
 
+    /**
+     * @param  array<int, Node>  $ast
+     * @param  array<int, Issue>  &$issues
+     */
     private function evaluateStaticCalls(array $ast, string $file, string $relativePath, array &$issues): void
     {
         /** @var array<Node\Expr\StaticCall> $staticCalls */
@@ -337,6 +344,7 @@ class UnguardedModelsAnalyzer extends AbstractFileAnalyzer
     /**
      * Build a map of all method/function scopes in the AST.
      *
+     * @param  array<int, Node>  $ast
      * @return array<Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Expr\Closure>
      */
     private function buildMethodScopeMap(array $ast): array

--- a/src/Analyzers/Security/VulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/VulnerableDependencyAnalyzer.php
@@ -10,6 +10,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Support\SecurityAdvisories\AdvisoryAnalyzerInterface;
 use ShieldCI\Support\SecurityAdvisories\AdvisoryFetcherInterface;
@@ -171,6 +172,8 @@ class VulnerableDependencyAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check for abandoned packages in composer.lock.
+     *
+     * @param  array<int, Issue>  &$issues
      */
     private function checkAbandonedPackages(array &$issues, string $composerLock): void
     {

--- a/src/ShieldCIServiceProvider.php
+++ b/src/ShieldCIServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Config\Repository;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use Psr\Log\LoggerInterface;
+use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\FileParser;
@@ -129,6 +130,8 @@ class ShieldCIServiceProvider extends ServiceProvider
 
     /**
      * Discover all analyzer classes.
+     *
+     * @return list<class-string<AnalyzerInterface>>
      */
     protected function discoverAnalyzers(): array
     {
@@ -153,7 +156,7 @@ class ShieldCIServiceProvider extends ServiceProvider
             foreach ($files as $file) {
                 $className = $this->getClassFromFile($file);
 
-                if ($className && class_exists($className)) {
+                if ($className && class_exists($className) && is_subclass_of($className, AnalyzerInterface::class)) {
                     $analyzers[] = $className;
                 }
             }

--- a/src/Support/PathFilter.php
+++ b/src/Support/PathFilter.php
@@ -93,6 +93,8 @@ class PathFilter
 
     /**
      * Get paths to analyze.
+     *
+     * @return array<string>
      */
     public function getAnalyzePaths(): array
     {
@@ -101,6 +103,8 @@ class PathFilter
 
     /**
      * Get excluded paths.
+     *
+     * @return array<string>
      */
     public function getExcludedPaths(): array
     {

--- a/src/Support/SecurityAdvisories/HttpAdvisoryFetcher.php
+++ b/src/Support/SecurityAdvisories/HttpAdvisoryFetcher.php
@@ -121,6 +121,7 @@ class HttpAdvisoryFetcher implements AdvisoryFetcherInterface
 
     /**
      * @param  array<string, mixed>  $vuln
+     * @return array<string, mixed>
      */
     private function formatVulnerability(array $vuln, string $version): array
     {

--- a/src/ValueObjects/AnalysisReport.php
+++ b/src/ValueObjects/AnalysisReport.php
@@ -144,6 +144,9 @@ final class AnalysisReport
         return $counts;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function summary(): array
     {
         return [
@@ -160,6 +163,9 @@ final class AnalysisReport
         ];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [

--- a/tests/Unit/Commands/BaselineCommandTest.php
+++ b/tests/Unit/Commands/BaselineCommandTest.php
@@ -449,6 +449,8 @@ class BaselineCommandTest extends TestCase
 
     /**
      * Register a mock AnalyzerManager with the given issues.
+     *
+     * @param  array<int, Issue>  $issues
      */
     private function registerMockAnalyzerManager(array $issues): void
     {

--- a/tests/Unit/Concerns/AnalyzesMiddlewareTest.php
+++ b/tests/Unit/Concerns/AnalyzesMiddlewareTest.php
@@ -463,6 +463,7 @@ class AnalyzesMiddlewareTest extends TestCase
                 return $this->appUsesGroupMiddleware($class);
             }
 
+            /** @return array<int, string> */
             public function publicGetGroupsContainingSession(): array
             {
                 return $this->getGroupsContainingSession();
@@ -699,6 +700,7 @@ class AnalyzesMiddlewareTest extends TestCase
                 private array $fixedGlobal,
             ) {}
 
+            /** @return array<int, string> */
             protected function getGlobalMiddleware(): array
             {
                 return $this->fixedGlobal;
@@ -733,6 +735,7 @@ class AnalyzesMiddlewareTest extends TestCase
                 protected $kernel,
             ) {}
 
+            /** @return array<int, string> */
             public function publicGetGlobalMiddleware(): array
             {
                 return $this->getGlobalMiddleware();
@@ -763,6 +766,7 @@ class AnalyzesMiddlewareTest extends TestCase
                 return $this->appUsesGroupMiddleware($class);
             }
 
+            /** @return array<int, string> */
             public function publicGetMiddleware(Route $route): array
             {
                 return $this->getMiddleware($route);
@@ -778,6 +782,7 @@ class AnalyzesMiddlewareTest extends TestCase
                 return $this->routeUsesBasenameMiddleware($route, $class);
             }
 
+            /** @return array<int, string> */
             public function publicGetBasenameMiddlewareClasses(Route $route): array
             {
                 return $this->getBasenameMiddlewareClasses($route);
@@ -798,6 +803,7 @@ class AnalyzesMiddlewareTest extends TestCase
                 return $this->isStartSessionMiddleware($middleware);
             }
 
+            /** @return array<int, string> */
             public function publicGetGroupsContainingSession(): array
             {
                 return $this->getGroupsContainingSession();

--- a/tests/Unit/Concerns/ParsesPHPStanAnalysisTest.php
+++ b/tests/Unit/Concerns/ParsesPHPStanAnalysisTest.php
@@ -167,16 +167,25 @@ class ParsesPHPStanAnalysisTest extends TestCase
         {
             use ParsesPHPStanAnalysis;
 
+            /**
+             * @param  array<int, Issue>  &$issues
+             */
             public function publicParsePHPStanAnalysis(PHPStan $phpStan, string|array $search, array &$issues): void
             {
                 $this->parsePHPStanAnalysis($phpStan, $search, $issues);
             }
 
+            /**
+             * @param  array<int, Issue>  &$issues
+             */
             public function publicMatchPHPStanAnalysis(PHPStan $phpStan, string|array $pattern, array &$issues): void
             {
                 $this->matchPHPStanAnalysis($phpStan, $pattern, $issues);
             }
 
+            /**
+             * @param  array<int, Issue>  &$issues
+             */
             public function publicPregMatchPHPStanAnalysis(PHPStan $phpStan, string $pattern, array &$issues): void
             {
                 $this->pregMatchPHPStanAnalysis($phpStan, $pattern, $issues);
@@ -187,6 +196,9 @@ class ParsesPHPStanAnalysisTest extends TestCase
                 return $this->getRecommendationFromMessage($message);
             }
 
+            /**
+             * @param  array<string, mixed>  $metadata
+             */
             protected function createIssueWithSnippet(
                 string $message,
                 string $filePath,

--- a/tests/Unit/ValueObjects/AnalysisReportTest.php
+++ b/tests/Unit/ValueObjects/AnalysisReportTest.php
@@ -627,6 +627,7 @@ class AnalysisReportTest extends TestCase
 
         $arr = $report->toArray();
         $resultArr = $arr['results'][0];
+        $this->assertIsArray($resultArr);
 
         $this->assertArrayHasKey('suppressed_issues', $resultArr);
         $this->assertCount(1, $resultArr['suppressed_issues']);
@@ -645,6 +646,7 @@ class AnalysisReportTest extends TestCase
 
         $arr = $report->toArray();
         $resultArr = $arr['results'][0];
+        $this->assertIsArray($resultArr);
 
         $this->assertArrayHasKey('suppressed_issues', $resultArr);
         $this->assertSame([], $resultArr['suppressed_issues']);


### PR DESCRIPTION
Second in the #284 stack — **base is #285**, not master, so this diff shows only the type work.

Adds value types to array params, returns, and properties across `src/`, then removes the eight broad ignore patterns that suppressed every untyped-array diagnostic repo-wide (the `$issues`/`$lines`/`$results`/`$packages`/`$metadata`/`$ast` param patterns plus the codebase-wide `return type has no value type` and `Property type has no value type`).

Most fixes are mechanical (`array<int, Issue>`, `list<string>`, `array<int, Node>`). Two needed precise shape arrays so their values stop leaking `mixed` into call sites: `SqlInjectionAnalyzer::$dbMethods` and the three `NodeVisitor` `$issues` buckets (which hold `array{message, line, severity, recommendation, code}`, not `Issue` objects).

`discoverAnalyzers()` now filters on `is_subclass_of(AnalyzerInterface)`, making its return provably `list<class-string<AnalyzerInterface>>` to match the `AnalyzerManager` constructor — also stops any non-analyzer `*Analyzer.php` from being registered. Discovery still yields all 73.

No behaviour change beyond that filter. phpstan green (level 9, larastan + `reportUnmatchedIgnoredErrors: true`), pint clean, 4401 tests pass.