### PR TITLE
fix: resolve string middleware aliases in authentication-authorization analyzer

### DIFF
--- a/src/Analyzers/Security/AuthenticationAnalyzer.php
+++ b/src/Analyzers/Security/AuthenticationAnalyzer.php
@@ -59,6 +59,15 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
     private array $resolvedAuthMiddleware = [];
 
     /**
+     * Memoized middleware alias => FQCN map, parsed from bootstrap/app.php
+     * (`$middleware->alias([...])`) and app/Http/Kernel.php ($middlewareAliases
+     * / legacy $routeMiddleware). Null until first resolved.
+     *
+     * @var array<string, string>|null
+     */
+    private ?array $middlewareAliasMap = null;
+
+    /**
      * Map of controller methods that are intentionally public.
      * Format: ['ControllerClass::method' => true]
      *
@@ -522,8 +531,10 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
     /**
      * Check whether the effective middleware list provides authentication.
      *
-     * Handles: 'auth', 'auth:api', 'can:ability', 'role:admin', 'permission:x',
-     * and fully-qualified custom auth middleware class names.
+     * Handles: 'auth', 'auth:api', 'auth.basic', 'can:ability', 'role:admin',
+     * 'permission:x', fully-qualified custom auth middleware class names, and
+     * bare string aliases that resolve (via bootstrap/app.php or Kernel) to a
+     * custom auth middleware class.
      *
      * @param  list<string>  $middleware
      */
@@ -535,7 +546,21 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
             }
 
             // Class-like strings (contain backslash = FQCN from NameResolver)
