### PR TITLE
fix: stop shield:analyze exhausting memory from uncleared per-analyzer AST caches

### DIFF
--- a/src/AnalyzerManager.php
+++ b/src/AnalyzerManager.php
@@ -74,6 +74,10 @@ class AnalyzerManager
      * Clear the singleton AstParser's file cache to prevent unbounded heap growth
      * when 73 analyzers each call parseFile() across the same project.
      * Called after every analyze() invocation in runAll() and run().
+     *
+     * Also forces cycle collection: visitors like ParentConnectingVisitor create
+     * child<->parent reference cycles inside cached ASTs, which plain refcounting
+     * cannot reclaim once the cache is dropped.
      */
     public function clearParserCache(): void
     {
@@ -85,6 +89,8 @@ class AnalyzerManager
         } catch (\Throwable) {
             // Parser not bound or doesn't support clearing — silently skip
         }
+
+        gc_collect_cycles();
     }
 
     private function initConfigCache(): void

--- a/src/Analyzers/Performance/EnvCallAnalyzer.php
+++ b/src/Analyzers/Performance/EnvCallAnalyzer.php
@@ -141,6 +141,18 @@ class EnvCallAnalyzer extends AbstractFileAnalyzer
     }
 
     /**
+     * Release both lazily created parsers (and their AST caches) after a run.
+     *
+     * Overrides the InspectsCode implementation to also drop $staticParser;
+     * both re-initialize on next use.
+     */
+    public function clearAstParserCache(): void
+    {
+        unset($this->parser);
+        $this->staticParser = null;
+    }
+
+    /**
      * Find all env() calls (both function and Env::get() static calls) in a single parse pass.
      *
      * Parses each file only once to detect both patterns, avoiding duplicate AST parsing.

--- a/src/Commands/AnalyzeCommand.php
+++ b/src/Commands/AnalyzeCommand.php
@@ -23,6 +23,7 @@ use ShieldCI\Enums\AnalysisFailureReason;
 use ShieldCI\Enums\SuppressionType;
 use ShieldCI\Enums\TriggerSource;
 use ShieldCI\Support\CiEnvironmentDetector;
+use ShieldCI\Support\MemoryLimit;
 use ShieldCI\ValueObjects\AnalysisReport;
 use ShieldCI\ValueObjects\FailureNotification;
 use ShieldCI\ValueObjects\FilterResult;
@@ -96,11 +97,16 @@ class AnalyzeCommand extends Command
         ClientInterface $client,
         TriggerSource $triggeredBy,
     ): int {
-        // Apply memory limit (best-effort: @-suppress the E_WARNING PHP 8.1+ raises when
-        // the current memory usage already exceeds the requested limit)
+        // Apply memory limit as a floor: raise a lower ambient limit, but never lower a
+        // higher one (e.g. Vapor's 2048M runtime default or an unlimited CLI). Best-effort:
+        // @-suppress the E_WARNING PHP 8.1+ raises when the current memory usage already
+        // exceeds the requested limit.
         $memoryLimit = config('shieldci.memory_limit');
         if ($memoryLimit !== null && is_string($memoryLimit)) {
-            @ini_set('memory_limit', $memoryLimit);
+            $currentLimit = ini_get('memory_limit');
+            if ($currentLimit === false || MemoryLimit::shouldRaise($currentLimit, $memoryLimit)) {
+                @ini_set('memory_limit', $memoryLimit);
+            }
         }
 
         // Set timeout (no-op on Lambda — warn instead)

--- a/src/Concerns/InspectsCode.php
+++ b/src/Concerns/InspectsCode.php
@@ -35,6 +35,17 @@ trait InspectsCode
     }
 
     /**
+     * Release the parser (and its AST cache) after an analyzer run.
+     *
+     * Called via method_exists() by AnalyzerManager/AnalyzeCommand between
+     * analyzers; the parser lazily re-initializes on next use.
+     */
+    public function clearAstParserCache(): void
+    {
+        unset($this->parser);
+    }
+
+    /**
      * Find all function calls matching the given name in specified paths.
      *
      * @param  string  $functionName  The function name to search for

--- a/src/ShieldCIServiceProvider.php
+++ b/src/ShieldCIServiceProvider.php
@@ -54,7 +54,11 @@ class ShieldCIServiceProvider extends ServiceProvider
             }
         );
 
-        // Register bindings
+        // Register bindings. The concrete AstParser is a singleton too: several
+        // analyzers type-hint the concrete class, and without this they would each
+        // receive a private parser instance whose AST cache survives the whole run,
+        // invisible to AnalyzerManager::clearParserCache().
+        $this->app->singleton(AstParser::class);
         $this->app->singleton(ParserInterface::class, AstParser::class);
         $this->app->singleton(ReporterInterface::class, Reporter::class);
         $this->app->singleton(Contracts\ClientInterface::class, ShieldCIClient::class);

--- a/src/Support/MemoryLimit.php
+++ b/src/Support/MemoryLimit.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Support;
+
+/**
+ * Parses php.ini-style memory limit values so the analyze command can treat
+ * the configured limit as a floor: raise a lower ambient limit, but never
+ * lower a higher one (e.g. Vapor's 2048M runtime default or an unlimited CLI).
+ */
+final class MemoryLimit
+{
+    /**
+     * Convert a php.ini-style memory limit ('512M', '1G', '-1') to bytes.
+     *
+     * Returns INF for unlimited (-1) and null when the value is unparseable.
+     */
+    public static function toBytes(string $limit): ?float
+    {
+        $limit = trim($limit);
+
+        if ($limit === '-1') {
+            return INF;
+        }
+
+        if (preg_match('/^(\d+)([KMGkmg])?$/', $limit, $matches) !== 1) {
+            return null;
+        }
+
+        $bytes = (float) $matches[1];
+
+        return match (strtoupper($matches[2] ?? '')) {
+            'K' => $bytes * 1024,
+            'M' => $bytes * 1024 * 1024,
+            'G' => $bytes * 1024 * 1024 * 1024,
+            default => $bytes,
+        };
+    }
+
+    /**
+     * Whether the configured limit should replace the current one.
+     *
+     * The configured value acts as a floor: apply it only when it is strictly
+     * higher than the current limit. An unparseable configured value is never
+     * applied; an unparseable current value is treated as replaceable.
+     */
+    public static function shouldRaise(string $current, string $configured): bool
+    {
+        $configuredBytes = self::toBytes($configured);
+        if ($configuredBytes === null) {
+            return false;
+        }
+
+        $currentBytes = self::toBytes($current);
+        if ($currentBytes === null) {
+            return true;
+        }
+
+        return $configuredBytes > $currentBytes;
+    }
+}

