### PR TITLE
fix: preserve base64 APP_KEY values containing double-slash

### DIFF
--- a/src/Analyzers/Security/AppKeyAnalyzer.php
+++ b/src/Analyzers/Security/AppKeyAnalyzer.php
@@ -274,12 +274,17 @@ class AppKeyAnalyzer extends AbstractFileAnalyzer
      */
     private function stripInlineComment(string $value): string
     {
-        // Only strip comments outside quotes
-        if (preg_match('/^([\'"])(.*)\1$/', trim($value))) {
-            return trim($value);
+        $value = trim($value);
+
+        // Fully-quoted values are returned verbatim.
+        if (preg_match('/^([\'"]).*\1$/', $value)) {
+            return $value;
         }
 
-        return preg_replace('/\s*(#|\/\/|;).*$/', '', trim($value)) ?? trim($value);
+        // In .env files, only `#` starts an inline comment, and only when preceded
+        // by whitespace. Base64 keys can contain `//`, `+`, and `/`, so those must
+        // never be treated as comment delimiters.
+        return preg_replace('/\s+#.*$/', '', $value) ?? $value;
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/AppKeyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/AppKeyAnalyzerTest.php
@@ -48,6 +48,47 @@ PHP;
         $this->assertPassed($result);
     }
 
+    public function test_passes_with_base64_key_containing_double_slash(): void
+    {
+        // A valid 32-byte key whose base64 encoding contains "//" (legal base64).
+        $envContent = <<<'ENV'
+APP_NAME=Laravel
+APP_KEY=base64:2/J40U++LCAOMbcQXVMoijPIbW48//FuI/2ppake6b4=
+APP_DEBUG=false
+ENV;
+
+        $tempDir = $this->createTempDirectory([
+            '.env' => $envContent,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_strips_trailing_inline_comment(): void
+    {
+        $envContent = <<<'ENV'
+APP_NAME=Laravel
+APP_KEY=base64:/AvmHMmBChdiKxwxReS4zWfHKXAfl0vsbJIf2fT3gHA= # production app key
+APP_DEBUG=false
+ENV;
+
+        $tempDir = $this->createTempDirectory([
+            '.env' => $envContent,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
     public function test_fails_when_app_key_is_empty(): void
     {
         $envContent = <<<'ENV'


### PR DESCRIPTION
`AppKeyAnalyzer` flagged valid keys like `base64:CMN22CTFv1xE2MRLJ+Kcf+L//3RsNbf3Ii19VCh6wFs=` as invalid. `stripInlineComment()` treated `//` (and `;`) as comment delimiters, but `/` is part of the base64 alphabet, so keys containing `//` were truncated and failed the length check.

`.env` files only use `#` for comments, so the fix drops the spurious `//`/`;` clauses and strips only a whitespace-preceded `#` comment. Added regression tests for a `//` key and for trailing inline-comment stripping.