### PR TITLE
fix: apply shieldci.memory_limit to PHPStan subprocesses

### DIFF
--- a/src/Analyzers/Reliability/PHPStanAnalyzer.php
+++ b/src/Analyzers/Reliability/PHPStanAnalyzer.php
@@ -309,9 +309,12 @@ class PHPStanAnalyzer extends AbstractFileAnalyzer
         $timeoutConfig = $this->config->get('shieldci.timeout', 300);
         $timeout = is_int($timeoutConfig) ? $timeoutConfig : (is_numeric($timeoutConfig) ? (int) $timeoutConfig : 300);
 
+        $memoryLimitConfig = $this->config->get('shieldci.memory_limit');
+        $memoryLimit = is_string($memoryLimitConfig) && $memoryLimitConfig !== '' ? $memoryLimitConfig : null;
+
         try {
             // Run PHPStan once on all paths
-            $runner->analyze($paths, $level, $timeout);
+            $runner->analyze($paths, $level, $timeout, $memoryLimit);
 
             // Categorize all issues
             $categorizedIssues = $this->categorizeIssues($runner, $activeCategories);

--- a/src/Support/PHPStan.php
+++ b/src/Support/PHPStan.php
@@ -238,6 +238,19 @@ class PHPStan
             $result[] = $option;
         }
 
+        // Apply shieldci.memory_limit to the PHPStan subprocess (per-process ceiling,
+        // parallel workers included) unless the user already pinned --memory-limit above.
+        $memoryLimit = config('shieldci.memory_limit');
+
+        $hasMemoryLimit = array_filter(
+            $result,
+            static fn (string $option): bool => str_starts_with($option, '--memory-limit'),
+        ) !== [];
+
+        if (! $hasMemoryLimit && is_string($memoryLimit) && PHPStanRunner::isValidMemoryLimit($memoryLimit)) {
+            $result[] = '--memory-limit='.$memoryLimit;
+        }
+
         return $result;
     }
 

--- a/src/Support/PHPStanRunner.php
+++ b/src/Support/PHPStanRunner.php
@@ -63,7 +63,7 @@ class PHPStanRunner
      * @param  string|array<string>  $paths
      * @return $this
      */
-    public function analyze(string|array $paths, int $level = 5, int $timeout = 300): self
+    public function analyze(string|array $paths, int $level = 5, int $timeout = 300, ?string $memoryLimit = null): self
     {
         $paths = is_array($paths) ? $paths : [$paths];
 
@@ -81,6 +81,13 @@ class PHPStanRunner
                 '--no-progress',
                 '--no-interaction',
             ];
+
+            // Apply the configured memory limit to the PHPStan subprocess. PHPStan's
+            // --memory-limit sets the ceiling per process (including parallel workers),
+            // so shieldci.memory_limit governs static analysis, not just the main process.
+            if ($memoryLimit !== null && self::isValidMemoryLimit($memoryLimit)) {
+                $command[] = '--memory-limit='.$memoryLimit;
+            }
 
             // Add paths
             foreach ($paths as $path) {
@@ -321,5 +328,16 @@ class PHPStanRunner
     public function isAvailable(): bool
     {
         return file_exists($this->basePath.'/vendor/bin/phpstan');
+    }
+
+    /**
+     * Validate a php.ini-style memory limit string (e.g. "512M", "2G", "-1").
+     *
+     * Invalid values are rejected so a misconfigured shieldci.memory_limit falls
+     * back to PHPStan's ambient limit instead of breaking analysis outright.
+     */
+    public static function isValidMemoryLimit(string $value): bool
+    {
+        return preg_match('/^(-1|\d+[KMGkmg]?)$/', $value) === 1;
     }
 }

--- a/tests/Unit/Analyzers/Reliability/PHPStanAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/PHPStanAnalyzerTest.php
@@ -585,6 +585,42 @@ PHP;
         $this->assertStringContainsString('exceeded the timeout of 1', $result->getMessage());
     }
 
