### PR TITLE
fix: stop fillable-foreign-key flagging inherited and dynamic $fillable

### DIFF
--- a/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
+++ b/src/Analyzers/Security/FillableForeignKeyAnalyzer.php
@@ -13,7 +13,6 @@ use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Issue;
-use ShieldCI\AnalyzersCore\ValueObjects\Location;
 use ShieldCI\Support\EloquentModelDetector;
 use ShieldCI\Support\EloquentModelHelper;
 
@@ -26,6 +25,9 @@ use ShieldCI\Support\EloquentModelHelper;
  * Out of scope by design (owned by MassAssignmentAnalyzer): $guarded = [] and untrusted
  * create()/update()/fill() sinks. Generic *_id fields are likewise not flagged — whether
  * a fillable foreign key is exploitable is a data-flow property, not a field-name one.
+ * Models that inherit $fillable/$guarded from a parent class, or build $fillable
+ * dynamically, are silently skipped rather than flagged: there is no local array to
+ * inspect, so a notice would be evidence-free noise.
  */
 class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
 {
@@ -102,19 +104,6 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
             $classes = $this->parser->findClasses($ast);
             foreach ($classes as $class) {
                 if ($this->modelDetector()->isModel($class, $ast, $this->getBasePath())) {
-                    if (! $this->hasLocalFillable($class) && ! $this->hasLocalGuarded($class)) {
-                        $issues[] = $this->createIssue(
-                            message: sprintf('Model "%s" does not define a local $fillable property; inherited fillable fields cannot be analyzed', $class->name?->toString() ?? 'Unknown'),
-                            location: new Location($this->getRelativePath($file)),
-                            severity: Severity::Medium,
-                            recommendation: 'Review inherited fillable definitions to ensure foreign key fields are not inadvertently exposed to mass assignment.',
-                            metadata: [
-                                'model_name' => $class->name?->toString(),
-                                'fillable_inherited' => true,
-                            ]
-                        );
-                    }
-
                     $this->checkFillableProperty($file, $class, $issues);
                     $this->checkFillableAttribute($file, $class, $issues);
                 }
@@ -126,22 +115,6 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
             : sprintf('Found %d foreign key%s in fillable arrays', count($issues), count($issues) === 1 ? '' : 's');
 
         return $this->resultBySeverity($summary, $issues);
-    }
-
-    /**
-     * Check if fillable is declared locally, via a $fillable property or a #[Fillable] attribute.
-     */
-    private function hasLocalFillable(Node\Stmt\Class_ $class): bool
-    {
-        return EloquentModelHelper::hasFillable($class);
-    }
-
-    /**
-     * Check if guarded is declared locally, via a $guarded property or a #[Guarded]/#[Unguarded] attribute.
-     */
-    private function hasLocalGuarded(Node\Stmt\Class_ $class): bool
-    {
-        return EloquentModelHelper::hasGuarded($class);
     }
 
     /**
@@ -163,23 +136,11 @@ class FillableForeignKeyAnalyzer extends AbstractFileAnalyzer
                     continue;
                 }
 
+                // A dynamically-built $fillable (non-array default) has no static
+                // array to inspect, so there is nothing to flag here. Mass-assignment
+                // concerns for such models are owned by MassAssignmentAnalyzer.
                 if (! $prop->default instanceof Node\Expr\Array_) {
-                    $issues[] = $this->createIssueWithSnippet(
-                        message: sprintf(
-                            'Model "%s" defines $fillable dynamically; foreign key exposure cannot be statically analyzed',
-                            $modelName
-                        ),
-                        filePath: $file,
-                        lineNumber: $stmt->getLine(),
-                        severity: Severity::Medium,
-                        recommendation: 'Prefer a static fillable property or manually review which fields are exposed to mass assignment.',
-                        metadata: [
-                            'model_name' => $modelName,
-                            'dynamic_fillable' => true,
-                        ]
-                    );
-
-                    return;
+                    continue;
                 }
 
                 // Check each item in the fillable array

--- a/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/FillableForeignKeyAnalyzerTest.php
@@ -974,10 +974,12 @@ PHP;
         $this->assertHasIssueContaining('impersonate', $result);
     }
 
-    public function test_still_notices_when_no_property_and_no_attribute(): void
+    public function test_model_without_local_fillable_or_guarded_is_not_flagged(): void
     {
-        // True positive preserved: a model with neither $fillable property nor
-        // #[Fillable] attribute still gets the medium "cannot analyze" notice.
+        // A model with neither a local $fillable/$guarded nor a #[Fillable] attribute
+        // inherits its config from the base Model (default $guarded = ['*'], fully
+        // protected). There is no local array to inspect, so the analyzer stays silent
+        // rather than emitting an evidence-free "cannot analyze" notice.
         $code = <<<'PHP'
 <?php
 
@@ -999,10 +1001,66 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        $inheritedIssues = array_filter(
-            $result->getIssues(),
-            fn ($i) => isset($i->metadata['fillable_inherited']) && $i->metadata['fillable_inherited'] === true
-        );
-        $this->assertNotEmpty($inheritedIssues, 'Model with no fillable property or attribute should still get the notice');
+        $this->assertPassed($result);
+        $this->assertIssueCount(0, $result);
+    }
+
+    public function test_model_inheriting_fillable_from_vendor_parent_is_not_flagged(): void
+    {
+        // Regression: a model extending an unresolvable (vendor) base class that defines
+        // $fillable/$guarded upstream. The AST analyzer cannot follow inheritance into
+        // vendor/, so it must stay silent instead of flagging the missing local property.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Acme\Package\BaseModel;
+
+class Report extends BaseModel
+{
+    protected $table = 'reports';
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Models/Report.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertIssueCount(0, $result);
+    }
+
+    public function test_dynamic_fillable_is_not_flagged(): void
+    {
+        // A $fillable built from a non-array expression has no static array to inspect,
+        // so it is silently skipped (not flagged with a "cannot analyze" notice).
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    protected $fillable = self::MASS_FIELDS;
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory(['Models/Post.php' => $code]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertIssueCount(0, $result);
     }
 }


### PR DESCRIPTION
Models with no local `$fillable`/`$guarded` — including ones that inherit config from a vendor base class — were flagged with an evidence-free "inherited fillable cannot be analyzed" notice. This is often a guaranteed false positive: Laravel's base `Model` defaults to `$guarded = ['*']` (fully protected), and a vendor parent the AST can't follow into may supply safe config.

Removes that notice and the sibling `dynamic_fillable` notice, so the analyzer only ever reports curated impersonation keys actually present in a local `$fillable` array or `#[Fillable]` attribute — consistent with its own "curated patterns only" docblock and with how `MassAssignmentAnalyzer` handles inherited parents silently.

Tests: inverted the old "still notices" test to assert zero issues; added a vendor-parent regression test and a dynamic-`$fillable` test.