### PR TITLE
fix: stop eloquent-n-plus-one flagging queries whose branch exits the loop

### DIFF
--- a/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
+++ b/src/Analyzers/BestPractices/EloquentNPlusOneAnalyzer.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\NodeVisitorAbstract;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
@@ -84,6 +85,7 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
 
                 $visitor = new NPlusOneVisitor($scanResult);
                 $traverser = new NodeTraverser;
+                $traverser->addVisitor(new ParentConnectingVisitor);
                 $traverser->addVisitor($visitor);
                 $traverser->traverse($ast);
 
@@ -210,6 +212,7 @@ class EloquentNPlusOneAnalyzer extends AbstractFileAnalyzer
 
         $visitor = new NPlusOneVisitor($scanResult, $seed);
         $traverser = new NodeTraverser;
+        $traverser->addVisitor(new ParentConnectingVisitor);
         $traverser->addVisitor($visitor);
         $traverser->traverse($ast);
 
@@ -842,7 +845,9 @@ class NPlusOneVisitor extends NodeVisitorAbstract
                     // Direct query execution methods
                     if ($this->isQueryExecutionMethod($methodName)) {
                         // Only flag if query depends on loop variable (true N+1 pattern)
-                        if ($this->queryDependsOnLoop($node, $currentLoop)) {
+                        // and the loop can actually iterate again after the query runs.
+                        if ($this->queryDependsOnLoop($node, $currentLoop)
+                            && ! $this->loopExitsAfterQuery($node)) {
                             $this->queryIssues[] = [
                                 'query' => "{$className}::{$methodName}()",
                                 'line' => $node->getStartLine(),
@@ -863,10 +868,12 @@ class NPlusOneVisitor extends NodeVisitorAbstract
                     if ($queryDescription !== null) {
                         // Only flag if query depends on loop variable (true N+1 pattern), is
                         // not a uniqueness-probe loop condition (generate-until-unique idiom),
-                        // and does not acquire a pessimistic lock (inherently per-row).
+                        // does not acquire a pessimistic lock (inherently per-row), and the
+                        // loop can actually iterate again after the query runs.
                         if ($this->queryDependsOnLoop($node, $currentLoop)
                             && ! isset($this->uniquenessProbeNodes[spl_object_id($node)])
-                            && ! $this->chainAcquiresLock($node)) {
+                            && ! $this->chainAcquiresLock($node)
+                            && ! $this->loopExitsAfterQuery($node)) {
                             $this->queryIssues[] = [
                                 'query' => $queryDescription,
                                 'line' => $node->getStartLine(),
@@ -1393,6 +1400,142 @@ class NPlusOneVisitor extends NodeVisitorAbstract
         return $current instanceof Expr\StaticCall
             && $current->name instanceof Node\Identifier
             && in_array(strtolower($current->name->toString()), self::LOCK_METHODS, true);
+    }
+
+    /**
+     * True if control unconditionally leaves every enclosing loop once the query
+     * statement finishes, so the query executes at most once per method call.
+     *
+     * Walks parent links (set by ParentConnectingVisitor) from the query up to the
+     * innermost loop: the statements following the query — climbing out of
+     * if/elseif/else blocks — must exit via return, throw, or a break when only a
+     * single loop encloses the query. Anything else (conditional exits, try/catch,
+     * switch, closures) is treated as repeatable.
+     */
+    private function loopExitsAfterQuery(Node $queryNode): bool
+    {
+        // Climb from the query expression to its enclosing statement.
+        $current = $queryNode->getAttribute('parent');
+
+        while ($current instanceof Node && ! $current instanceof Stmt) {
+            if ($current instanceof Expr\Closure || $current instanceof Expr\ArrowFunction) {
+                return false; // deferred execution — control flow is unknowable
+            }
+            $current = $current->getAttribute('parent');
+        }
+
+        if ($this->isLoopNode($current)) {
+            // The query sits in a loop header (while/for condition, foreach
+            // iterable) and re-runs as that loop iterates.
+            return false;
+        }
+
+        while ($current instanceof Stmt) {
+            $parent = $current->getAttribute('parent');
+
+            if (! $parent instanceof Node) {
+                return false;
+            }
+
+            $siblings = $this->stmtListContaining($parent, $current);
+
+            if ($siblings === null) {
+                // Unsupported construct (try/catch, switch, ...): a throw may be
+                // caught and the loop resumed, so treat the query as repeatable.
+                return false;
+            }
+
+            $index = array_search($current, $siblings, true);
+
+            if (! is_int($index)) {
+                return false;
+            }
+
+            $suffix = array_slice($siblings, $index + 1);
+
+            if ($suffix !== []) {
+                return $this->stmtsExitEveryLoop($suffix);
+            }
+
+            if ($this->isLoopNode($parent)) {
+                // End of the loop body without an unconditional exit: the next
+                // iteration begins.
+                return false;
+            }
+
+            // Nothing follows at this level: control flows out of the enclosing
+            // construct. Else/elseif branches rejoin after their If_ statement.
+            $current = $parent instanceof Stmt\ElseIf_ || $parent instanceof Stmt\Else_
+                ? $parent->getAttribute('parent')
+                : $parent;
+        }
+
+        return false;
+    }
+
+    /**
+     * True if the node is one of the loop constructs this visitor tracks.
+     */
+    private function isLoopNode(mixed $node): bool
+    {
+        return $node instanceof Stmt\Foreach_ || $node instanceof Stmt\For_
+            || $node instanceof Stmt\While_ || $node instanceof Stmt\Do_;
+    }
+
+    /**
+     * The statement list of $parent that directly contains $child, for constructs
+     * this heuristic can reason about; null for anything else.
+     *
+     * @return array<int, Stmt>|null
+     */
+    private function stmtListContaining(Node $parent, Stmt $child): ?array
+    {
+        $stmts = match (true) {
+            $parent instanceof Stmt\If_,
+            $parent instanceof Stmt\ElseIf_,
+            $parent instanceof Stmt\Else_,
+            $parent instanceof Stmt\Block,
+            $parent instanceof Stmt\Foreach_,
+            $parent instanceof Stmt\For_,
+            $parent instanceof Stmt\While_,
+            $parent instanceof Stmt\Do_ => $parent->stmts,
+            default => null,
+        };
+
+        return $stmts !== null && in_array($child, $stmts, true) ? $stmts : null;
+    }
+
+    /**
+     * True if this statement run unconditionally exits every enclosing loop before
+     * any construct that could let the loop iterate again.
+     *
+     * @param  array<int, Stmt>  $stmts
+     */
+    private function stmtsExitEveryLoop(array $stmts): bool
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Stmt\Return_) {
+                return true;
+            }
+
+            if ($stmt instanceof Stmt\Break_) {
+                // break exits only the innermost loop, so it proves at-most-once
+                // execution only when a single loop encloses the query.
+                return $stmt->num === null && count($this->loopStack) === 1;
+            }
+
+            if ($stmt instanceof Stmt\Expression) {
+                if ($stmt->expr instanceof Expr\Throw_) {
+                    return true;
+                }
+
+                continue; // plain expressions cannot re-enter the loop
+            }
+
+            return false;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/EloquentNPlusOneAnalyzerTest.php
@@ -3323,4 +3323,441 @@ PHP;
         $this->assertFailed($result);
         $this->assertHasIssueContaining('StoreItem::whereKey', $result);
     }
+
+    public function test_find_followed_by_return_in_loop_is_not_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class AssignmentController
+{
+    public function attach(array $incoming): string
+    {
+        foreach ($incoming as $employeeId) {
+            if ($this->deployedElsewhere($employeeId)) {
+                // Runs at most once: the branch unconditionally leaves the loop
+                $employee = Employee::find($employeeId);
+
+                return 'already deployed';
+            }
+        }
+
+        return 'attached';
+    }
+
+    private function deployedElsewhere(int $id): bool
+    {
+        return $id > 100;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/AssignmentController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass - the query's branch returns, so it executes at most once
+        $this->assertPassed($result);
+    }
+
+    public function test_chain_query_followed_by_return_in_loop_is_not_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class AssignmentController
+{
+    public function attach(array $ids): ?object
+    {
+        foreach ($ids as $id) {
+            if ($id > 100) {
+                $employee = Employee::where('id', $id)->first();
+
+                return $employee;
+            }
+        }
+
+        return null;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/AssignmentController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass - method-chain query followed by an unconditional return
+        $this->assertPassed($result);
+    }
+
+    public function test_query_followed_by_throw_in_loop_is_not_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class ItemController
+{
+    public function validateAll(array $ids): void
+    {
+        foreach ($ids as $id) {
+            if ($id < 0) {
+                $item = Item::find($id);
+
+                throw new \RuntimeException('invalid item');
+            }
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/ItemController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass - throw unconditionally exits the loop
+        $this->assertPassed($result);
+    }
+
+    public function test_query_followed_by_break_in_single_loop_is_not_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class ItemController
+{
+    public function firstMatch(array $ids): void
+    {
+        foreach ($ids as $id) {
+            if ($id > 100) {
+                $match = Item::find($id);
+                break;
+            }
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/ItemController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass - break exits the only enclosing loop
+        $this->assertPassed($result);
+    }
+
+    public function test_query_followed_by_log_then_return_is_not_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class AssignmentController
+{
+    public function attach(array $ids): string
+    {
+        foreach ($ids as $id) {
+            if ($id > 100) {
+                $employee = Employee::find($id);
+                Log::info('conflict found');
+
+                return 'conflict';
+            }
+        }
+
+        return 'attached';
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/AssignmentController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass - plain expression statements cannot re-enter the loop
+        $this->assertPassed($result);
+    }
+
+    public function test_query_in_if_with_return_after_if_is_not_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class ItemController
+{
+    public function firstOnly(array $ids): ?object
+    {
+        foreach ($ids as $id) {
+            if ($id > 0) {
+                $item = Item::find($id);
+            }
+
+            return $item ?? null;
+        }
+
+        return null;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/ItemController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass - the loop body unconditionally returns after the if block
+        $this->assertPassed($result);
+    }
+
+    public function test_query_in_elseif_and_else_followed_by_return_is_not_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class ItemController
+{
+    public function resolve(array $ids): ?object
+    {
+        foreach ($ids as $id) {
+            if ($id === 0) {
+                continue;
+            } elseif ($id < 100) {
+                $a = Item::find($id);
+
+                return $a;
+            } else {
+                $b = Item::find($id);
+
+                return $b;
+            }
+        }
+
+        return null;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/ItemController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should pass - both branches unconditionally return after their query
+        $this->assertPassed($result);
+    }
+
+    public function test_query_with_conditional_return_still_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class UserController
+{
+    public function firstActive(array $ids): ?object
+    {
+        foreach ($ids as $id) {
+            // The query runs every iteration; only the return is conditional
+            $user = User::find($id);
+            if ($user !== null) {
+                return $user;
+            }
+        }
+
+        return null;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/UserController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should flag - the loop can iterate again after the query
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('User::find', $result);
+    }
+
+    public function test_query_followed_by_break_in_nested_loop_still_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class ItemController
+{
+    public function scan(array $groups): void
+    {
+        foreach ($groups as $group) {
+            foreach ($group as $id) {
+                if ($id > 5) {
+                    // break only exits the inner loop; the outer loop repeats
+                    $item = Item::find($id);
+                    break;
+                }
+            }
+        }
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/ItemController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should flag - the query can run once per outer iteration
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('Item::find', $result);
+    }
+
+    public function test_query_then_return_inside_try_still_flagged(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class ItemController
+{
+    public function firstResolvable(array $ids): ?object
+    {
+        foreach ($ids as $id) {
+            try {
+                $item = Item::find($id);
+
+                return $item;
+            } catch (\Throwable $e) {
+                // A throwing query is caught and the loop resumes
+                continue;
+            }
+        }
+
+        return null;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/ItemController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should flag - inside try, the loop can resume via the catch block
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('Item::find', $result);
+    }
+
+    public function test_query_in_while_condition_still_flagged_despite_return_after_loop(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class CategoryController
+{
+    public function rootOf(array $seeds): mixed
+    {
+        foreach ($seeds as $seed) {
+            $currentId = $seed;
+            // The query re-runs on every while iteration - the return below
+            // only exits after the whole chain walk
+            while ($category = Category::find($currentId)) {
+                $currentId = $category->parent_id;
+            }
+
+            return $currentId;
+        }
+
+        return null;
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Controllers/CategoryController.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        // Should flag - a loop-header query repeats even though the outer
+        // foreach body ends in a return
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('Category::find', $result);
+    }
 }


### PR DESCRIPTION
A loop-dependent query followed by an unconditional `return` / `throw` (or `break` when a single loop encloses it) executes at most once per method call — e.g. `Employee::find($id)` inside an `if` that builds an error message and returns. Not an N+1, but it was flagged.

- Add `ParentConnectingVisitor` to both traversals and a conservative `loopExitsAfterQuery()` dominance check in `NPlusOneVisitor`, applied to the static-call and method-chain branches.
- Conservative by design: conditional returns, `break` in nested loops, try/catch, switch, closures, and loop-header queries (e.g. a `while` condition) all stay flagged — each locked in by a regression test.

Stacked on #297 (lock suppression).