### PR TITLE
refactor: narrow php-parser node access at level 9

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,8 +25,12 @@ parameters:
         - vendor/shieldci/analyzers-core/src/Abstracts/AbstractAnalyzer.php
 
     ignoreErrors:
-        # Test files - AnalyzerInterface doesn't have setBasePath/setPaths, but concrete implementations do
-        - '#Call to an undefined method ShieldCI\\AnalyzersCore\\Contracts\\AnalyzerInterface::(setBasePath|setPaths)\(\)#'
+        # Tests type analyzers as AnalyzerInterface but drive them through the setBasePath/
+        # setPaths methods on the concrete implementations. The interface lives in
+        # analyzers-core and must not change, so these stay suppressed in tests.
+        -
+            message: '#Call to an undefined method ShieldCI\\AnalyzersCore\\Contracts\\AnalyzerInterface::(setBasePath|setPaths)\(\)#'
+            path: tests
 
         # Test helper methods with untyped arrays
         -
@@ -35,12 +39,6 @@ parameters:
         -
             message: '#has parameter \$analyzerClasses with no value type specified in iterable type array#'
             path: tests/Unit/AnalyzerManagerTest.php
-
-        # AstParser has extended methods beyond ParserInterface
-        - '#Call to an undefined method ShieldCI\\AnalyzersCore\\Contracts\\ParserInterface::findClasses\(\)#'
-
-        # PHPParser node property access (false positives)
-        - '#Access to an undefined property PhpParser\\Node\\Arg\|PhpParser\\Node\\VariadicPlaceholder::\$value#'
 
         # Collection return types (generic type specifications not needed)
         - '#return type with generic class Illuminate\\Support\\Collection does not specify its types#'