-            if (str_contains($mw, '\\') && $this->isCustomAuthMiddlewareClass($mw)) {
+            if (str_contains($mw, '\\')) {
+                if ($this->isCustomAuthMiddlewareClass($mw)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            // Bare string alias (e.g. 'device.token', 'device.token:param') —
+            // resolve via the app's alias map, then introspect the target class
+            // for auth signals. The map is memoized, so common 'auth' routes
+            // never trigger this lookup.
+            $alias = explode(':', $mw, 2)[0];
+            $aliasMap = $this->resolveMiddlewareAliases();
+            if (isset($aliasMap[$alias]) && $this->isCustomAuthMiddlewareClass($aliasMap[$alias])) {
                 return true;
             }
         }
@@ -1459,13 +1484,19 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
 
     /**
      * Check if a middleware name represents authentication middleware.
-     * Supports: auth, auth:api, auth:sanctum, auth:web, etc.
+     * Supports: auth, auth:api, auth:sanctum, auth:web, and the built-in
+     * HTTP Basic auth alias auth.basic (optionally auth.basic:guard,field).
      */
     private function isAuthMiddleware(string $middleware): bool
     {
+        $middleware = trim($middleware);
+
         // Match 'auth' optionally followed by a colon and guard name
         // Examples: 'auth', 'auth:api', 'auth:sanctum', 'auth:web'
-        return (bool) preg_match('/^auth(?::[a-zA-Z0-9_-]+)?$/i', trim($middleware));
+        // The built-in 'auth.basic' alias challenges and rejects unauthenticated
+        // requests, so it counts as authentication too.
+        return (bool) preg_match('/^auth(?::[a-zA-Z0-9_-]+)?$/i', $middleware)
+            || (bool) preg_match('/^auth\.basic(?::.+)?$/i', $middleware);
     }
 
     /**
@@ -1625,6 +1656,166 @@ class AuthenticationAnalyzer extends AbstractFileAnalyzer
         $this->resolvedAuthMiddleware[$fqcn] = $isAuth;
 
         return $isAuth;
+    }
+
+    /**
+     * Resolve the app's middleware alias => FQCN map, memoized.
+     *
+     * Combines aliases declared in bootstrap/app.php (Laravel 11+
+     * `$middleware->alias([...])`) and app/Http/Kernel.php ($middlewareAliases /
+     * legacy $routeMiddleware). Missing files simply contribute nothing, so an
+     * unresolvable bare alias falls through unchanged.
+     *
+     * @return array<string, string>
+     */
+    private function resolveMiddlewareAliases(): array
+    {
+        if ($this->middlewareAliasMap !== null) {
+            return $this->middlewareAliasMap;
+        }
+
+        return $this->middlewareAliasMap = array_merge(
+            $this->extractKernelAliasMap($this->buildPath('app/Http/Kernel.php')),
+            $this->extractBootstrapAliasMap($this->buildPath('bootstrap/app.php')),
+        );
+    }
+
+    /**
+     * Extract the alias map from bootstrap/app.php's `$middleware->alias([...])`
+     * calls (Laravel 11+).
+     *
+     * @return array<string, string>
+     */
+    private function extractBootstrapAliasMap(string $file): array
+    {
+        if (! is_file($file)) {
+            return [];
+        }
+
+        $ast = $this->parser->parseFile($file);
+        if (empty($ast)) {
+            return [];
+        }
+
+        // Resolve names WITHOUT replacing nodes so ::class values expose a
+        // `resolvedName` attribute (used by resolveClassFqcn) while leaving the
+        // shared, mtime-cached AST untouched for other consumers.
+        $this->parser->resolveNames($ast, ['replaceNodes' => false]);
+
+        $map = [];
+
+        foreach ($this->parser->findMethodCalls($ast, 'alias') as $call) {
+            if (! ($call instanceof Node\Expr\MethodCall)) {
+                continue;
+            }
+
+            // Middleware::alias() takes exactly one array argument; the shape
+            // filter also rejects any unrelated ->alias(...) call.
+            if (count($call->args) !== 1) {
+                continue;
+            }
+
+            $arg = $call->args[0];
+            if (! ($arg instanceof Node\Arg) || ! ($arg->value instanceof Node\Expr\Array_)) {
+                continue;
+            }
+
+            $map = array_merge($map, $this->extractAliasMapFromArray($arg->value));
+        }
+
+        return $map;
+    }
+
+    /**
+     * Extract the alias map from app/Http/Kernel.php's $middlewareAliases
+     * (Laravel 10) or legacy $routeMiddleware (Laravel 8/9) property.
+     *
+     * @return array<string, string>
+     */
+    private function extractKernelAliasMap(string $file): array
+    {
+        if (! is_file($file)) {
+            return [];
+        }
+
+        $ast = $this->parser->parseFile($file);
+        if (empty($ast)) {
+            return [];
+        }
+
+        $this->parser->resolveNames($ast, ['replaceNodes' => false]);
+
+        $map = [];
+
+        foreach ($this->parser->findClasses($ast) as $class) {
+            foreach ($class->stmts as $stmt) {
+                if (! ($stmt instanceof Node\Stmt\Property)) {
+                    continue;
+                }
+
+                $name = $stmt->props[0]->name->toString();
+                if ($name !== 'middlewareAliases' && $name !== 'routeMiddleware') {
+                    continue;
+                }
+
+                $default = $stmt->props[0]->default ?? null;
+                if (! ($default instanceof Node\Expr\Array_)) {
+                    continue;
+                }
+
+                $map = array_merge($map, $this->extractAliasMapFromArray($default));
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Turn an array literal of ['alias' => Class::class | 'Fqcn'] pairs into an
+     * alias => FQCN map. Non-string keys and unrecognised values are skipped.
+     *
+     * @return array<string, string>
+     */
+    private function extractAliasMapFromArray(Node\Expr\Array_ $array): array
+    {
+        $map = [];
+
+        foreach ($array->items as $item) {
+            if (! ($item instanceof Node\Expr\ArrayItem)) {
+                continue;
+            }
+
+            if (! ($item->key instanceof Node\Scalar\String_)) {
+                continue;
+            }
+
+            $alias = $item->key->value;
+
+            if ($item->value instanceof Node\Expr\ClassConstFetch) {
+                // ::class value — read the FQCN from the NameResolver attribute
+                // (populated by resolveNames(..., ['replaceNodes' => false])).
+                $classNode = $item->value->class;
+                if (! ($classNode instanceof Node\Name)) {
+                    continue;
+                }
+                $resolved = $classNode->getAttribute('resolvedName');
+                $fqcn = $resolved instanceof Node\Name\FullyQualified
+                    ? $resolved->toString()
+                    : $classNode->toString();
+            } elseif ($item->value instanceof Node\Scalar\String_) {
+                $fqcn = ltrim($item->value->value, '\\');
+            } else {
+                continue;
+            }
+
+            if ($fqcn === '') {
+                continue;
+            }
+
+            $map[$alias] = $fqcn;
+        }
+
+        return $map;
     }
 }
 

--- a/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/AuthenticationAnalyzerTest.php
@@ -4007,6 +4007,567 @@ PHP;
         $this->assertHasIssueContaining('POST route without authentication middleware', $result);
     }
 
+    // ==========================================
+    // String middleware alias resolution (#307)
+    // ==========================================
+
+    public function test_passes_route_group_with_string_aliased_custom_auth_middleware_via_bootstrap(): void
+    {
+        // #307 exact repro: a custom auth middleware attached by a STRING ALIAS
+        // registered in bootstrap/app.php (Laravel 11+) must be recognised as
+        // authentication — clearing both the route finding and the dependent
+        // "sensitive method" controller finding.
+        $bootstrap = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->alias([
+            'device.token' => \App\Http\Middleware\EnsureDeviceToken::class,
+        ]);
+    })
+    ->create();
+PHP;
+
+        $middleware = <<<'PHP'
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\AuthenticationException;
+
+class EnsureDeviceToken
+{
+    public function handle($request, $next)
+    {
+        $token = $request->bearerToken();
+        if (! $token) {
+            throw new AuthenticationException('Device not registered');
+        }
+        return $next($request);
+    }
+}
+PHP;
+
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\ScanController;
+
+Route::middleware(['device.token', 'throttle:scan'])->prefix('reception/device')->group(function () {
+    Route::post('scan', [ScanController::class, 'store']);
+});
+PHP;
+
+        $controller = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+class ScanController extends Controller
+{
+    public function store()
+    {
+        return response()->json(['ok' => true]);
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrap,
+            'app/Http/Middleware/EnsureDeviceToken.php' => $middleware,
+            'routes/api.php' => $routes,
+            'app/Http/Controllers/ScanController.php' => $controller,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_route_with_string_alias_from_kernel_middleware_aliases(): void
+    {
+        // Laravel 10 style: alias declared in app/Http/Kernel.php $middlewareAliases.
+        $kernel = <<<'PHP'
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $middlewareAliases = [
+        'device.token' => \App\Http\Middleware\EnsureDeviceToken::class,
+    ];
+}
+PHP;
+
+        $middleware = <<<'PHP'
+<?php
+
+namespace App\Http\Middleware;
+
+class EnsureDeviceToken
+{
+    public function handle($request, $next)
+    {
+        $token = $request->bearerToken();
+        if (! $token) {
+            abort(401);
+        }
+        return $next($request);
+    }
+}
+PHP;
+
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\ScanController;
+
+Route::post('/reception/scan', [ScanController::class, 'store'])->middleware(['device.token']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Kernel.php' => $kernel,
+            'app/Http/Middleware/EnsureDeviceToken.php' => $middleware,
+            'routes/api.php' => $routes,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_route_with_string_alias_from_legacy_route_middleware(): void
+    {
+        // Laravel 8/9 style: alias declared in the older $routeMiddleware property.
+        $kernel = <<<'PHP'
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $routeMiddleware = [
+        'device.token' => \App\Http\Middleware\EnsureDeviceToken::class,
+    ];
+}
+PHP;
+
+        $middleware = <<<'PHP'
+<?php
+
+namespace App\Http\Middleware;
+
+class EnsureDeviceToken
+{
+    public function handle($request, $next)
+    {
+        if (! $request->bearerToken()) {
+            abort(401);
+        }
+        return $next($request);
+    }
+}
+PHP;
+
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\ScanController;
+
+Route::post('/reception/scan', [ScanController::class, 'store'])->middleware(['device.token']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Kernel.php' => $kernel,
+            'app/Http/Middleware/EnsureDeviceToken.php' => $middleware,
+            'routes/api.php' => $routes,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_route_with_string_alias_value_as_plain_fqcn_string(): void
+    {
+        // Alias value written as a plain string FQCN (with a leading backslash)
+        // rather than ::class — must be normalised before class introspection.
+        $kernel = <<<'PHP'
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $routeMiddleware = [
+        'device.token' => '\App\Http\Middleware\EnsureDeviceToken',
+    ];
+}
+PHP;
+
+        $middleware = <<<'PHP'
+<?php
+
+namespace App\Http\Middleware;
+
+class EnsureDeviceToken
+{
+    public function handle($request, $next)
+    {
+        if (! $request->bearerToken()) {
+            abort(401);
+        }
+        return $next($request);
+    }
+}
+PHP;
+
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\ScanController;
+
+Route::post('/reception/scan', [ScanController::class, 'store'])->middleware(['device.token']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Http/Kernel.php' => $kernel,
+            'app/Http/Middleware/EnsureDeviceToken.php' => $middleware,
+            'routes/api.php' => $routes,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_route_with_string_alias_and_middleware_parameter(): void
+    {
+        // The alias token carries a parameter ('device.token:tenant'); only the
+        // alias name (before the first colon) is used for map resolution.
+        $bootstrap = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->alias([
+            'device.token' => \App\Http\Middleware\EnsureDeviceToken::class,
+        ]);
+    })
+    ->create();
+PHP;
+
+        $middleware = <<<'PHP'
+<?php
+
+namespace App\Http\Middleware;
+
+class EnsureDeviceToken
+{
+    public function handle($request, $next, $tenant = null)
+    {
+        if (! $request->bearerToken()) {
+            abort(401);
+        }
+        return $next($request);
+    }
+}
+PHP;
+
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\ScanController;
+
+Route::post('/reception/scan', [ScanController::class, 'store'])->middleware(['device.token:tenant']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrap,
+            'app/Http/Middleware/EnsureDeviceToken.php' => $middleware,
+            'routes/api.php' => $routes,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_route_with_auth_basic_middleware(): void
+    {
+        // The built-in 'auth.basic' alias (HTTP Basic auth) is authentication.
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\InternalController;
+
+Route::post('/internal/sync', [InternalController::class, 'store'])->middleware('auth.basic');
+PHP;
+
+        $tempDir = $this->createTempDirectory(['routes/api.php' => $routes]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_flags_route_with_string_alias_to_non_auth_middleware(): void
+    {
+        // Negative control: an alias resolving to a NON-auth middleware must
+        // still be flagged — resolution introspects the target, it does not
+        // trust the alias blindly.
+        $bootstrap = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->alias([
+            'audit.log' => \App\Http\Middleware\LogRequests::class,
+        ]);
+    })
+    ->create();
+PHP;
+
+        $middleware = <<<'PHP'
+<?php
+
+namespace App\Http\Middleware;
+
+class LogRequests
+{
+    public function handle($request, $next)
+    {
+        logger()->info('Request logged: ' . $request->url());
+        return $next($request);
+    }
+}
+PHP;
+
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\ScanController;
+
+Route::post('/reception/scan', [ScanController::class, 'store'])->middleware(['audit.log']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrap,
+            'app/Http/Middleware/LogRequests.php' => $middleware,
+            'routes/api.php' => $routes,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('POST route without authentication middleware', $result);
+    }
+
+    public function test_flags_route_with_string_alias_but_no_alias_registration(): void
+    {
+        // Negative control (empty-map safety): a bare alias with no bootstrap or
+        // Kernel registration cannot be resolved, so the route stays flagged.
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\ScanController;
+
+Route::post('/reception/scan', [ScanController::class, 'store'])->middleware(['device.token']);
+PHP;
+
+        $tempDir = $this->createTempDirectory(['routes/api.php' => $routes]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('POST route without authentication middleware', $result);
+    }
+
+    public function test_flags_route_with_unregistered_string_alias(): void
+    {
+        // Negative control: the map resolves 'device.token', but the route uses a
+        // DIFFERENT, unregistered alias — resolution is per-alias, not blanket.
+        $bootstrap = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->alias([
+            'device.token' => \App\Http\Middleware\EnsureDeviceToken::class,
+        ]);
+    })
+    ->create();
+PHP;
+
+        $middleware = <<<'PHP'
+<?php
+
+namespace App\Http\Middleware;
+
+class EnsureDeviceToken
+{
+    public function handle($request, $next)
+    {
+        if (! $request->bearerToken()) {
+            abort(401);
+        }
+        return $next($request);
+    }
+}
+PHP;
+
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\ScanController;
+
+Route::post('/reception/scan', [ScanController::class, 'store'])->middleware(['other.token']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrap,
+            'app/Http/Middleware/EnsureDeviceToken.php' => $middleware,
+            'routes/api.php' => $routes,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('POST route without authentication middleware', $result);
+    }
+
+    public function test_flags_route_protected_only_by_throttle_alias(): void
+    {
+        // Negative control: stripping the ':param' for alias lookup must not turn
+        // a non-auth built-in like 'throttle:scan' into authentication.
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\ScanController;
+
+Route::post('/reception/scan', [ScanController::class, 'store'])->middleware(['throttle:scan']);
+PHP;
+
+        $tempDir = $this->createTempDirectory(['routes/api.php' => $routes]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('POST route without authentication middleware', $result);
+    }
+
+    public function test_resolves_alias_despite_unrelated_alias_call_in_bootstrap(): void
+    {
+        // Robustness: an unrelated non-array ->alias() call elsewhere must not
+        // break parsing; the real string-keyed alias map is still resolved.
+        $bootstrap = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->alias([
+            'device.token' => \App\Http\Middleware\EnsureDeviceToken::class,
+        ]);
+    })
+    ->withExceptions(function ($exceptions): void {
+        $exceptions->alias('legacy', 'modern');
+    })
+    ->create();
+PHP;
+
+        $middleware = <<<'PHP'
+<?php
+
+namespace App\Http\Middleware;
+
+class EnsureDeviceToken
+{
+    public function handle($request, $next)
+    {
+        if (! $request->bearerToken()) {
+            abort(401);
+        }
+        return $next($request);
+    }
+}
+PHP;
+
+        $routes = <<<'PHP'
+<?php
+
+use App\Http\Controllers\ScanController;
+
+Route::post('/reception/scan', [ScanController::class, 'store'])->middleware(['device.token']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrap,
+            'app/Http/Middleware/EnsureDeviceToken.php' => $middleware,
+            'routes/api.php' => $routes,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
     public function test_passes_routes_in_group_with_intermediate_method_calls(): void
     {
         // Route::prefix()->middleware()->group() — the ->prefix() sits between the StaticCall


### PR DESCRIPTION
## Summary

`authentication-authorization` flagged routes protected by a **custom auth middleware attached via a string alias** as "route without authentication middleware", because the analyzer only recognised custom middleware referenced by FQCN. Aliases are the idiomatic way to attach middleware, so this produced false positives on genuinely authenticated route groups — and, via the shared route-auth stats, on the controllers they reach (the dependent "sensitive method without authentication check" findings).

Fixes #307.

## Root cause

`isRouteMiddlewareAuthenticated()` only attempted class recognition (`isCustomAuthMiddlewareClass()`) when the middleware token contained a backslash (a FQCN). A bare alias like `'device.token'` was never resolved back to its class, and the analyzer built no alias → class map.

## Fix

- Resolve a bare alias against a memoized `alias => FQCN` map parsed from `bootstrap/app.php` (`$middleware->alias([...])`, Laravel 11+) and `app/Http/Kernel.php` (`$middlewareAliases`, plus legacy `$routeMiddleware`), then run the existing source-signal check on the resolved class. An alias resolving to a non-auth middleware is still flagged, since resolution introspects the target rather than trusting the alias.
- Recognise the built-in `auth.basic` alias (HTTP Basic auth) as authentication.

Parsing reuses the existing AST helpers (`parseFile` / `resolveNames(['replaceNodes' => false])` / `findMethodCalls` / `findClasses`) and mirrors the `bootstrap/app.php` and Kernel-property patterns already used in the analyzer suite. `replaceNodes => false` is required so `::class` values expose a `resolvedName` attribute and the shared mtime-cached AST is left untouched for other consumers.

## Verification

- 11 new tests: the exact #307 reproduction (bootstrap alias + route group + controller cascade), Kernel `$middlewareAliases` / legacy `$routeMiddleware`, plain-string FQCN alias values, alias-with-parameter, `auth.basic`, plus negative controls (alias → non-auth middleware, no registration, unregistered alias, throttle-only) that must still flag.
- Full suite green (4475 tests, 0 failures); PHPStan level 9 clean on the changed source; Pint clean.