+    public function test_passes_configured_memory_limit_to_phpstan(): void
+    {
+        $tempDir = $this->createTempDirectory(['app/Services/ValidService.php' => "<?php\nclass ValidService {}"]);
+        $argsFile = $tempDir.'/captured_args.txt';
+
+        @mkdir($tempDir.'/vendor/bin', 0755, true);
+        // Records the arguments PHPStan was invoked with, then returns empty JSON.
+        $script = <<<BASH
+#!/bin/bash
+printf '%s\\n' "\$@" > "{$argsFile}"
+echo '{"files":[]}'
+BASH;
+        file_put_contents($tempDir.'/vendor/bin/phpstan', $script);
+        chmod($tempDir.'/vendor/bin/phpstan', 0755);
+
+        $configRepo = new Repository([
+            'shieldci' => [
+                'memory_limit' => '2048M',
+                'analyzers' => ['reliability' => ['enabled' => true, 'phpstan' => [
+                    'level' => 5, 'paths' => ['app'], 'categories' => ['undefined-variable'], 'disabled_categories' => [],
+                ]]],
+            ],
+        ]);
+
+        $analyzer = new PHPStanAnalyzer($configRepo);
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $analyzer->analyze();
+
+        $this->assertFileExists($argsFile);
+        $captured = file_get_contents($argsFile);
+        $this->assertIsString($captured);
+        $this->assertStringContainsString('--memory-limit=2048M', $captured);
+    }
+
     /**
      * Create a mock PHPStan script that returns predefined issues.
      *

--- a/tests/Unit/Support/PHPStanRunnerTest.php
+++ b/tests/Unit/Support/PHPStanRunnerTest.php
@@ -668,6 +668,51 @@ BASH;
         $runner->analyze(['app'], 5, 1); // 1-second timeout
     }
 
+    public function test_analyze_passes_memory_limit_to_phpstan(): void
+    {
+        $this->createMockPHPStanWithArgCapture();
+
+        $runner = new PHPStanRunner($this->tempDir);
+        $runner->analyze(['app'], 5, 300, '2048M');
+
+        $this->assertStringContainsString('--memory-limit=2048M', $this->getCapturedArgs());
+    }
+
+    public function test_analyze_omits_memory_limit_when_null(): void
+    {
+        $this->createMockPHPStanWithArgCapture();
+
+        $runner = new PHPStanRunner($this->tempDir);
+        $runner->analyze(['app'], 5, 300, null);
+
+        $this->assertStringNotContainsString('--memory-limit', $this->getCapturedArgs());
+    }
+
+    public function test_analyze_omits_invalid_memory_limit(): void
+    {
+        $this->createMockPHPStanWithArgCapture();
+
+        $runner = new PHPStanRunner($this->tempDir);
+        $runner->analyze(['app'], 5, 300, 'not-a-size');
+
+        $this->assertStringNotContainsString('--memory-limit', $this->getCapturedArgs());
+    }
+
+    public function test_is_valid_memory_limit_accepts_php_ini_formats(): void
+    {
+        $this->assertTrue(PHPStanRunner::isValidMemoryLimit('512M'));
+        $this->assertTrue(PHPStanRunner::isValidMemoryLimit('2048M'));
+        $this->assertTrue(PHPStanRunner::isValidMemoryLimit('2G'));
+        $this->assertTrue(PHPStanRunner::isValidMemoryLimit('1024k'));
+        $this->assertTrue(PHPStanRunner::isValidMemoryLimit('134217728'));
+        $this->assertTrue(PHPStanRunner::isValidMemoryLimit('-1'));
+
+        $this->assertFalse(PHPStanRunner::isValidMemoryLimit(''));
+        $this->assertFalse(PHPStanRunner::isValidMemoryLimit('not-a-size'));
+        $this->assertFalse(PHPStanRunner::isValidMemoryLimit('512MB'));
+        $this->assertFalse(PHPStanRunner::isValidMemoryLimit('1.5G'));
+    }
+
     /**
      * Create a mock PHPStan script that returns predefined issues.
      *
@@ -769,6 +814,54 @@ BASH;
 
         $content = file_get_contents($path);
         $this->assertIsString($content, 'Captured config file should be readable');
+
+        return $content;
+    }
+
+    /**
+     * Create a mock PHPStan script that records every argument it is invoked with.
+     */
+    private function createMockPHPStanWithArgCapture(): void
+    {
+        $vendorBinDir = $this->tempDir.'/vendor/bin';
+        mkdir($vendorBinDir, 0755, true);
+
+        $output = [
+            'totals' => [
+                'errors' => 0,
+                'file_errors' => 0,
+            ],
+            'files' => [],
+            'errors' => [],
+        ];
+
+        $json = json_encode($output, JSON_PRETTY_PRINT);
+        $capturedArgsPath = $this->tempDir.'/captured_args.txt';
+
+        // Script that records each argument on its own line, then outputs JSON.
+        $script = <<<BASH
+#!/bin/bash
+printf '%s\\n' "\$@" > "{$capturedArgsPath}"
+
+cat <<'EOF'
+{$json}
+EOF
+BASH;
+
+        file_put_contents($vendorBinDir.'/phpstan', $script);
+        chmod($vendorBinDir.'/phpstan', 0755);
+    }
+
+    /**
+     * Read the captured argument list content.
+     */
+    private function getCapturedArgs(): string
+    {
+        $path = $this->tempDir.'/captured_args.txt';
+        $this->assertFileExists($path, 'Captured args file should exist');
+
+        $content = file_get_contents($path);
+        $this->assertIsString($content, 'Captured args file should be readable');
 
         return $content;
     }