--- a/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
+++ b/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
@@ -247,7 +247,8 @@ class ChunkMissingVisitor extends NodeVisitorAbstract
             if ($current->name instanceof Node\Identifier
                 && $current->name->toString() === 'select') {
                 foreach ($current->args as $arg) {
-                    if ($this->containsDbRaw($arg->value)) {
+                    // A first-class callable yields a VariadicPlaceholder, which has no value.
+                    if ($arg instanceof Node\Arg && $this->containsDbRaw($arg->value)) {
                         return true;
                     }
                 }

--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -728,7 +728,7 @@ class NPlusOneVisitor extends NodeVisitorAbstract
                 $node->var->name === $loopVariable &&
                 $node->name instanceof Node\Identifier &&
                 $node->name->toString() === 'relationLoaded' &&
-                ! empty($node->args) &&
+                ($node->args[0] ?? null) instanceof Node\Arg &&
                 $node->args[0]->value instanceof Node\Scalar\String_) {
 
                 $relationship = $node->args[0]->value->value;
@@ -1377,7 +1377,7 @@ class NPlusOneVisitor extends NodeVisitorAbstract
 
         while ($current instanceof Expr\MethodCall) {
             foreach ($current->args as $arg) {
-                if ($this->expressionReferencesVariable($arg->value, $varName)) {
+                if ($arg instanceof Node\Arg && $this->expressionReferencesVariable($arg->value, $varName)) {
                     return true;
                 }
             }
@@ -1387,7 +1387,7 @@ class NPlusOneVisitor extends NodeVisitorAbstract
         // Check static call arguments at the root
         if ($current instanceof Expr\StaticCall) {
             foreach ($current->args as $arg) {
-                if ($this->expressionReferencesVariable($arg->value, $varName)) {
+                if ($arg instanceof Node\Arg && $this->expressionReferencesVariable($arg->value, $varName)) {
                     return true;
                 }
             }
@@ -1418,7 +1418,7 @@ class NPlusOneVisitor extends NodeVisitorAbstract
             }
             // Check method arguments too
             foreach ($expr->args as $arg) {
-                if ($this->expressionReferencesVariable($arg->value, $varName)) {
+                if ($arg instanceof Node\Arg && $this->expressionReferencesVariable($arg->value, $varName)) {
                     return true;
                 }
             }

--- a/src/Analyzers/BestPractices/FatModelAnalyzer.php
+++ b/src/Analyzers/BestPractices/FatModelAnalyzer.php
@@ -10,10 +10,10 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\NodeVisitorAbstract;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
-use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\Concerns\ReadsConfigArrays;
 use ShieldCI\Support\EloquentModelDetector;
@@ -43,7 +43,7 @@ class FatModelAnalyzer extends AbstractFileAnalyzer
     private int $complexityThreshold;
 
     public function __construct(
-        private ParserInterface $parser,
+        private AstParser $parser,
         private Config $config
     ) {}
 

--- a/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInBladeAnalyzer.php
@@ -1038,7 +1038,7 @@ class BladeLogicVisitor extends NodeVisitorAbstract
             if ($expr instanceof Expr\FuncCall
                 && $expr->name instanceof Name
                 && $expr->name->toString() === 'e'
-                && count($expr->args) >= 1) {
+                && ($expr->args[0] ?? null) instanceof Node\Arg) {
                 $inner = $expr->args[0]->value;
             }
 

--- a/src/Analyzers/BestPractices/LogicInRoutesAnalyzer.php
+++ b/src/Analyzers/BestPractices/LogicInRoutesAnalyzer.php
@@ -331,7 +331,9 @@ class LogicInRoutesVisitor extends NodeVisitorAbstract
 
         // Check each argument for closures
         foreach ($node->args as $arg) {
-            if ($arg->value instanceof Node\Expr\Closure || $arg->value instanceof Node\Expr\ArrowFunction) {
+            // A first-class callable yields a VariadicPlaceholder, which has no value.
+            if ($arg instanceof Node\Arg
+                && ($arg->value instanceof Node\Expr\Closure || $arg->value instanceof Node\Expr\ArrowFunction)) {
                 $this->analyzeClosure($arg->value);
             }
         }

--- a/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
+++ b/src/Analyzers/BestPractices/MissingDatabaseTransactionsAnalyzer.php
@@ -301,7 +301,8 @@ class TransactionVisitor extends NodeVisitorAbstract
                         $this->manualTransactionDepth++;
                     } elseif ($methodName === 'transaction' && ! empty($node->args)) {
                         // Track the closure passed to DB::transaction()
-                        $firstArg = $node->args[0]->value;
+                        $firstArgNode = $node->args[0];
+                        $firstArg = $firstArgNode instanceof Node\Arg ? $firstArgNode->value : null;
                         if ($firstArg instanceof Node\Expr\Closure || $firstArg instanceof Node\Expr\ArrowFunction) {
                             $this->transactionClosurePositions[$firstArg->getStartFilePos()] = true;
                         }
@@ -976,7 +977,8 @@ class TransactionDelegatedMethodScanner extends NodeVisitorAbstract
             && $node->name->toString() === 'transaction'
             && ! empty($node->args)
         ) {
-            $firstArg = $node->args[0]->value;
+            $firstArgNode = $node->args[0];
+            $firstArg = $firstArgNode instanceof Node\Arg ? $firstArgNode->value : null;
             if ($firstArg instanceof Node\Expr\Closure || $firstArg instanceof Node\Expr\ArrowFunction) {
                 $this->transactionClosurePositions[$firstArg->getStartFilePos()] = true;
             }

--- a/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
+++ b/src/Analyzers/BestPractices/MixedQueryBuilderEloquentAnalyzer.php
@@ -702,7 +702,7 @@ class MixedQueryVisitor extends NodeVisitorAbstract
         }
 
         $arg = $node->args[0];
-        if ($arg->value instanceof Node\Scalar\String_) {
+        if ($arg instanceof Node\Arg && $arg->value instanceof Node\Scalar\String_) {
             $tableName = $arg->value->value;
             $tableName = explode(' ', $tableName)[0];
             // Check if table already tracked as eloquent

--- a/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
+++ b/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
@@ -13,10 +13,10 @@ use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\NodeVisitorAbstract;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
-use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\Support\EloquentModelDetector;
 
@@ -126,7 +126,7 @@ class ServiceContainerResolutionAnalyzer extends AbstractFileAnalyzer
     private array $manualInstantiationExcludePatterns = [];
 
     public function __construct(
-        private ParserInterface $parser,
+        private AstParser $parser,
         private Config $config
     ) {}
 

--- a/src/Analyzers/Performance/EnvCallAnalyzer.php
+++ b/src/Analyzers/Performance/EnvCallAnalyzer.php
@@ -217,7 +217,10 @@ class EnvCallAnalyzer extends AbstractFileAnalyzer
         $args = [];
 
         foreach ($funcCall->args as $index => $arg) {
-            $args[$index] = $this->extractStaticArgumentValue($arg->value);
+            // A first-class callable yields a VariadicPlaceholder, which has no value.
+            if ($arg instanceof Node\Arg) {
+                $args[$index] = $this->extractStaticArgumentValue($arg->value);
+            }
         }
 
         return $args;
@@ -268,7 +271,10 @@ class EnvCallAnalyzer extends AbstractFileAnalyzer
         $args = [];
 
         foreach ($staticCall->args as $index => $arg) {
-            $args[$index] = $this->extractStaticArgumentValue($arg->value);
+            // A first-class callable yields a VariadicPlaceholder, which has no value.
+            if ($arg instanceof Node\Arg) {
+                $args[$index] = $this->extractStaticArgumentValue($arg->value);
+            }
         }
 
         return $args;

--- a/src/Analyzers/Security/AuthenticationAnalyzer.php
+++ b/src/Analyzers/Security/AuthenticationAnalyzer.php
@@ -11,10 +11,10 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\NodeVisitorAbstract;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
-use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
@@ -82,7 +82,7 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
     private array $routeAuthStats = [];
 
     public function __construct(
-        private ParserInterface $parser,
+        private AstParser $parser,
         private Config $config
     ) {}
 
@@ -860,7 +860,8 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
             if ($methodName === 'middleware') {
                 // Extract middleware name from arguments
                 foreach ($currentExpr->args as $arg) {
-                    $value = $arg->value;
+                    // A first-class callable yields a VariadicPlaceholder, which has no value.
+                    $value = $arg instanceof Node\Arg ? $arg->value : null;
                     if ($value instanceof Node\Scalar\String_) {
                         // Check for auth or authorization middleware
                         if ($this->isAuthMiddleware($value->value) || $this->isAuthorizationMiddleware($value->value)) {
@@ -883,7 +884,8 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
                 // Extract method names from only/except
                 $methods = [];
                 foreach ($currentExpr->args as $arg) {
-                    $value = $arg->value;
+                    // A first-class callable yields a VariadicPlaceholder, which has no value.
+                    $value = $arg instanceof Node\Arg ? $arg->value : null;
                     if ($value instanceof Node\Expr\Array_) {
                         foreach ($value->items as $item) {
                             if ($item instanceof Node\Expr\ArrayItem && $item->value instanceof Node\Scalar\String_) {

--- a/src/Analyzers/Security/DebugModeAnalyzer.php
+++ b/src/Analyzers/Security/DebugModeAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Security;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\Expr\FuncCall;
@@ -351,11 +352,12 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
      */
     private function checkErrorReportingCall(FuncCall $funcCall, string $file, array &$issues): void
     {
-        if (! isset($funcCall->args[0])) {
+        $argNode = $funcCall->args[0] ?? null;
+        if (! $argNode instanceof Arg) {
             return;
         }
 
-        $arg = $funcCall->args[0]->value;
+        $arg = $argNode->value;
 
         $isVerbose = false;
 
@@ -400,7 +402,12 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
             return;
         }
 
-        $settingArg = $funcCall->args[0]->value;
+        $settingArgNode = $funcCall->args[0];
+        if (! $settingArgNode instanceof Arg) {
+            return;
+        }
+
+        $settingArg = $settingArgNode->value;
 
         if (! $settingArg instanceof String_) {
             return;
@@ -412,7 +419,12 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
             return;
         }
 
-        $valueArg = $funcCall->args[1]->value;
+        $valueArgNode = $funcCall->args[1];
+        if (! $valueArgNode instanceof Arg) {
+            return;
+        }
+
+        $valueArg = $valueArgNode->value;
 
         $isTruthy = false;
 

--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -7,10 +7,10 @@ namespace ShieldCI\Analyzers\Security;
 use Illuminate\Contracts\Config\Repository as Config;
 use PhpParser\Node;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
-use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
@@ -37,7 +37,7 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
     private ?EloquentModelDetector $modelDetector = null;
 
     public function __construct(
-        private ParserInterface $parser,
+        private AstParser $parser,
         private Config $config
     ) {}
 

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShieldCI\Analyzers\Security;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Scalar\String_;
@@ -160,7 +161,7 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
 
         foreach ($forceSchemeCallNodes as $call) {
             /** @var StaticCall $call */
-            if (isset($call->args[0])
+            if (($call->args[0] ?? null) instanceof Arg
                 && $call->args[0]->value instanceof String_
                 && $call->args[0]->value->value === 'https'
             ) {
@@ -180,7 +181,12 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
                 return true;
             }
 
-            $firstArg = $call->args[0]->value;
+            $firstArgNode = $call->args[0];
+            if (! $firstArgNode instanceof Arg) {
+                continue;
+            }
+
+            $firstArg = $firstArgNode->value;
 
             // Explicit false → HTTPS is NOT forced; skip this call
             if ($firstArg instanceof ConstFetch && strtolower((string) $firstArg->name) === 'false') {

--- a/src/Analyzers/Security/LoginThrottlingAnalyzer.php
+++ b/src/Analyzers/Security/LoginThrottlingAnalyzer.php
@@ -6,10 +6,10 @@ namespace ShieldCI\Analyzers\Security;
 
 use PhpParser\Node;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
-use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
@@ -30,7 +30,7 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
     use DetectsLaravelVersion;
 
     public function __construct(
-        private ParserInterface $parser
+        private AstParser $parser
     ) {}
 
     protected function metadata(): AnalyzerMetadata

--- a/src/Analyzers/Security/MassAssignmentAnalyzer.php
+++ b/src/Analyzers/Security/MassAssignmentAnalyzer.php
@@ -6,10 +6,10 @@ namespace ShieldCI\Analyzers\Security;
 
 use PhpParser\Node;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
-use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
@@ -120,7 +120,7 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
     private ?array $composerClassMap = null;
 
     public function __construct(
-        private ParserInterface $parser
+        private AstParser $parser
     ) {}
 
     protected function metadata(): AnalyzerMetadata
@@ -1240,7 +1240,8 @@ class MassAssignmentAnalyzer extends AbstractFileAnalyzer
         if ($node instanceof Node\Expr\MethodCall) {
             if ($node->var instanceof Node\Expr\Variable || $node->var instanceof Node\Expr\FuncCall) {
                 if (! empty($node->args)) {
-                    $arg = $node->args[0]->value;
+                    $argNode = $node->args[0];
+                    $arg = $argNode instanceof Node\Arg ? $argNode->value : null;
                     if ($arg instanceof Node\Scalar\String_) {
                         // Check for dot notation indicating nested data
                         if (str_contains($arg->value, '.')) {

--- a/src/Analyzers/Security/SqlInjectionAnalyzer.php
+++ b/src/Analyzers/Security/SqlInjectionAnalyzer.php
@@ -372,7 +372,12 @@ class SqlInjectionAnalyzer extends AbstractFileAnalyzer
             return ['vulnerable' => false, 'node' => null];
         }
 
-        $firstArg = $call->args[0]->value;
+        $firstArgNode = $call->args[0];
+        if (! $firstArgNode instanceof Node\Arg) {
+            return ['vulnerable' => false, 'node' => null];
+        }
+
+        $firstArg = $firstArgNode->value;
         $hasBindings = count($call->args) >= 2;
 
         // Determine effective strictness:
@@ -432,7 +437,12 @@ class SqlInjectionAnalyzer extends AbstractFileAnalyzer
             return ['vulnerable' => false, 'node' => null];
         }
 
-        $sqlArg = $call->args[1]->value;
+        $sqlArgNode = $call->args[1];
+        if (! $sqlArgNode instanceof Node\Arg) {
+            return ['vulnerable' => false, 'node' => null];
+        }
+
+        $sqlArg = $sqlArgNode->value;
 
         // Check for vulnerable patterns and return the specific node
         $vulnerableNode = $this->findVulnerableNode($sqlArg);

--- a/src/Analyzers/Security/UnguardedModelsAnalyzer.php
+++ b/src/Analyzers/Security/UnguardedModelsAnalyzer.php
@@ -333,7 +333,9 @@ class UnguardedModelsAnalyzer extends AbstractFileAnalyzer
 
         // Check if any argument is a Closure or Arrow function
         foreach ($call->args as $arg) {
-            if ($arg->value instanceof Node\Expr\Closure || $arg->value instanceof Node\Expr\ArrowFunction) {
+            // A first-class callable yields a VariadicPlaceholder, which has no value.
+            if ($arg instanceof Node\Arg
+                && ($arg->value instanceof Node\Expr\Closure || $arg->value instanceof Node\Expr\ArrowFunction)) {
                 return true;
             }
         }

--- a/src/Analyzers/Security/XssAnalyzer.php
+++ b/src/Analyzers/Security/XssAnalyzer.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Str;
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
@@ -378,12 +377,12 @@ class XssAnalyzer extends AbstractFileAnalyzer
         $responseMakeCalls = $astParser->findStaticCalls($ast, 'Response', 'make');
 
         foreach ($responseMakeCalls as $call) {
-            if (! isset($call->args[0])) {
+            $argNode = $call->args[0] ?? null;
+            if (! $argNode instanceof Node\Arg) {
                 continue;
             }
 
-            /** @var Expr $argExpr */
-            $argExpr = $call->args[0]->value;
+            $argExpr = $argNode->value;
 
             // Skip if the argument is wrapped in an escape function
             if ($this->isEscapedExpressionAst($argExpr)) {
@@ -416,8 +415,9 @@ class XssAnalyzer extends AbstractFileAnalyzer
             }
 
             // response($content) — with direct content argument
-            if (isset($funcCall->args[0])) {
-                $argExpr = $funcCall->args[0]->value;
+            $responseArgNode = $funcCall->args[0] ?? null;
+            if ($responseArgNode instanceof Node\Arg) {
+                $argExpr = $responseArgNode->value;
 
                 if (! $this->isEscapedExpressionAst($argExpr)
                     && ! $this->isJsonResponseAst($argExpr)

--- a/src/Concerns/InspectsCode.php
+++ b/src/Concerns/InspectsCode.php
@@ -143,7 +143,10 @@ trait InspectsCode
         $args = [];
 
         foreach ($funcCall->args as $index => $arg) {
-            $args[$index] = $this->extractArgumentValue($arg->value);
+            // A first-class callable (env(...)) yields a VariadicPlaceholder, which has no value.
+            if ($arg instanceof Node\Arg) {
+                $args[$index] = $this->extractArgumentValue($arg->value);
+            }
         }
 
         return $args;

--- a/src/Support/EloquentModelDetector.php
+++ b/src/Support/EloquentModelDetector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\UseItem;
-use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 
 /**
  * Answers one question: is this class declaration an Eloquent model?
@@ -54,7 +54,7 @@ final class EloquentModelDetector
         'Illuminate\\Database\\Eloquent\\Relations\\MorphPivot',
     ];
 
-    public function __construct(private readonly ParserInterface $parser) {}
+    public function __construct(private readonly AstParser $parser) {}
 
     /** @var array<string, bool|null> "path::ShortName" => Eloquent verdict */
     private array $verdictCache = [];

--- a/src/Support/ModelVariableScanner.php
+++ b/src/Support/ModelVariableScanner.php
@@ -317,10 +317,13 @@ class ModelVariableScanner extends NodeVisitorAbstract
 
         $relationships = [];
         foreach ($expr->args as $arg) {
-            $relationships = array_merge(
-                $relationships,
-                $this->parseRelationshipArgument($arg->value)
-            );
+            // A first-class callable (with(...)) yields a VariadicPlaceholder, which has no value.
+            if ($arg instanceof Node\Arg) {
+                $relationships = array_merge(
+                    $relationships,
+                    $this->parseRelationshipArgument($arg->value)
+                );
+            }
         }
 
         return array_unique($relationships);

--- a/tests/AnalyzerTestCase.php
+++ b/tests/AnalyzerTestCase.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ShieldCI\Tests;
 
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
-use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Status;
 use ShieldCI\AnalyzersCore\Support\AstParser;
@@ -14,7 +13,7 @@ abstract class AnalyzerTestCase extends TestCase
 {
     protected AnalyzerInterface $analyzer;
 
-    protected ParserInterface $parser;
+    protected AstParser $parser;
 
     protected function setUp(): void
     {

--- a/tests/Fixtures/inspects-code/sample_functions.php
+++ b/tests/Fixtures/inspects-code/sample_functions.php
@@ -11,4 +11,8 @@ function someFunction()
     $flag = config('app.flag', true);
     $result = strlen($name);
     $complex = config(getenv('APP_CONFIG_KEY'));
+
+    // First-class callable syntax: the call's single argument is a
+    // VariadicPlaceholder, not an Arg, so argument extraction must skip it.
+    $callable = strtoupper(...);
 }

--- a/tests/Unit/Concerns/InspectsCodeTest.php
+++ b/tests/Unit/Concerns/InspectsCodeTest.php
@@ -162,6 +162,21 @@ class InspectsCodeTest extends TestCase
 
     /** @test */
     #[Test]
+    public function it_skips_variadic_placeholder_arguments(): void
+    {
+        $inspector = new ConcreteInspectsCode;
+        $inspector->setFixturePath(__DIR__.'/../../Fixtures/inspects-code');
+
+        // strtoupper(...) is a first-class callable — its only "argument" is a
+        // VariadicPlaceholder, which has no value and must be skipped.
+        $results = $inspector->publicFindFunctionCalls('strtoupper');
+
+        $this->assertCount(1, $results);
+        $this->assertSame([], $results[0]['args']);
+    }
+
+    /** @test */
+    #[Test]
     public function it_skips_files_that_throw_during_parsing(): void
     {
         $inspector = new ConcreteInspectsCode;

--- a/tests/Unit/Support/ModelVariableScannerTest.php
+++ b/tests/Unit/Support/ModelVariableScannerTest.php
@@ -50,6 +50,14 @@ class ModelVariableScannerTest extends TestCase
         $this->assertEqualsCanonicalizing(['airports'], $s->eagerLoadsOf('cities'));
     }
 
+    public function test_skips_variadic_placeholder_in_eager_load_call(): void
+    {
+        // load(...) is a first-class callable — its only "argument" is a
+        // VariadicPlaceholder, which has no value and must be skipped.
+        $s = $this->scan("\$cities = City::all();\n\$cities->load(...);");
+        $this->assertSame([], $s->eagerLoadsOf('cities'));
+    }
+
     public function test_unknown_variable_returns_null(): void
     {
         $s = $this->scan('$x = someHelper();');


### PR DESCRIPTION
Fourth in the #284 stack — **base is #287**.

Removes the two php-parser node-access ignore patterns (`findClasses` on `ParserInterface`, `$value` on `Arg|VariadicPlaceholder`) and fixes the 44 `src/` errors behind them.

**`property.notFound` (30):** php-parser types a call's args as `array<Arg|VariadicPlaceholder>`, and a first-class-callable spread (`foo(...)`) yields a `VariadicPlaceholder` with no `->value`. Each access is guarded with `instanceof Arg` — `continue`/`return` in loops, a null-coalescing ternary where the value is `instanceof`-checked right after, or a combined condition where the arg node is already a local.

**`method.notFound` (14):** `findClasses()` is an `AstParser` method absent from `ParserInterface`, so the six analyzers/detectors that call it now type their injected parser as `AstParser` — matching `ModelTableResolver`, which already did. `FatModelAnalyzer` follows (it feeds its parser to `EloquentModelDetector`), and `AnalyzerTestCase::$parser` is retyped to match (it was already `new AstParser`).

The `setBasePath`/`setPaths` pattern stays but is **scoped to tests**: `AnalyzerInterface` lives in analyzers-core and must not change, and tests drive concrete analyzers through those methods.

phpstan green (level 9, larastan), pint clean, 4406 tests pass.