--- a/tests/Unit/AnalyzerManagerTest.php
+++ b/tests/Unit/AnalyzerManagerTest.php
@@ -12,12 +12,15 @@ use Illuminate\Routing\Router;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use ShieldCI\AnalyzerManager;
+use ShieldCI\Analyzers\Performance\EnvCallAnalyzer;
+use ShieldCI\Analyzers\Security\MassAssignmentAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\AnalyzerInterface;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
 use ShieldCI\AnalyzersCore\Results\AnalysisResult;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\Tests\TestCase;
 
@@ -920,6 +923,54 @@ class AnalyzerManagerTest extends TestCase
 
         $this->assertNotNull($analyzerInstance);
         $this->assertTrue($analyzerInstance->clearAstParserCacheCalled);
+    }
+
+    /** @test */
+    #[Test]
+    public function run_all_leaves_no_analyzer_holding_a_private_populated_parser(): void
+    {
+        $app = $this->app;
+        assert($app !== null);
+
+        $manager = new AnalyzerManager(
+            $app->make(Config::class),
+            [
+                EnvCallAnalyzer::class,
+                MassAssignmentAnalyzer::class,
+            ],
+            $app,
+        );
+
+        $manager->runAll();
+
+        $singleton = $app->make(ParserInterface::class);
+        $this->assertInstanceOf(AstParser::class, $singleton);
+
+        $astCache = (new \ReflectionProperty(AstParser::class, 'astCache'))
+            ->getValue($singleton);
+        $this->assertSame([], $astCache, 'The shared parser cache must be empty after the run.');
+
+        $sawEnvCall = false;
+        $sawMassAssignment = false;
+
+        foreach ($manager->getAnalyzers() as $analyzer) {
+            if ($analyzer instanceof EnvCallAnalyzer) {
+                $sawEnvCall = true;
+                $staticParser = (new \ReflectionProperty(EnvCallAnalyzer::class, 'staticParser'))
+                    ->getValue($analyzer);
+                $this->assertNull($staticParser, 'EnvCallAnalyzer must release its lazily created parser after analyze().');
+            }
+
+            if ($analyzer instanceof MassAssignmentAnalyzer) {
+                $sawMassAssignment = true;
+                $parser = (new \ReflectionProperty(MassAssignmentAnalyzer::class, 'parser'))
+                    ->getValue($analyzer);
+                $this->assertSame($singleton, $parser, 'Concrete-typed analyzers must hold the shared parser singleton.');
+            }
+        }
+
+        $this->assertTrue($sawEnvCall);
+        $this->assertTrue($sawMassAssignment);
     }
 
     /**

--- a/tests/Unit/Analyzers/Performance/EnvCallAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Performance/EnvCallAnalyzerTest.php
@@ -1054,4 +1054,43 @@ PHP;
         $this->assertNotEmpty($issues);
         $this->assertEquals(Severity::High, $issues[0]->severity);
     }
+
+    public function test_clear_ast_parser_cache_releases_both_parsers(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+namespace App\Services;
+
+class TokenService
+{
+    public function getToken()
+    {
+        return env('SERVICE_TOKEN');
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Services/TokenService.php' => $code,
+        ]);
+
+        $analyzer = new EnvCallAnalyzer;
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+        $analyzer->analyze();
+
+        $staticParser = new \ReflectionProperty(EnvCallAnalyzer::class, 'staticParser');
+        $this->assertNotNull($staticParser->getValue($analyzer));
+
+        $analyzer->clearAstParserCache();
+
+        $this->assertNull($staticParser->getValue($analyzer));
+        $traitParser = new \ReflectionProperty(EnvCallAnalyzer::class, 'parser');
+        $this->assertFalse($traitParser->isInitialized($analyzer));
+
+        // The analyzer must still work after its parsers are released.
+        $result = $analyzer->analyze();
+        $this->assertFailed($result);
+    }
 }

--- a/tests/Unit/Commands/AnalyzeCommandTest.php
+++ b/tests/Unit/Commands/AnalyzeCommandTest.php
@@ -427,6 +427,48 @@ class AnalyzeCommandTest extends TestCase
 
     /** @test */
     #[Test]
