### PR TITLE
fix: stop eloquent-n-plus-one flagging pessimistic-lock chains in loops

### DIFF
--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -601,6 +601,12 @@ class NPlusOneVisitor extends NodeVisitorAbstract
     ];
 
     /**
+     * @var array<string> Pessimistic-lock builder methods. A query acquiring one is
+     *                    inherently per-row and can neither be eager-loaded nor batched.
+     */
+    private const LOCK_METHODS = ['lockforupdate', 'sharedlock'];
+
+    /**
      * @var array<int, array{relationship: string, line: int, loop_type: string, variable: string}>
      */
     private array $issues = [];
@@ -855,10 +861,12 @@ class NPlusOneVisitor extends NodeVisitorAbstract
                     // Walk up the chain to find if it starts with a static call (Model::)
                     $queryDescription = $this->getQueryChainDescription($node);
                     if ($queryDescription !== null) {
-                        // Only flag if query depends on loop variable (true N+1 pattern) and
-                        // is not a uniqueness-probe loop condition (generate-until-unique idiom).
+                        // Only flag if query depends on loop variable (true N+1 pattern), is
+                        // not a uniqueness-probe loop condition (generate-until-unique idiom),
+                        // and does not acquire a pessimistic lock (inherently per-row).
                         if ($this->queryDependsOnLoop($node, $currentLoop)
-                            && ! isset($this->uniquenessProbeNodes[spl_object_id($node)])) {
+                            && ! isset($this->uniquenessProbeNodes[spl_object_id($node)])
+                            && ! $this->chainAcquiresLock($node)) {
                             $this->queryIssues[] = [
                                 'query' => $queryDescription,
                                 'line' => $node->getStartLine(),
@@ -1365,6 +1373,26 @@ class NPlusOneVisitor extends NodeVisitorAbstract
         }
 
         return null;
+    }
+
+    /**
+     * Check if any call in a method chain acquires a pessimistic row lock.
+     */
+    private function chainAcquiresLock(Expr\MethodCall $node): bool
+    {
+        $current = $node;
+
+        while ($current instanceof Expr\MethodCall) {
+            if ($current->name instanceof Node\Identifier
+                && in_array(strtolower($current->name->toString()), self::LOCK_METHODS, true)) {
+                return true;
+            }
+            $current = $current->var;
+        }
+
+        return $current instanceof Expr\StaticCall
+            && $current->name instanceof Node\Identifier
+            && in_array(strtolower($current->name->toString()), self::LOCK_METHODS, true);
     }
 
     /**

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
@@ -3223,4 +3223,104 @@ PHP;
 
         $this->assertPassed($result);
     }
+
+    public function test_lock_for_update_in_loop_is_not_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class StockController
+{
+    public function issue(array $items): void
+    {
+        foreach ($items as $item) {
+            // Pessimistic lock is inherently per-row - not an N+1 to fix
+            $stock = StoreItem::lockForUpdate()->whereKey($item['id'])->firstOrFail();
+            $stock->decrement('quantity', $item['qty']);
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/StockController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass - a lockForUpdate chain cannot be eager-loaded or batched
+        $this->assertPassed($result);
+    }
+
+    public function test_shared_lock_in_loop_is_not_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class StockController
+{
+    public function read(array $ids): void
+    {
+        foreach ($ids as $id) {
+            $row = StoreItem::where('id', $id)->sharedLock()->first();
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/StockController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass - sharedLock anywhere in the chain marks it per-row
+        $this->assertPassed($result);
+    }
+
+    public function test_lockless_chain_in_loop_is_still_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class StockController
+{
+    public function issue(array $items): void
+    {
+        foreach ($items as $item) {
+            // Same shape as the lock tests but without a lock - genuine N+1
+            $stock = StoreItem::whereKey($item['id'])->firstOrFail();
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/StockController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should flag - loop-dependent query with no lock in the chain
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('StoreItem::whereKey', $result);
+    }
 }


### PR DESCRIPTION
A query whose chain acquires a pessimistic row lock (`lockForUpdate()` / `sharedLock()`) is inherently per-row — the lock must be taken and held for that specific row — so it can never be eager-loaded or batched and is never a real N+1. Found while dogfooding: `StoreItem::lockForUpdate()->whereKey($id)->firstOrFail()` inside a `foreach` was flagged.

- Add `LOCK_METHODS` constant and `chainAcquiresLock()` helper to `NPlusOneVisitor`; skip loop-dependent chains containing a lock method (same style as the existing uniqueness-probe exclusion).
- Lock method names match the pair already used in `MassAssignmentAnalyzer` and `LogicInRoutesAnalyzer`.
- Tests: `lockForUpdate` at chain root and `sharedLock` mid-chain no longer flag; the same chain without a lock still flags.