### PR TITLE
docs: add changelog entry for v1.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.12.3
+
+### Fixed
+- `shieldci.memory_limit` is now passed to the PHPStan analyzer's subprocess via `--memory-limit`, so analyzing a large project no longer exhausts the ambient PHP memory limit while PHPStan builds ASTs (#295)
+
 ## v1.12.2
 
 ### Fixed


### PR DESCRIPTION
Adds the v1.12.3 changelog entry for #295 (`shieldci.memory_limit` now applies to PHPStan subprocesses).