--- a/tests/Unit/Support/PHPStanTest.php
+++ b/tests/Unit/Support/PHPStanTest.php
@@ -289,6 +289,57 @@ class PHPStanTest extends TestCase
 
     /** @test */
     #[Test]
+    public function it_appends_memory_limit_from_config_to_options(): void
+    {
+        config(['shieldci.memory_limit' => '2048M']);
+
+        $phpstan = new TestablePHPStan;
+        $options = $phpstan->publicGetPHPStanOptions();
+
+        $this->assertContains('--memory-limit=2048M', $options);
+    }
+
+    /** @test */
+    #[Test]
+    public function it_omits_memory_limit_when_config_value_is_invalid(): void
+    {
+        config(['shieldci.memory_limit' => 'not-a-size']);
+
+        $phpstan = new TestablePHPStan;
+        $options = $phpstan->publicGetPHPStanOptions();
+
+        foreach ($options as $option) {
+            $this->assertStringNotContainsString('--memory-limit', $option);
+        }
+    }
+
+    /** @test */
+    #[Test]
+    public function it_does_not_duplicate_user_provided_memory_limit_option(): void
+    {
+        config([
+            'shieldci.memory_limit' => '2048M',
+            'shieldci.analyzers.reliability.phpstan.options' => [
+                '--error-format' => 'json',
+                '--no-progress' => true,
+                '--memory-limit' => '1G',
+            ],
+        ]);
+
+        $phpstan = new TestablePHPStan;
+        $options = $phpstan->publicGetPHPStanOptions();
+
+        $memoryOptions = array_values(array_filter(
+            $options,
+            static fn (string $option): bool => str_starts_with($option, '--memory-limit'),
+        ));
+
+        $this->assertCount(1, $memoryOptions);
+        $this->assertSame('--memory-limit=1G', $memoryOptions[0]);
+    }
+
+    /** @test */
+    #[Test]
     public function it_gets_default_config_path(): void
     {
         $phpstan = new TestablePHPStan;


### PR DESCRIPTION
## Summary
`shieldci.memory_limit` was applied via `ini_set()` only in the main artisan process. The PHPStan analyzer shells out to `vendor/bin/phpstan` in a **separate** PHP process that inherited none of it, so the config was silently ignored and large codebases could exhaust the ambient PHP memory limit at the `nikic/php-parser` stage.

This threads the configured value into **both** PHPStan subprocess paths — `PHPStanRunner` (used by `PHPStanAnalyzer`) and `Support\PHPStan` (used by `CollectionCallAnalyzer`) — via PHPStan's native `--memory-limit` flag, which sets the ceiling **per process, including parallel workers**. A php.ini-format guard drops an invalid value rather than breaking analysis, and a user-set `--memory-limit` in `phpstan.options` is left untouched.

## Verification
- Pint: clean
- PHPStan Level 9: 0 errors
- Full suite: 4420 tests, 0 failures