### PR TITLE
refactor: narrow mixed config/JSON values, add ReadsConfigArrays trait

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -42,24 +42,17 @@ parameters:
         # PHPParser node property access (false positives)
         - '#Access to an undefined property PhpParser\\Node\\Arg\|PhpParser\\Node\\VariadicPlaceholder::\$value#'
 
-        # Shell command outputs and JSON decode can be false or mixed
-        - '#Cannot access offset .* on mixed#'
-        - '#Argument of an invalid type mixed supplied for foreach#'
-
-        # Config and Laravel app operations return mixed
-        - '#Cannot call method (getAnalyzerId|getMessage|getIssues|version|error)\(\) on mixed#'
-        - '#Property .* does not accept mixed#'
-        - '#Part .* \(mixed\) of encapsed string cannot be cast to string#'
-
-        # JSON/array decode and file operations return mixed
-        - '#Method .* should return string but returns string\|false#'
-
-        # Constructor parameter issues with mixed config data
-        - '#Argument of an invalid type .*\|false supplied for foreach#'
-        - '#Parameter .* of class .* constructor expects .*, mixed given#'
-
         # Collection return types (generic type specifications not needed)
         - '#return type with generic class Illuminate\\Support\\Collection does not specify its types#'
+
+        # Test files: assertions reach into mixed analyzer output (result metadata, decoded
+        # JSON). Scoped to tests and slated for removal once the test suite narrows these.
+        -
+            message: '#Cannot access offset .* on mixed#'
+            path: tests
+        -
+            message: '#Part .* \(mixed\) of encapsed string cannot be cast to string#'
+            path: tests
 
         # Test file specific ignores - artisan command testing returns int|PendingCommand
         - '#Cannot call method (assertSuccessful|assertFailed|expectsOutput|expectsOutputToContain)\(\) on Illuminate\\Testing\\PendingCommand\|int#'

