### PR TITLE
docs: add changelog entry for v1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.12.1
+
+### Fixed
+- `app-key-security` no longer flags a valid base64 `APP_KEY` containing `//` as malformed (#291)
+
 ## v1.12.0
 
 ### Changed


### PR DESCRIPTION
Adds the v1.12.1 `### Fixed` entry for #291 (`app-key-security` no longer flags a valid base64 `APP_KEY` containing `//`).