### PR TITLE
fix: route method-local AstParser instances through the shared parser

### DIFF
--- a/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
+++ b/src/Analyzers/BestPractices/ChunkMissingAnalyzer.php
@@ -10,7 +10,6 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\PrettyPrinter\Standard;
 use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
-use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
@@ -25,7 +24,7 @@ use ShieldCI\Support\SeededTableScanner;
 class ChunkMissingAnalyzer extends AbstractFileAnalyzer
 {
     public function __construct(
-        private ParserInterface $parser
+        private AstParser $parser
     ) {}
 
     protected function metadata(): AnalyzerMetadata
@@ -49,9 +48,8 @@ class ChunkMissingAnalyzer extends AbstractFileAnalyzer
         // Tiny seeded reference-catalogue tables (plans, pillars, …) are bounded by
         // construction, so looping over them is not a chunking problem. Scan once; the
         // set is empty when there is no database/seeders/ directory.
-        $astParser = new AstParser;
-        $catalogueTables = (new SeededTableScanner($astParser))->catalogueTables($this->getBasePath()) ?? [];
-        $tableResolver = new ModelTableResolver($astParser);
+        $catalogueTables = (new SeededTableScanner($this->parser))->catalogueTables($this->getBasePath()) ?? [];
+        $tableResolver = new ModelTableResolver($this->parser);
 
         foreach ($phpFiles as $file) {
             try {

--- a/src/Analyzers/Security/CsrfAnalyzer.php
+++ b/src/Analyzers/Security/CsrfAnalyzer.php
@@ -31,6 +31,10 @@ use ShieldCI\Support\BootstrapRouteParser;
  */
 class CsrfAnalyzer extends AbstractFileAnalyzer
 {
+    public function __construct(
+        private AstParser $parser
+    ) {}
+
     protected function metadata(): AnalyzerMetadata
     {
         return new AnalyzerMetadata(
@@ -93,7 +97,7 @@ class CsrfAnalyzer extends AbstractFileAnalyzer
 
         // Compute route files covered by web/API middleware via external registration
         // (require from web.php/api.php, or Route::middleware()->group() in bootstrap/app.php)
-        $bootstrapParser = new BootstrapRouteParser($this->getBasePath(), new AstParser);
+        $bootstrapParser = new BootstrapRouteParser($this->getBasePath(), $this->parser);
         $webProtectedFiles = $bootstrapParser->getWebProtectedRouteFiles();
         $apiRegisteredFiles = $bootstrapParser->getApiRegisteredRouteFiles();
 

--- a/src/Analyzers/Security/DebugModeAnalyzer.php
+++ b/src/Analyzers/Security/DebugModeAnalyzer.php
@@ -39,6 +39,10 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
 {
     use ClassifiesFiles;
 
+    public function __construct(
+        private AstParser $parser
+    ) {}
+
     private const HIGH_SEVERITY_FUNCTIONS = ['dd', 'dump', 'var_dump', 'print_r'];
 
     /** @var list<string> */
@@ -248,7 +252,6 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
      */
     private function checkDebugFunctions(array &$issues): void
     {
-        $astParser = new AstParser;
         $nodeFinder = new NodeFinder;
 
         foreach ($this->getPhpFiles() as $file) {
@@ -257,7 +260,7 @@ class DebugModeAnalyzer extends AbstractFileAnalyzer
                 continue;
             }
 
-            $ast = $astParser->parseFile($file);
+            $ast = $this->parser->parseFile($file);
 
             if ($ast === []) {
                 continue;

--- a/src/Analyzers/Security/HSTSHeaderAnalyzer.php
+++ b/src/Analyzers/Security/HSTSHeaderAnalyzer.php
@@ -12,7 +12,6 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
-use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\AnalyzersCore\Support\ConfigFileHelper;
 use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
@@ -149,15 +148,15 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
             return false;
         }
 
-        $astParser = new AstParser;
-        $ast = $astParser->parseFile($providerPath);
+        $this->initializeParser();
+        $ast = $this->parser->parseFile($providerPath);
 
         if ($ast === []) {
             return false;
         }
 
         // Check for URL::forceScheme('https')
-        $forceSchemeCallNodes = $astParser->findStaticCalls($ast, 'URL', 'forceScheme');
+        $forceSchemeCallNodes = $this->parser->findStaticCalls($ast, 'URL', 'forceScheme');
 
         foreach ($forceSchemeCallNodes as $call) {
             /** @var StaticCall $call */
@@ -171,7 +170,7 @@ class HSTSHeaderAnalyzer extends AbstractFileAnalyzer
 
         // Check for URL::forceHttps() — inspect the $force argument to avoid false positives
         // when forceHttps(false) is used to explicitly disable HTTPS enforcement.
-        $forceHttpsCallNodes = $astParser->findStaticCalls($ast, 'URL', 'forceHttps');
+        $forceHttpsCallNodes = $this->parser->findStaticCalls($ast, 'URL', 'forceHttps');
 
         foreach ($forceHttpsCallNodes as $call) {
             /** @var StaticCall $call */

--- a/src/Analyzers/Security/XssAnalyzer.php
+++ b/src/Analyzers/Security/XssAnalyzer.php
@@ -101,7 +101,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
      */
     private const SUPERGLOBAL_NAMES = ['_GET', '_POST', '_REQUEST', '_COOKIE', '_FILES'];
 
-    public function __construct(Router $router, Kernel $kernel)
+    public function __construct(Router $router, Kernel $kernel, private AstParser $parser)
     {
         $this->router = $router;
         $this->kernel = $kernel;
@@ -331,8 +331,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
      */
     private function analyzePhpFileWithAst(string $file): array
     {
-        $astParser = new AstParser;
-        $ast = $astParser->parseFile($file);
+        $ast = $this->parser->parseFile($file);
 
         if ($ast === []) {
             return [];
@@ -374,7 +373,7 @@ class XssAnalyzer extends AbstractFileAnalyzer
 
         // 2. Find Response::make() with user input
         /** @var StaticCall[] $responseMakeCalls */
-        $responseMakeCalls = $astParser->findStaticCalls($ast, 'Response', 'make');
+        $responseMakeCalls = $this->parser->findStaticCalls($ast, 'Response', 'make');
 
         foreach ($responseMakeCalls as $call) {
             $argNode = $call->args[0] ?? null;

--- a/tests/Unit/Analyzers/Security/CsrfAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/CsrfAnalyzerTest.php
@@ -13,7 +13,7 @@ class CsrfAnalyzerTest extends AnalyzerTestCase
 {
     protected function createAnalyzer(): AnalyzerInterface
     {
-        return new CsrfAnalyzer;
+        return new CsrfAnalyzer($this->parser);
     }
 
     // ==================== Blade Form CSRF Tests (10 tests) ====================

--- a/tests/Unit/Analyzers/Security/DebugModeAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/DebugModeAnalyzerTest.php
@@ -13,7 +13,7 @@ class DebugModeAnalyzerTest extends AnalyzerTestCase
 {
     protected function createAnalyzer(): AnalyzerInterface
     {
-        return new DebugModeAnalyzer;
+        return new DebugModeAnalyzer($this->parser);
     }
 
     // =================================================================

--- a/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
@@ -32,7 +32,7 @@ class XssAnalyzerTest extends AnalyzerTestCase
             throw new \RuntimeException('Router or Kernel not available in test application');
         }
 
-        return new XssAnalyzer($router, $kernel);
+        return new XssAnalyzer($router, $kernel, $this->parser);
     }
 
     /**
@@ -63,7 +63,7 @@ class XssAnalyzerTest extends AnalyzerTestCase
             throw new \RuntimeException('Router or Kernel not available in test application');
         }
 
-        $analyzer = new XssAnalyzer($router, $kernel);
+        $analyzer = new XssAnalyzer($router, $kernel, $this->parser);
 
         // Explicitly mark as a web app so the HTTP header check is not skipped.
         // The test environment has no session routes, so without this override

--- a/tests/Unit/ShieldCIServiceProviderTest.php
+++ b/tests/Unit/ShieldCIServiceProviderTest.php
@@ -7,12 +7,16 @@ namespace ShieldCI\Tests\Unit;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use ShieldCI\AnalyzerManager;
+use ShieldCI\Analyzers\BestPractices\ChunkMissingAnalyzer;
 use ShieldCI\Analyzers\BestPractices\FatModelAnalyzer;
 use ShieldCI\Analyzers\BestPractices\ServiceContainerResolutionAnalyzer;
 use ShieldCI\Analyzers\Security\AuthenticationAnalyzer;
+use ShieldCI\Analyzers\Security\CsrfAnalyzer;
+use ShieldCI\Analyzers\Security\DebugModeAnalyzer;
 use ShieldCI\Analyzers\Security\FillableForeignKeyAnalyzer;
 use ShieldCI\Analyzers\Security\LoginThrottlingAnalyzer;
 use ShieldCI\Analyzers\Security\MassAssignmentAnalyzer;
+use ShieldCI\Analyzers\Security\XssAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
 use ShieldCI\AnalyzersCore\Support\AstParser;
 use ShieldCI\Contracts\ReporterInterface;
@@ -61,6 +65,10 @@ class ShieldCIServiceProviderTest extends TestCase
             LoginThrottlingAnalyzer::class,
             FatModelAnalyzer::class,
             ServiceContainerResolutionAnalyzer::class,
+            ChunkMissingAnalyzer::class,
+            CsrfAnalyzer::class,
+            DebugModeAnalyzer::class,
+            XssAnalyzer::class,
         ];
 
         foreach ($analyzerClasses as $class) {


### PR DESCRIPTION
Follow-up to #302: five analyzers still created method-local `new AstParser` instances that bypassed the shared singleton — `XssAnalyzer` built one per analyzed file, `DebugModeAnalyzer`'s scan loop accumulated a private unmanaged AST cache, and `CsrfAnalyzer`/`ChunkMissingAnalyzer`/`HSTSHeaderAnalyzer` re-parsed files the shared cache may already hold.

- `XssAnalyzer`, `DebugModeAnalyzer`, `CsrfAnalyzer`: constructor-inject the singleton (same pattern as the #302 six).
- `ChunkMissingAnalyzer`: narrow the existing `ParserInterface` hint to `AstParser` and pass its injected parser to `SeededTableScanner`/`ModelTableResolver` (the hint mismatch was why a second parser existed).
- `HSTSHeaderAnalyzer`: reuse its `InspectsCode` trait parser, which `clearAstParserCache()` already releases.

The provider test now proves the container hands all ten concrete-typed analyzers the shared singleton.