--- a/src/Analyzers/BestPractices/FatModelAnalyzer.php
+++ b/src/Analyzers/BestPractices/FatModelAnalyzer.php
@@ -15,6 +15,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Concerns\ReadsConfigArrays;
 use ShieldCI\Support\EloquentModelDetector;
 
 /**
@@ -27,6 +28,8 @@ use ShieldCI\Support\EloquentModelDetector;
  */
 class FatModelAnalyzer extends AbstractFileAnalyzer
 {
+    use ReadsConfigArrays;
+
     public const METHOD_THRESHOLD = 15;
 
     public const LOC_THRESHOLD = 300;
@@ -61,11 +64,10 @@ class FatModelAnalyzer extends AbstractFileAnalyzer
     {
         // Load configuration from config file (best-practices.fat-model)
         $analyzerConfig = $this->config->get('shieldci.analyzers.best-practices.fat-model', []);
-        $analyzerConfig = is_array($analyzerConfig) ? $analyzerConfig : [];
 
-        $this->methodThreshold = $analyzerConfig['method_threshold'] ?? self::METHOD_THRESHOLD;
-        $this->locThreshold = $analyzerConfig['loc_threshold'] ?? self::LOC_THRESHOLD;
-        $this->complexityThreshold = $analyzerConfig['complexity_threshold'] ?? self::COMPLEXITY_THRESHOLD;
+        $this->methodThreshold = $this->configInt($analyzerConfig, 'method_threshold', self::METHOD_THRESHOLD);
+        $this->locThreshold = $this->configInt($analyzerConfig, 'loc_threshold', self::LOC_THRESHOLD);
+        $this->complexityThreshold = $this->configInt($analyzerConfig, 'complexity_threshold', self::COMPLEXITY_THRESHOLD);
 
         $issues = [];
 

--- a/src/Analyzers/BestPractices/FrameworkOverrideAnalyzer.php
+++ b/src/Analyzers/BestPractices/FrameworkOverrideAnalyzer.php
@@ -15,12 +15,15 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Concerns\ReadsConfigArrays;
 
 /**
  * Detects overriding standard Laravel framework classes that should use extension points instead.
  */
 class FrameworkOverrideAnalyzer extends AbstractFileAnalyzer
 {
+    use ReadsConfigArrays;
+
     // Classes that should NEVER be extended (High severity)
     private const NEVER_EXTEND = [
         // Core Foundation
@@ -102,11 +105,10 @@ class FrameworkOverrideAnalyzer extends AbstractFileAnalyzer
     {
         // Load configuration from config file (best-practices.framework-override)
         $analyzerConfig = $this->config->get('shieldci.analyzers.best-practices.framework-override', []);
-        $analyzerConfig = is_array($analyzerConfig) ? $analyzerConfig : [];
 
-        $this->neverExtend = $analyzerConfig['never_extend'] ?? self::NEVER_EXTEND;
-        $this->rarelyExtend = $analyzerConfig['rarely_extend'] ?? self::RARELY_EXTEND;
-        $this->okToExtend = $analyzerConfig['ok_to_extend'] ?? self::OK_TO_EXTEND;
+        $this->neverExtend = $this->configStringList($analyzerConfig, 'never_extend', self::NEVER_EXTEND);
+        $this->rarelyExtend = $this->configStringList($analyzerConfig, 'rarely_extend', self::RARELY_EXTEND);
+        $this->okToExtend = $this->configStringList($analyzerConfig, 'ok_to_extend', self::OK_TO_EXTEND);
 
         $issues = [];
         $phpFiles = $this->getPhpFiles();

--- a/src/Analyzers/BestPractices/HardcodedStoragePathsAnalyzer.php
+++ b/src/Analyzers/BestPractices/HardcodedStoragePathsAnalyzer.php
@@ -15,12 +15,15 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Concerns\ReadsConfigArrays;
 
 /**
  * Detects hardcoded storage paths instead of Laravel helpers.
  */
 class HardcodedStoragePathsAnalyzer extends AbstractFileAnalyzer
 {
+    use ReadsConfigArrays;
+
     /** @var array<int, string> */
     private array $allowedPaths;
 
@@ -61,10 +64,9 @@ class HardcodedStoragePathsAnalyzer extends AbstractFileAnalyzer
     protected function runAnalysis(): ResultInterface
     {
         // Load configuration
-        $analyzerConfig = $this->config->get('shieldci.analyzers.best-practices.hardcoded-storage-paths', []);
-        $analyzerConfig = is_array($analyzerConfig) ? $analyzerConfig : [];
+        $analyzerConfig = $this->toStringKeyedArray($this->config->get('shieldci.analyzers.best-practices.hardcoded-storage-paths', []));
 
-        $this->allowedPaths = $analyzerConfig['allowed_paths'] ?? [];
+        $this->allowedPaths = $this->configStringList($analyzerConfig, 'allowed_paths', []);
         $additionalPatternsRaw = $analyzerConfig['additional_patterns'] ?? [];
         $additionalPatterns = [];
         if (is_array($additionalPatternsRaw)) {

--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -21,6 +21,7 @@ use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
+use ShieldCI\Concerns\ReadsConfigArrays;
 use ShieldCI\Support\BladeCompilerFactory;
 
 /**
@@ -36,6 +37,8 @@ use ShieldCI\Support\BladeCompilerFactory;
  */
 class LogicInBladeAnalyzer extends AbstractFileAnalyzer
 {
+    use ReadsConfigArrays;
+
     public const DEFAULT_MAX_PHP_BLOCK_LINES = 10;
 
     public const DEFAULT_MIN_ARITHMETIC_OPERATORS = 2;
@@ -73,11 +76,10 @@ class LogicInBladeAnalyzer extends AbstractFileAnalyzer
     {
         // Load configuration
         $analyzerConfig = $this->config->get('shieldci.analyzers.best-practices.logic-in-blade', []);
-        $analyzerConfig = is_array($analyzerConfig) ? $analyzerConfig : [];
 
-        $this->maxPhpBlockLines = $analyzerConfig['max_php_block_lines'] ?? self::DEFAULT_MAX_PHP_BLOCK_LINES;
-        $this->minArithmeticOperators = $analyzerConfig['min_arithmetic_operators'] ?? self::DEFAULT_MIN_ARITHMETIC_OPERATORS;
-        $this->maxForeachDepth = $analyzerConfig['max_foreach_depth'] ?? self::DEFAULT_MAX_FOREACH_DEPTH;
+        $this->maxPhpBlockLines = $this->configInt($analyzerConfig, 'max_php_block_lines', self::DEFAULT_MAX_PHP_BLOCK_LINES);
+        $this->minArithmeticOperators = $this->configInt($analyzerConfig, 'min_arithmetic_operators', self::DEFAULT_MIN_ARITHMETIC_OPERATORS);
+        $this->maxForeachDepth = $this->configInt($analyzerConfig, 'max_foreach_depth', self::DEFAULT_MAX_FOREACH_DEPTH);
 
         $issues = [];
 

--- a/src/Analyzers/BestPractices/LogicInRoutesAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInRoutesAnalyzer.php
@@ -15,6 +15,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Concerns\ReadsConfigArrays;
 
 /**
  * Detects business logic in route files.
@@ -24,6 +25,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
  */
 class LogicInRoutesAnalyzer extends AbstractFileAnalyzer
 {
+    use ReadsConfigArrays;
+
     public const DEFAULT_MAX_CLOSURE_LINES = 5;
 
     public const DEFAULT_ALLOW_SIMPLE_READS = true;
@@ -54,10 +57,9 @@ class LogicInRoutesAnalyzer extends AbstractFileAnalyzer
     {
         // Load configuration
         $analyzerConfig = $this->config->get('shieldci.analyzers.best-practices.logic-in-routes', []);
-        $analyzerConfig = is_array($analyzerConfig) ? $analyzerConfig : [];
 
-        $this->maxClosureLines = $analyzerConfig['max_closure_lines'] ?? self::DEFAULT_MAX_CLOSURE_LINES;
-        $this->allowSimpleReads = $analyzerConfig['allow_simple_reads'] ?? self::DEFAULT_ALLOW_SIMPLE_READS;
+        $this->maxClosureLines = $this->configInt($analyzerConfig, 'max_closure_lines', self::DEFAULT_MAX_CLOSURE_LINES);
+        $this->allowSimpleReads = $this->configBool($analyzerConfig, 'allow_simple_reads', self::DEFAULT_ALLOW_SIMPLE_READS);
 
         $issues = [];
 

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -15,6 +15,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\Concerns\ClassifiesFiles;
+use ShieldCI\Concerns\ReadsConfigArrays;
 
 /**
  * Detects multiple database write operations without transactions.
@@ -27,6 +28,7 @@ use ShieldCI\Concerns\ClassifiesFiles;
 class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
 {
     use ClassifiesFiles;
+    use ReadsConfigArrays;
 
     /**
      * Minimum number of writes that require full transactional atomicity.
@@ -57,9 +59,8 @@ class MissingDatabaseTransactionsAnalyzer extends AbstractFileAnalyzer
     {
         // Load configuration from config file (best-practices.missing-database-transactions)
         $analyzerConfig = $this->config->get('shieldci.analyzers.best-practices.missing-database-transactions', []);
-        $analyzerConfig = is_array($analyzerConfig) ? $analyzerConfig : [];
 
-        $this->threshold = $analyzerConfig['threshold'] ?? self::DEFAULT_THRESHOLD;
+        $this->threshold = $this->configInt($analyzerConfig, 'threshold', self::DEFAULT_THRESHOLD);
 
         $issues = [];
 

--- a/src/Analyzers/CodeQuality/CommentedCodeAnalyzer.php
+++ b/src/Analyzers/CodeQuality/CommentedCodeAnalyzer.php
@@ -11,6 +11,7 @@ use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Concerns\ReadsConfigArrays;
 
 /**
  * Detects commented-out code that should be removed.
@@ -35,6 +36,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
  */
 class CommentedCodeAnalyzer extends AbstractFileAnalyzer
 {
+    use ReadsConfigArrays;
+
     /**
      * Default: Minimum consecutive commented lines to flag.
      */
@@ -125,11 +128,10 @@ class CommentedCodeAnalyzer extends AbstractFileAnalyzer
     {
         // Load configuration from config file (code-quality.commented-code)
         $analyzerConfig = $this->config->get('shieldci.analyzers.code-quality.commented-code', []);
-        $analyzerConfig = is_array($analyzerConfig) ? $analyzerConfig : [];
 
-        $this->minConsecutiveLines = $analyzerConfig['min_consecutive_lines'] ?? self::MIN_CONSECUTIVE_LINES;
-        $this->maxNeutralLines = $analyzerConfig['max_neutral_lines'] ?? self::MAX_NEUTRAL_LINES;
-        $this->codeScoreThreshold = $analyzerConfig['code_score_threshold'] ?? self::CODE_SCORE_THRESHOLD;
+        $this->minConsecutiveLines = $this->configInt($analyzerConfig, 'min_consecutive_lines', self::MIN_CONSECUTIVE_LINES);
+        $this->maxNeutralLines = $this->configInt($analyzerConfig, 'max_neutral_lines', self::MAX_NEUTRAL_LINES);
+        $this->codeScoreThreshold = $this->configInt($analyzerConfig, 'code_score_threshold', self::CODE_SCORE_THRESHOLD);
 
         $issues = [];
         $minLines = $this->minConsecutiveLines;

--- a/src/Analyzers/CodeQuality/NestingDepthAnalyzer.php
+++ b/src/Analyzers/CodeQuality/NestingDepthAnalyzer.php
@@ -15,6 +15,7 @@ use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\Concerns\ReadsConfigArrays;
 
 /**
  * Identifies deeply nested code blocks.
@@ -26,6 +27,8 @@ use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
  */
 class NestingDepthAnalyzer extends AbstractFileAnalyzer
 {
+    use ReadsConfigArrays;
+
     public const DEFAULT_THRESHOLD = 4;
 
     private int $threshold;
@@ -52,9 +55,8 @@ class NestingDepthAnalyzer extends AbstractFileAnalyzer
     {
         // Load configuration from config file (code-quality.nesting-depth)
         $analyzerConfig = $this->config->get('shieldci.analyzers.code-quality.nesting-depth', []);
-        $analyzerConfig = is_array($analyzerConfig) ? $analyzerConfig : [];
 
-        $this->threshold = $analyzerConfig['threshold'] ?? self::DEFAULT_THRESHOLD;
+        $this->threshold = $this->configInt($analyzerConfig, 'threshold', self::DEFAULT_THRESHOLD);
 
         $issues = [];
         $threshold = $this->threshold;

--- a/src/Analyzers/Performance/HorizonSuggestionAnalyzer.php
+++ b/src/Analyzers/Performance/HorizonSuggestionAnalyzer.php
@@ -85,8 +85,9 @@ class HorizonSuggestionAnalyzer extends AbstractAnalyzer
         }
 
         $driver = $this->config->get("queue.connections.{$defaultConnection}.driver");
+        $driverLabel = is_scalar($driver) ? (string) $driver : 'unknown';
 
-        return "Queue driver is '{$driver}', not 'redis' (Horizon only works with Redis queues)";
+        return "Queue driver is '{$driverLabel}', not 'redis' (Horizon only works with Redis queues)";
     }
 
     protected function runAnalysis(): ResultInterface

--- a/src/Analyzers/Performance/MysqlSingleServerAnalyzer.php
+++ b/src/Analyzers/Performance/MysqlSingleServerAnalyzer.php
@@ -132,7 +132,8 @@ class MysqlSingleServerAnalyzer extends AbstractAnalyzer
             return "Not relevant in '{$currentEnv}' environment (only relevant in: {$relevantEnvs})";
         }
 
-        $defaultConnection = $this->config->get('database.default', 'unknown');
+        $defaultConnectionValue = $this->config->get('database.default', 'unknown');
+        $defaultConnection = is_string($defaultConnectionValue) ? $defaultConnectionValue : 'unknown';
         $driver = $this->config->get("database.connections.{$defaultConnection}.driver", 'unknown');
 
         if (! is_string($driver)) {

--- a/src/Analyzers/Reliability/DatabaseStatusAnalyzer.php
+++ b/src/Analyzers/Reliability/DatabaseStatusAnalyzer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Reliability;
 
-use Illuminate\Support\Facades\DB;
+use Illuminate\Database\DatabaseManager;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
@@ -35,7 +35,7 @@ class DatabaseStatusAnalyzer extends AbstractFileAnalyzer
 
     public function __construct(?DatabaseConnectionChecker $connectionChecker = null)
     {
-        $this->connectionChecker = $connectionChecker ?? new DatabaseConnectionChecker(DB::getFacadeRoot());
+        $this->connectionChecker = $connectionChecker ?? new DatabaseConnectionChecker(app(DatabaseManager::class));
     }
 
     protected function metadata(): AnalyzerMetadata

--- a/src/Analyzers/Reliability/QueueTimeoutAnalyzer.php
+++ b/src/Analyzers/Reliability/QueueTimeoutAnalyzer.php
@@ -317,7 +317,8 @@ class QueueTimeoutAnalyzer extends AbstractFileAnalyzer
             }
 
             // Check current environment
-            $currentEnv = config('app.env', 'production');
+            $currentEnvValue = config('app.env', 'production');
+            $currentEnv = is_string($currentEnvValue) ? $currentEnvValue : 'production';
             $envConfig = config("horizon.environments.{$currentEnv}", []);
             if (is_array($envConfig)) {
                 /** @var array<string, mixed> $envConfig */

--- a/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
+++ b/src/Analyzers/Security/FrontendVulnerableDependencyAnalyzer.php
@@ -307,10 +307,11 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
             $decoded = json_decode($line, true);
 
             if (json_last_error() === JSON_ERROR_NONE && is_array($decoded) && isset($decoded['type']) && is_string($decoded['type'])) {
-                if ($decoded['type'] === 'auditAdvisory' && isset($decoded['data']['advisory']) && is_array($decoded['data']['advisory'])) {
-                    $result['advisories'][] = $decoded['data']['advisory'];
-                } elseif ($decoded['type'] === 'auditSummary' && isset($decoded['data']) && is_array($decoded['data'])) {
-                    $result['summary'] = $decoded['data'];
+                $data = $decoded['data'] ?? null;
+                if ($decoded['type'] === 'auditAdvisory' && is_array($data) && isset($data['advisory']) && is_array($data['advisory'])) {
+                    $result['advisories'][] = $data['advisory'];
+                } elseif ($decoded['type'] === 'auditSummary' && is_array($data)) {
+                    $result['summary'] = $data;
                 }
             }
         }
@@ -402,8 +403,9 @@ class FrontendVulnerableDependencyAnalyzer extends AbstractFileAnalyzer
         }
 
         // Only create summary issue if no detailed issues were created
-        if (! $detailedIssuesCreated && isset($results['metadata']['vulnerabilities']) && is_array($results['metadata']['vulnerabilities'])) {
-            $vulns = $results['metadata']['vulnerabilities'];
+        $metadata = $results['metadata'] ?? null;
+        if (! $detailedIssuesCreated && is_array($metadata) && isset($metadata['vulnerabilities']) && is_array($metadata['vulnerabilities'])) {
+            $vulns = $metadata['vulnerabilities'];
             $total = isset($vulns['total']) && is_numeric($vulns['total']) ? (int) $vulns['total'] : 0;
 
             if ($total > 0) {

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -226,7 +226,8 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
                 // Check if this file is in ignored list
                 $relativePath = $this->getRelativePath($file->getPathname());
                 $shouldIgnore = false;
-                foreach ($config['ignored_middleware'] as $ignoredPath) {
+                $ignoredMiddleware = $config['ignored_middleware'] ?? [];
+                foreach (is_array($ignoredMiddleware) ? $ignoredMiddleware : [] as $ignoredPath) {
                     if (is_string($ignoredPath) && str_contains($relativePath, $ignoredPath)) {
                         $shouldIgnore = true;
                         break;

--- a/src/Analyzers/Security/PasswordSecurityAnalyzer.php
+++ b/src/Analyzers/Security/PasswordSecurityAnalyzer.php
@@ -145,11 +145,14 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
 
         $minRounds = $config['bcrypt_min_rounds'];
 
-        if (isset($configArray['bcrypt']['rounds']) && is_int($configArray['bcrypt']['rounds']) && $configArray['bcrypt']['rounds'] < $minRounds) {
+        $bcrypt = $configArray['bcrypt'] ?? null;
+        $bcryptRounds = is_array($bcrypt) ? ($bcrypt['rounds'] ?? null) : null;
+
+        if (is_int($bcryptRounds) && $bcryptRounds < $minRounds) {
             $issues[] = $this->createIssueWithSnippet(
                 message: sprintf(
                     'Bcrypt rounds (%d) is below recommended minimum of %d',
-                    $configArray['bcrypt']['rounds'],
+                    $bcryptRounds,
                     $minRounds
                 ),
                 filePath: $hashingConfig,
@@ -160,7 +163,7 @@ class PasswordSecurityAnalyzer extends AbstractFileAnalyzer
                     $minRounds
                 ),
                 metadata: [
-                    'rounds' => $configArray['bcrypt']['rounds'],
+                    'rounds' => $bcryptRounds,
                     'issue_type' => 'weak_bcrypt_rounds',
                 ]
             );

--- a/src/Analyzers/Security/XssAnalyzer.php
+++ b/src/Analyzers/Security/XssAnalyzer.php
@@ -109,7 +109,8 @@ class XssAnalyzer extends AbstractFileAnalyzer
         $this->client = new Client;
 
         // Skip HTTP checks in CI mode
-        $this->skipHttpChecks = config('shieldci.ci_mode', false);
+        $ciMode = config('shieldci.ci_mode', false);
+        $this->skipHttpChecks = is_bool($ciMode) ? $ciMode : false;
     }
 
     public function setStatelessOverride(?bool $stateless): void

--- a/src/Concerns/ReadsConfigArrays.php
+++ b/src/Concerns/ReadsConfigArrays.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Concerns;
+
+/**
+ * Reads Laravel config values at their declared types.
+ *
+ * Laravel's config() helper is typed as mixed, so an is_array() check only
+ * proves array<mixed, mixed> and a raw offset read yields mixed. These helpers
+ * coerce a config value to the type a property expects, falling back to the
+ * caller's default whenever the stored value is missing or the wrong shape.
+ */
+trait ReadsConfigArrays
+{
+    /**
+     * Coerce a value into a string-keyed array, dropping any non-string keys.
+     *
+     * @return array<string, mixed>
+     */
+    protected function toStringKeyedArray(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $stringKeyed = [];
+
+        foreach ($value as $key => $item) {
+            if (is_string($key)) {
+                $stringKeyed[$key] = $item;
+            }
+        }
+
+        return $stringKeyed;
+    }
+
+    /**
+     * Read an integer entry from a mixed config value.
+     */
+    protected function configInt(mixed $config, string $key, int $default): int
+    {
+        $value = is_array($config) ? ($config[$key] ?? null) : null;
+
+        return is_int($value) ? $value : $default;
+    }
+
+    /**
+     * Read a boolean entry from a mixed config value.
+     */
+    protected function configBool(mixed $config, string $key, bool $default): bool
+    {
+        $value = is_array($config) ? ($config[$key] ?? null) : null;
+
+        return is_bool($value) ? $value : $default;
+    }
+
+    /**
+     * Read a list-of-strings entry from a mixed config value, dropping non-strings.
+     *
+     * @param  array<int, string>  $default
+     * @return array<int, string>
+     */
+    protected function configStringList(mixed $config, string $key, array $default): array
+    {
+        $value = is_array($config) ? ($config[$key] ?? null) : null;
+
+        return is_array($value) ? array_values(array_filter($value, 'is_string')) : $default;
+    }
+}

--- a/src/ShieldCIServiceProvider.php
+++ b/src/ShieldCIServiceProvider.php
@@ -151,7 +151,7 @@ class ShieldCIServiceProvider extends ServiceProvider
                 continue;
             }
 
-            $files = glob($directory.'/*Analyzer.php');
+            $files = glob($directory.'/*Analyzer.php') ?: [];
 
             foreach ($files as $file) {
                 $className = $this->getClassFromFile($file);

--- a/src/Support/Composer.php
+++ b/src/Support/Composer.php
@@ -106,7 +106,7 @@ class Composer extends BaseComposer
 
         $data = json_decode($content, true);
 
-        return ($data['dev'] ?? true) === true;
+        return (is_array($data) ? ($data['dev'] ?? true) : true) === true;
     }
 
     /**

--- a/src/Support/PHPStan.php
+++ b/src/Support/PHPStan.php
@@ -7,6 +7,7 @@ namespace ShieldCI\Support;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use ShieldCI\Concerns\ReadsConfigArrays;
 use Symfony\Component\Process\Process;
 
 /**
@@ -14,6 +15,8 @@ use Symfony\Component\Process\Process;
  */
 class PHPStan
 {
+    use ReadsConfigArrays;
+
     /**
      * The PHPStan analysis result.
      *
@@ -145,7 +148,8 @@ class PHPStan
         }
 
         $output = $this->runCommand($options, false);
-        $this->result = json_decode($output, true);
+        $decoded = json_decode($output, true);
+        $this->result = is_array($decoded) ? $this->toStringKeyedArray($decoded) : null;
 
         return $this;
     }

--- a/src/Support/PHPStanRunner.php
+++ b/src/Support/PHPStanRunner.php
@@ -7,6 +7,7 @@ namespace ShieldCI\Support;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ShieldCI\AnalyzersCore\Support\PlatformDetector;
+use ShieldCI\Concerns\ReadsConfigArrays;
 use Symfony\Component\Process\Process;
 
 /**
@@ -17,6 +18,8 @@ use Symfony\Component\Process\Process;
  */
 class PHPStanRunner
 {
+    use ReadsConfigArrays;
+
     /**
      * Known false positive patterns to suppress.
      *
@@ -91,11 +94,8 @@ class PHPStanRunner
 
             // Parse JSON output
             $output = $process->getOutput();
-            $this->result = json_decode($output, true);
-
-            if (! is_array($this->result)) {
-                $this->result = ['files' => []];
-            }
+            $decoded = json_decode($output, true);
+            $this->result = is_array($decoded) ? $this->toStringKeyedArray($decoded) : ['files' => []];
         } finally {
             // Clean up temp config file
             $this->cleanupTempConfig();
@@ -211,13 +211,15 @@ class PHPStanRunner
      */
     public function getIssues(): Collection
     {
-        if ($this->result === null || ! isset($this->result['files'])) {
+        $files = $this->result['files'] ?? null;
+
+        if (! is_array($files)) {
             return collect();
         }
 
         $issues = [];
 
-        foreach ($this->result['files'] as $file => $fileData) {
+        foreach ($files as $file => $fileData) {
             if (! is_string($file) || ! is_array($fileData) || ! isset($fileData['messages']) || ! is_array($fileData['messages'])) {
                 continue;
             }

--- a/src/Support/Reporter.php
+++ b/src/Support/Reporter.php
@@ -102,7 +102,8 @@ class Reporter implements ReporterInterface
                 $metadata = $result->getMetadata();
 
                 // Get name from metadata
-                $name = $metadata['name'] ?? $result->getAnalyzerId();
+                $nameValue = $metadata['name'] ?? null;
+                $name = is_string($nameValue) ? $nameValue : $result->getAnalyzerId();
 
                 // Build status line with optional timeToFix
                 $statusLine = "{$name}. {$status}";
@@ -554,7 +555,7 @@ class Reporter implements ReporterInterface
 
     public function toJson(AnalysisReport $report): string
     {
-        return json_encode($report->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        return json_encode($report->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?: '';
     }
 
     public function toApi(AnalysisReport $report): array
@@ -775,7 +776,8 @@ class Reporter implements ReporterInterface
         $metadata = $result->getMetadata();
 
         // Get name from metadata
-        $name = $metadata['name'] ?? $result->getAnalyzerId();
+        $nameValue = $metadata['name'] ?? null;
+        $name = is_string($nameValue) ? $nameValue : $result->getAnalyzerId();
 
         // Build status line with optional timeToFix
         $statusLine = "{$name}. {$status}";

--- a/src/Support/SecurityAdvisories/HttpAdvisoryFetcher.php
+++ b/src/Support/SecurityAdvisories/HttpAdvisoryFetcher.php
@@ -95,8 +95,10 @@ class HttpAdvisoryFetcher implements AdvisoryFetcherInterface
                 continue;
             }
 
-            $package = $queries[$index]['package']['name'];
-            $version = $queries[$index]['version'];
+            $query = $queries[$index];
+            $queryPackage = $query['package'] ?? null;
+            $package = is_array($queryPackage) ? ($queryPackage['name'] ?? null) : null;
+            $version = $query['version'] ?? null;
 
             if (! is_string($package) || ! is_string($version)) {
                 continue;
@@ -139,7 +141,7 @@ class HttpAdvisoryFetcher implements AdvisoryFetcherInterface
         $link = null;
         if (isset($vuln['references']) && is_array($vuln['references'])) {
             foreach ($vuln['references'] as $reference) {
-                if (isset($reference['url']) && is_string($reference['url'])) {
+                if (is_array($reference) && isset($reference['url']) && is_string($reference['url'])) {
                     $link = $reference['url'];
                     break;
                 }

--- a/src/ValueObjects/AnalysisReport.php
+++ b/src/ValueObjects/AnalysisReport.php
@@ -49,6 +49,9 @@ final class AnalysisReport
         return (int) round(($passed / $denominator) * 100);
     }
 
+    /**
+     * @return Collection<int, ResultInterface>
+     */
     public function passed(): Collection
     {
         return $this->results->filter(
@@ -56,6 +59,9 @@ final class AnalysisReport
         );
     }
 
+    /**
+     * @return Collection<int, ResultInterface>
+     */
     public function failed(): Collection
     {
         return $this->results->filter(
@@ -63,6 +69,9 @@ final class AnalysisReport
         );
     }
 
+    /**
+     * @return Collection<int, ResultInterface>
+     */
     public function warnings(): Collection
     {
         return $this->results->filter(
@@ -70,6 +79,9 @@ final class AnalysisReport
         );
     }
 
+    /**
+     * @return Collection<int, ResultInterface>
+     */
     public function skipped(): Collection
     {
         return $this->results->filter(
@@ -77,6 +89,9 @@ final class AnalysisReport
         );
     }
 
+    /**
+     * @return Collection<int, ResultInterface>
+     */
     public function errors(): Collection
     {
         return $this->results->filter(

--- a/tests/Unit/Concerns/ReadsConfigArraysTest.php
+++ b/tests/Unit/Concerns/ReadsConfigArraysTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Concerns;
+
+use PHPUnit\Framework\Attributes\Test;
+use ShieldCI\Concerns\ReadsConfigArrays;
+use ShieldCI\Tests\TestCase;
+
+class ReadsConfigArraysTest extends TestCase
+{
+    /** @test */
+    #[Test]
+    public function to_string_keyed_array_returns_empty_for_non_array(): void
+    {
+        $reader = new class
+        {
+            use ReadsConfigArrays;
+
+            /**
+             * @return array<string, mixed>
+             */
+            public function call(mixed $value): array
+            {
+                return $this->toStringKeyedArray($value);
+            }
+        };
+
+        $this->assertSame([], $reader->call('not-an-array'));
+        $this->assertSame([], $reader->call(null));
+        $this->assertSame([], $reader->call(42));
+    }
+
+    /** @test */
+    #[Test]
+    public function to_string_keyed_array_keeps_string_keys_and_drops_non_string_keys(): void
+    {
+        $reader = new class
+        {
+            use ReadsConfigArrays;
+
+            /**
+             * @return array<string, mixed>
+             */
+            public function call(mixed $value): array
+            {
+                return $this->toStringKeyedArray($value);
+            }
+        };
+
+        $result = $reader->call([
+            'driver' => 'redis',
+            0 => 'dropped',
+            'timeout' => 30,
+        ]);
+
+        $this->assertSame(['driver' => 'redis', 'timeout' => 30], $result);
+    }
+
+    /** @test */
+    #[Test]
+    public function config_int_reads_integers_and_falls_back_otherwise(): void
+    {
+        $reader = new class
+        {
+            use ReadsConfigArrays;
+
+            public function call(mixed $config, string $key, int $default): int
+            {
+                return $this->configInt($config, $key, $default);
+            }
+        };
+
+        $this->assertSame(15, $reader->call(['threshold' => 15], 'threshold', 10));
+        $this->assertSame(10, $reader->call(['threshold' => '15'], 'threshold', 10));
+        $this->assertSame(10, $reader->call(['other' => 15], 'threshold', 10));
+        $this->assertSame(10, $reader->call('not-an-array', 'threshold', 10));
+    }
+
+    /** @test */
+    #[Test]
+    public function config_bool_reads_booleans_and_falls_back_otherwise(): void
+    {
+        $reader = new class
+        {
+            use ReadsConfigArrays;
+
+            public function call(mixed $config, string $key, bool $default): bool
+            {
+                return $this->configBool($config, $key, $default);
+            }
+        };
+
+        $this->assertTrue($reader->call(['enabled' => true], 'enabled', false));
+        $this->assertFalse($reader->call(['enabled' => 1], 'enabled', false));
+        $this->assertFalse($reader->call(['other' => true], 'enabled', false));
+        $this->assertFalse($reader->call(null, 'enabled', false));
+    }
+
+    /** @test */
+    #[Test]
+    public function config_string_list_keeps_strings_and_falls_back_otherwise(): void
+    {
+        $reader = new class
+        {
+            use ReadsConfigArrays;
+
+            /**
+             * @param  array<int, string>  $default
+             * @return array<int, string>
+             */
+            public function call(mixed $config, string $key, array $default): array
+            {
+                return $this->configStringList($config, $key, $default);
+            }
+        };
+
+        $this->assertSame(
+            ['App\\Models\\User', 'App\\Models\\Post'],
+            $reader->call(['classes' => ['App\\Models\\User', 42, 'App\\Models\\Post']], 'classes', [])
+        );
+        $this->assertSame(['default'], $reader->call(['other' => ['x']], 'classes', ['default']));
+        $this->assertSame(['default'], $reader->call('not-an-array', 'classes', ['default']));
+    }
+}


### PR DESCRIPTION
Third in the #284 stack — **base is #286**.

Removes the eight blanket `mixed`-family ignore patterns (offset-on-mixed, method-on-mixed, property-does-not-accept-mixed, constructor-expects-mixed, encapsed-string-cast, foreach-on-mixed/false, string|false return) and fixes the 38 `src/` errors behind them.

Root cause: Laravel `config()` / `json_decode()` return `mixed`, so `is_array()` only proves `array<mixed, mixed>` and a scalar read stays `mixed`. Adds `src/Concerns/ReadsConfigArrays.php` — promoted from laravel-pro so pro can later import it — with `toStringKeyedArray` plus `configInt`/`configBool`/`configStringList`, applied to the analyzers that load typed thresholds/lists from config. Remaining spots narrow inline: `is_scalar`/`is_string` guards before interpolation, stepwise `is_array` narrowing through decoded JSON, `glob() ?: []`, `json_encode() ?: `, and typed closure elements via `Collection<int, ResultInterface>` returns on the status filters.

`DatabaseStatusAnalyzer` resolves the manager via `app(DatabaseManager::class)` instead of the `mixed`-typed `DB::getFacadeRoot()` — same singleton, honest type.

The 110 offset-on-mixed / encapsed errors in **test assertions** are deferred behind two tests-scoped ignores, to be dismantled in the tests PR (PR 5).

phpstan green (level 9, larastan), pint clean, 4401 tests pass.