+    public function it_does_not_lower_memory_limit_when_current_is_higher(): void
+    {
+        $original = ini_get('memory_limit');
+        $this->assertNotFalse($original);
+
+        try {
+            ini_set('memory_limit', '4G');
+            config(['shieldci.memory_limit' => '1G']);
+            $this->registerTestAnalyzers();
+
+            $this->artisan('shield:analyze', ['--format' => 'json'])
+                ->assertSuccessful();
+
+            $this->assertSame('4G', ini_get('memory_limit'));
+        } finally {
+            ini_set('memory_limit', $original);
+        }
+    }
+
+    /** @test */
+    #[Test]
+    public function it_raises_memory_limit_when_current_is_lower(): void
+    {
+        $original = ini_get('memory_limit');
+        $this->assertNotFalse($original);
+
+        try {
+            ini_set('memory_limit', '2G');
+            config(['shieldci.memory_limit' => '3G']);
+            $this->registerTestAnalyzers();
+
+            $this->artisan('shield:analyze', ['--format' => 'json'])
+                ->assertSuccessful();
+
+            $this->assertSame('3G', ini_get('memory_limit'));
+        } finally {
+            ini_set('memory_limit', $original);
+        }
+    }
+
+    /** @test */
+    #[Test]
     public function it_applies_timeout_from_config(): void
     {
         config(['shieldci.timeout' => 300]);

--- a/tests/Unit/Concerns/InspectsCodeTest.php
+++ b/tests/Unit/Concerns/InspectsCodeTest.php
@@ -428,6 +428,27 @@ class InspectsCodeTest extends TestCase
             $this->assertGreaterThan(0, $entry['line']);
         }
     }
+
+    /** @test */
+    #[Test]
+    public function clear_ast_parser_cache_releases_the_parser_and_reinitializes_on_next_use(): void
+    {
+        $inspector = new ConcreteInspectsCode;
+        $inspector->setFixturePath(__DIR__.'/../../Fixtures/inspects-code');
+
+        $before = $inspector->publicFindFunctionCalls('env');
+
+        $property = new \ReflectionProperty(ConcreteInspectsCode::class, 'parser');
+        $this->assertTrue($property->isInitialized($inspector));
+
+        $inspector->clearAstParserCache();
+
+        $this->assertFalse($property->isInitialized($inspector));
+
+        $after = $inspector->publicFindFunctionCalls('env');
+        $this->assertTrue($property->isInitialized($inspector));
+        $this->assertCount(count($before), $after);
+    }
 }
 
 /**

--- a/tests/Unit/ShieldCIServiceProviderTest.php
+++ b/tests/Unit/ShieldCIServiceProviderTest.php
@@ -7,7 +7,14 @@ namespace ShieldCI\Tests\Unit;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use ShieldCI\AnalyzerManager;
+use ShieldCI\Analyzers\BestPractices\FatModelAnalyzer;
+use ShieldCI\Analyzers\BestPractices\ServiceContainerResolutionAnalyzer;
+use ShieldCI\Analyzers\Security\AuthenticationAnalyzer;
+use ShieldCI\Analyzers\Security\FillableForeignKeyAnalyzer;
+use ShieldCI\Analyzers\Security\LoginThrottlingAnalyzer;
+use ShieldCI\Analyzers\Security\MassAssignmentAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
+use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\Contracts\ReporterInterface;
 use ShieldCI\ShieldCIServiceProvider;
 use ShieldCI\Support\Composer;
@@ -29,6 +36,42 @@ class ShieldCIServiceProviderTest extends TestCase
         $parser = $this->app->make(ParserInterface::class);
 
         $this->assertInstanceOf(ParserInterface::class, $parser);
+    }
+
+    /** @test */
+    #[Test]
+    public function it_shares_one_ast_parser_between_concrete_and_interface_resolution(): void
+    {
+        $parser = $this->app->make(AstParser::class);
+
+        $this->assertSame($parser, $this->app->make(AstParser::class));
+        $this->assertSame($parser, $this->app->make(ParserInterface::class));
+    }
+
+    /** @test */
+    #[Test]
+    public function analyzers_type_hinting_the_concrete_parser_receive_the_shared_singleton(): void
+    {
+        $singleton = $this->app->make(ParserInterface::class);
+
+        $analyzerClasses = [
+            AuthenticationAnalyzer::class,
+            MassAssignmentAnalyzer::class,
+            FillableForeignKeyAnalyzer::class,
+            LoginThrottlingAnalyzer::class,
+            FatModelAnalyzer::class,
+            ServiceContainerResolutionAnalyzer::class,
+        ];
+
+        foreach ($analyzerClasses as $class) {
+            $analyzer = $this->app->make($class);
+            $parser = (new \ReflectionProperty($class, 'parser'))->getValue($analyzer);
+
+            $this->assertSame($singleton, $parser, sprintf(
+                '%s must receive the shared AstParser singleton so its AST cache is cleared between analyzers.',
+                $class
+            ));
+        }
     }
 
     /** @test */

--- a/tests/Unit/Support/MemoryLimitTest.php
+++ b/tests/Unit/Support/MemoryLimitTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Support;
+
+use PHPUnit\Framework\Attributes\Test;
+use ShieldCI\Support\MemoryLimit;
+use ShieldCI\Tests\TestCase;
+
+class MemoryLimitTest extends TestCase
+{
+    /** @test */
+    #[Test]
+    public function it_converts_ini_style_limits_to_bytes(): void
+    {
+        $this->assertSame(536870912.0, MemoryLimit::toBytes('512M'));
+        $this->assertSame(1073741824.0, MemoryLimit::toBytes('1G'));
+        $this->assertSame(131072.0, MemoryLimit::toBytes('128k'));
+        $this->assertSame(1024.0, MemoryLimit::toBytes('1K'));
+        $this->assertSame(262144.0, MemoryLimit::toBytes('262144'));
+        $this->assertSame(INF, MemoryLimit::toBytes('-1'));
+    }
+
+    /** @test */
+    #[Test]
+    public function it_returns_null_for_unparseable_limits(): void
+    {
+        $this->assertNull(MemoryLimit::toBytes(''));
+        $this->assertNull(MemoryLimit::toBytes('abc'));
+        $this->assertNull(MemoryLimit::toBytes('12MB'));
+        $this->assertNull(MemoryLimit::toBytes('1.5G'));
+        $this->assertNull(MemoryLimit::toBytes('-2'));
+    }
+
+    /** @test */
+    #[Test]
+    public function it_raises_only_when_configured_limit_is_higher(): void
+    {
+        $this->assertTrue(MemoryLimit::shouldRaise('128M', '512M'));
+        $this->assertTrue(MemoryLimit::shouldRaise('1G', '2048M'));
+
+        $this->assertFalse(MemoryLimit::shouldRaise('2048M', '512M'));
+        $this->assertFalse(MemoryLimit::shouldRaise('512M', '512M'));
+    }
+
+    /** @test */
+    #[Test]
+    public function it_never_lowers_an_unlimited_current_limit(): void
+    {
+        $this->assertFalse(MemoryLimit::shouldRaise('-1', '512M'));
+        $this->assertFalse(MemoryLimit::shouldRaise('-1', '-1'));
+    }
+
+    /** @test */
+    #[Test]
+    public function it_raises_a_finite_limit_to_unlimited(): void
+    {
+        $this->assertTrue(MemoryLimit::shouldRaise('512M', '-1'));
+    }
+
+    /** @test */
+    #[Test]
+    public function it_handles_unparseable_values_conservatively(): void
+    {
+        // Unparseable configured value: never apply it.
+        $this->assertFalse(MemoryLimit::shouldRaise('512M', 'nonsense'));
+
+        // Unparseable current value: trust the configured limit.
+        $this->assertTrue(MemoryLimit::shouldRaise('nonsense', '512M'));
+    }
+}


### PR DESCRIPTION
Fixes `shield:analyze` exhausting the PHP memory limit on multi-megabyte codebases (reported on Vapor: fatal at 1024M in php-parser mid-run on a ~540-file app).

- Six analyzers type-hint the concrete `AstParser`, so the container gave each a private instance whose AST cache was invisible to the per-analyzer `clearParserCache()` — the concrete class is now bound to the same singleton.
- `InspectsCode` / `EnvCallAnalyzer` lazily create their own parsers; they now implement `clearAstParserCache()`, making the existing (previously dead) call sites effective for free-package analyzers.
- `clearParserCache()` now also runs `gc_collect_cycles()`: `ParentConnectingVisitor` leaves child↔parent cycles in ASTs that refcounting alone cannot reclaim.
- `shieldci.memory_limit` is now a floor — `ini_set` runs after every php.ini layer, so the old unconditional set silently overrode the deployment's effective limit (in the reported case lowering the runtime default of 2048M to 1024M inside a 4 GB Lambda).

Verified against the reporting app: previously fatal at 1024M around analyzer 37/73; now completes all 73 analyzers under a 512M cap.