### PR TITLE
fix: eliminate login-throttling false positives on Sanctum-style APIs

### DIFF
--- a/src/Analyzers/Security/LoginThrottlingAnalyzer.php
+++ b/src/Analyzers/Security/LoginThrottlingAnalyzer.php
@@ -81,6 +81,10 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
             $hasApiMiddlewareThrottle = $this->hasThrottleInLaravel11Middleware('api');
         }
 
+        // NOTE: web and api throttle signals are collapsed into one flag, so an
+        // api-only throttle (e.g. throttleApi()) also suppresses unthrottled web
+        // /login findings. Pre-existing behaviour; splitting web vs api suppression
+        // would be a separate change.
         $hasGlobalThrottling = $hasLoginRateLimiting || $hasWebMiddlewareThrottle || $hasApiMiddlewareThrottle;
 
         // Check route files for login routes without throttling
@@ -603,6 +607,14 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
             return false;
         }
 
+        // Canonical Laravel 11+ helper: $middleware->throttleApi() injects
+        // throttle:api into the api group at runtime (with or without arguments).
+        // It only affects the api group — there is no throttleWeb() equivalent —
+        // and throttleWithRedis() merely swaps the driver, so it must not count.
+        if ($group === 'api' && preg_match('/\$middleware\s*->\s*throttleApi\s*\(/s', $content) === 1) {
+            return true;
+        }
+
         // Look for $middleware->{group}() containing ThrottleRequests or 'throttle'
         // Pattern: $middleware->web(...) or $middleware->api(...)
         $pattern = '/\$middleware\s*->\s*'.preg_quote($group, '/').'\s*\(/s';
@@ -660,43 +672,27 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
 
                 $lines = FileParser::getLines($filePath);
 
-                // Track route groups for context
-                // NOTE: This uses brace-depth tracking which can drift with string literals containing braces,
-                // heredocs, or complex nested structures. AST-based route group detection would be more robust
-                // but requires parsing route files as PHP AST, which can be complex due to facade calls.
-                // TODO: Consider migrating to AST-based route group detection for better accuracy.
-                $inWebGroup = false;
-                $groupDepth = 0;
-                $braceDepth = 0;
+                // AST-derived line ranges of throttled route groups (fluent and
+                // array forms, nesting-safe) — replaces the former brace-depth
+                // heuristic. A route whose line sits inside a range is covered by
+                // group-level throttling.
+                $throttledRanges = $bootstrapParser->getThrottledGroupLineRanges($filePath);
 
                 foreach ($lines as $lineNumber => $line) {
                     if (! is_string($line)) {
                         continue;
                     }
 
-                    // Track brace depth for group nesting (heuristic - can drift)
-                    $braceDepth += substr_count($line, '{') - substr_count($line, '}');
-
-                    // Detect Route::group with middleware
-                    if (preg_match('/Route::group\s*\(\s*\[/i', $line)) {
-                        $groupDepth = $braceDepth;
-                        // Check if group has throttle middleware
-                        if (preg_match('/["\']middleware["\']\s*=>\s*.*["\']throttle/i', $line)) {
-                            $inWebGroup = true;
-                        }
-                    }
-
-                    // Exit group when braces close
-                    if ($inWebGroup && $braceDepth <= $groupDepth - 1) {
-                        $inWebGroup = false;
-                    }
+                    // FileParser::getLines is 0-based; findings report $lineNumber + 1,
+                    // which is the 1-based scale the AST ranges use.
+                    $inThrottledGroup = $this->lineInRanges($lineNumber + 1, $throttledRanges);
 
                     // Check for Auth::routes() helper
                     if (preg_match('/Auth::routes\s*\(/i', $line)) {
                         // Auth::routes() includes login routes - check if throttled
                         $hasThrottle = $this->checkRouteHasThrottling($lines, $lineNumber);
 
-                        if (! $hasThrottle && ! $hasGlobalThrottling && ! $inWebGroup) {
+                        if (! $hasThrottle && ! $hasGlobalThrottling && ! $inThrottledGroup) {
                             $issues[] = $this->createIssueWithSnippet(
                                 message: 'Auth::routes() includes login endpoint without explicit rate limiting',
                                 filePath: $filePath,
@@ -730,8 +726,19 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
                     }
 
                     if ($routeUri !== null) {
+                        // Skip endpoints matched only on the broad 'auth'/'oauth'
+                        // substring whose action segment is a non-credential one
+                        // (token revocation / identity reads). The credential-keyword
+                        // guard ensures a real login/token route is never suppressed.
+                        $segments = explode('/', trim((string) strtok($routeUri, '?'), '/'));
+                        $lastSegment = strtolower((string) end($segments));
+                        $isCredentialUri = preg_match('/login|signin|authenticate|token/i', $routeUri) === 1;
+                        if (! $isCredentialUri && in_array($lastSegment, ['logout', 'signout', 'me'], true)) {
+                            continue;
+                        }
+
                         // Check if this route or surrounding lines have throttle middleware
-                        $hasThrottle = $this->checkRouteHasThrottling($lines, $lineNumber) || $inWebGroup;
+                        $hasThrottle = $this->checkRouteHasThrottling($lines, $lineNumber) || $inThrottledGroup;
 
                         if (! $hasThrottle && ! $hasGlobalThrottling) {
                             $routeType = $isApiRoute ? 'API authentication' : 'Login';
@@ -822,6 +829,22 @@ class LoginThrottlingAnalyzer extends AbstractFileAnalyzer
                preg_match('/->middleware\(\[.*["\']throttle/i', $line) ||  // Array with quotes
                preg_match('/->middleware\(["\'][^"\']*["\'],\s*["\']throttle/i', $line) ||  // Varargs
                preg_match('/ThrottleRequests::class/i', $line);  // Class reference
+    }
+
+    /**
+     * Whether a 1-based line falls within any of the given inclusive ranges.
+     *
+     * @param  array<int, array{start: int, end: int}>  $ranges
+     */
+    private function lineInRanges(int $line, array $ranges): bool
+    {
+        foreach ($ranges as $range) {
+            if ($line >= $range['start'] && $line <= $range['end']) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Support/BootstrapRouteParser.php
+++ b/src/Support/BootstrapRouteParser.php
@@ -23,6 +23,11 @@ use ShieldCI\AnalyzersCore\Contracts\ParserInterface;
  *      (inherit that file's middleware group automatically)
  *   2. Files registered via Route::middleware('web|api')->...->group(base_path('...'))
  *      in bootstrap/app.php's withRouting(then: ...) callback or in app/Providers/*.php
+ *
+ * It also exposes {@see self::getThrottledGroupLineRanges()} for the in-file case:
+ * the line spans of throttled Route::...->group(Closure) blocks declared directly
+ * inside a route file (fluent and array forms), used to tell whether a given route
+ * line is covered by group-level throttling.
  */
 class BootstrapRouteParser
 {
@@ -135,6 +140,131 @@ class BootstrapRouteParser
             $this->getFilesRegisteredWithThrottleMiddlewareInBootstrap(),
             $this->getFilesRegisteredWithThrottleMiddlewareInProvidersDir(),
         )));
+    }
+
+    /**
+     * Returns the line ranges of throttled Route::...->group(Closure) blocks
+     * declared inside the given route file. Covers both the fluent form
+     * (Route::middleware([...'throttle'...])->group(fn)) and the array form
+     * (Route::group(['middleware' => 'throttle...'], fn)), and is nesting-safe:
+     * overlapping ranges are returned as-is, so a route line inside any range
+     * is treated as covered. Path-argument groups (->group(base_path(...))) open
+     * no closure and are intentionally ignored here.
+     *
+     * @return array<int, array{start: int, end: int}>
+     */
+    public function getThrottledGroupLineRanges(string $filePath): array
+    {
+        if (! file_exists($filePath)) {
+            return [];
+        }
+
+        $ast = $this->parser->parseFile($filePath);
+        if (empty($ast)) {
+            return [];
+        }
+
+        $ranges = [];
+
+        // Fluent form: Route::middleware([...'throttle'...])->group(function () {...})
+        // Also covers ->group(['middleware' => 'throttle'], function () {...}).
+        foreach ($this->parser->findMethodCalls($ast, 'group') as $call) {
+            if (! ($call instanceof MethodCall)) {
+                continue;
+            }
+            $closure = $this->closureArgument($call->args);
+            if ($closure === null) {
+                continue;
+            }
+            if ($this->chainContainsThrottleMiddleware($call->var)
+                || $this->argsCarryThrottleMiddleware($call->args)) {
+                $ranges[] = ['start' => $closure->getStartLine(), 'end' => $closure->getEndLine()];
+            }
+        }
+
+        // Array form: Route::group(['middleware' => 'throttle...'], function () {...})
+        foreach ($this->parser->findNodes($ast, StaticCall::class) as $call) {
+            if (! ($call instanceof StaticCall)
+                || ! ($call->name instanceof Identifier)
+                || $call->name->name !== 'group') {
+                continue;
+            }
+            $closure = $this->closureArgument($call->args);
+            if ($closure === null) {
+                continue;
+            }
+            if ($this->argsCarryThrottleMiddleware($call->args)) {
+                $ranges[] = ['start' => $closure->getStartLine(), 'end' => $closure->getEndLine()];
+            }
+        }
+
+        return $ranges;
+    }
+
+    /**
+     * Returns the first Closure/ArrowFunction argument of a group() call, if any.
+     *
+     * @param  array<Node\Arg|Node\VariadicPlaceholder>  $args
+     */
+    private function closureArgument(array $args): ?Node
+    {
+        foreach ($args as $arg) {
+            if ($arg instanceof Node\Arg
+                && ($arg->value instanceof Node\Expr\Closure || $arg->value instanceof Node\Expr\ArrowFunction)) {
+                return $arg->value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Detects the array-config group form: a ['middleware' => 'throttle...'] or
+     * ['middleware' => ['auth', 'throttle...']] entry among the call arguments.
+     *
+     * @param  array<Node\Arg|Node\VariadicPlaceholder>  $args
+     */
+    private function argsCarryThrottleMiddleware(array $args): bool
+    {
+        foreach ($args as $arg) {
+            if (! ($arg instanceof Node\Arg) || ! ($arg->value instanceof Node\Expr\Array_)) {
+                continue;
+            }
+            foreach ($arg->value->items as $item) {
+                if (! ($item instanceof Node\Expr\ArrayItem)
+                    || ! ($item->key instanceof String_)
+                    || $item->key->value !== 'middleware') {
+                    continue;
+                }
+                if ($this->middlewareValueHasThrottle($item->value)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether a 'middleware' value (a string or a list of strings) carries a throttle.
+     */
+    private function middlewareValueHasThrottle(Node $value): bool
+    {
+        if ($value instanceof String_) {
+            return str_starts_with($value->value, 'throttle');
+        }
+
+        if ($value instanceof Node\Expr\Array_) {
+            foreach ($value->items as $item) {
+                if ($item instanceof Node\Expr\ArrayItem
+                    && $item->value instanceof String_
+                    && str_starts_with($item->value->value, 'throttle')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Support/BootstrapRouteParser.php
+++ b/src/Support/BootstrapRouteParser.php
@@ -167,38 +167,43 @@ class BootstrapRouteParser
         $ranges = [];
 
         // Fluent form: Route::middleware([...'throttle'...])->group(function () {...})
-        // Also covers ->group(['middleware' => 'throttle'], function () {...}).
+        // (throttle in the method chain) — also handles ->group(['middleware' =>
+        // 'throttle'], function () {...}) via the config-array check.
         foreach ($this->parser->findMethodCalls($ast, 'group') as $call) {
-            if (! ($call instanceof MethodCall)) {
-                continue;
-            }
-            $closure = $this->closureArgument($call->args);
-            if ($closure === null) {
-                continue;
-            }
-            if ($this->chainContainsThrottleMiddleware($call->var)
-                || $this->argsCarryThrottleMiddleware($call->args)) {
-                $ranges[] = ['start' => $closure->getStartLine(), 'end' => $closure->getEndLine()];
+            if ($call instanceof MethodCall) {
+                $this->collectThrottledGroupRange(
+                    $call->args,
+                    $this->chainContainsThrottleMiddleware($call->var),
+                    $ranges,
+                );
             }
         }
 
-        // Array form: Route::group(['middleware' => 'throttle...'], function () {...})
+        // Array form: Route::group(['middleware' => 'throttle...'], function () {...}).
         foreach ($this->parser->findNodes($ast, StaticCall::class) as $call) {
-            if (! ($call instanceof StaticCall)
-                || ! ($call->name instanceof Identifier)
-                || $call->name->name !== 'group') {
-                continue;
-            }
-            $closure = $this->closureArgument($call->args);
-            if ($closure === null) {
-                continue;
-            }
-            if ($this->argsCarryThrottleMiddleware($call->args)) {
-                $ranges[] = ['start' => $closure->getStartLine(), 'end' => $closure->getEndLine()];
+            if ($call instanceof StaticCall
+                && $call->name instanceof Identifier
+                && $call->name->name === 'group') {
+                $this->collectThrottledGroupRange($call->args, false, $ranges);
             }
         }
 
         return $ranges;
+    }
+
+    /**
+     * Records the closure argument's line range when the group is throttled —
+     * either through its method chain ($chainThrottled) or a config-array argument.
+     *
+     * @param  array<Node\Arg|Node\VariadicPlaceholder>  $args
+     * @param  array<int, array{start: int, end: int}>  $ranges
+     */
+    private function collectThrottledGroupRange(array $args, bool $chainThrottled, array &$ranges): void
+    {
+        $closure = $this->closureArgument($args);
+        if ($closure !== null && ($chainThrottled || $this->argsCarryThrottleMiddleware($args))) {
+            $ranges[] = ['start' => $closure->getStartLine(), 'end' => $closure->getEndLine()];
+        }
     }
 
     /**

--- a/tests/Unit/Analyzers/Security/LoginThrottlingAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/LoginThrottlingAnalyzerTest.php
@@ -440,9 +440,17 @@ return Application::configure(basePath: dirname(__DIR__))
     ->create();
 PHP;
 
+        // A real API login route makes this pass contingent on throttleApi()
+        // detection: the global throttle:api it injects must suppress the finding.
+        $routeCode = <<<'PHP'
+<?php
+
+Route::post('/login', [ApiAuthController::class, 'login']);
+PHP;
+
         $tempDir = $this->createTempDirectory([
             'bootstrap/app.php' => $bootstrapCode,
-            'routes/web.php' => '<?php // empty routes',
+            'routes/api.php' => $routeCode,
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -451,8 +459,398 @@ PHP;
 
         $result = $analyzer->analyze();
 
-        // Has global RateLimiter usage (from hasRateLimiterUsage check), so should pass
         $this->assertPassed($result);
+    }
+
+    public function test_throttle_api_with_custom_limiter_detected(): void
+    {
+        $bootstrapCode = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->throttleApi('login');
+    })
+    ->create();
+PHP;
+
+        $routeCode = <<<'PHP'
+<?php
+
+Route::post('/login', [ApiAuthController::class, 'login']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrapCode,
+            'routes/api.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['bootstrap', 'routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_throttle_with_redis_alone_does_not_count_as_api_throttle(): void
+    {
+        // throttleWithRedis() only swaps the throttle driver; it does not enable
+        // throttling, so an unthrottled API login route must still be flagged.
+        $bootstrapCode = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->throttleWithRedis();
+    })
+    ->create();
+PHP;
+
+        $routeCode = <<<'PHP'
+<?php
+
+Route::post('/login', [ApiAuthController::class, 'login']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrapCode,
+            'routes/api.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['bootstrap', 'routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('/login', $result);
+    }
+
+    public function test_passes_with_fluent_group_array_throttle(): void
+    {
+        // The exact fluent form from issue #309: throttle:api in the group's
+        // middleware array, applied via Route::middleware([...])->group(...).
+        $routeCode = <<<'PHP'
+<?php
+
+Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
+    Route::post('/login', [ApiAuthController::class, 'login']);
+});
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/api.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_with_fluent_group_throttle_login_far_from_opener(): void
+    {
+        // Login route sits more than 3 lines below the group opener, so the old
+        // ±3-line look-back could not see the throttle. AST range covers it.
+        $routeCode = <<<'PHP'
+<?php
+
+Route::middleware('throttle:5,1')->group(function () {
+    Route::get('/a', [AController::class, 'index']);
+    Route::get('/b', [BController::class, 'index']);
+    Route::get('/c', [CController::class, 'index']);
+    Route::get('/d', [DController::class, 'index']);
+    Route::post('/login', [LoginController::class, 'login']);
+});
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_fluent_group_without_throttle_still_flags_login(): void
+    {
+        // A fluent group carrying no throttle must not be treated as covered.
+        $routeCode = <<<'PHP'
+<?php
+
+Route::middleware('auth')->prefix('acct')->group(function () {
+    Route::post('/login', [LoginController::class, 'login']);
+});
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('login', $result);
+    }
+
+    public function test_nested_throttle_group_does_not_leak_coverage(): void
+    {
+        // The login route is after the inner group closes but still inside the
+        // outer throttle group; overlapping AST ranges keep it covered.
+        $routeCode = <<<'PHP'
+<?php
+
+Route::middleware('throttle:5,1')->group(function () {
+    Route::middleware('throttle:5,1')->prefix('inner')->group(function () {
+        Route::get('/ping', [PingController::class, 'index']);
+    });
+
+    Route::post('/login', [LoginController::class, 'login']);
+});
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_fluent_group_with_path_argument_does_not_leak(): void
+    {
+        // ->group(base_path(...)) opens no closure, so it must not mark the
+        // following top-level login route as covered.
+        $routeCode = <<<'PHP'
+<?php
+
+Route::middleware('throttle:5,1')->group(base_path('routes/inner.php'));
+
+Route::post('/login', [LoginController::class, 'login']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/web.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('login', $result);
+    }
+
+    public function test_skips_auth_logout_endpoint(): void
+    {
+        // Matches only on the broad 'auth' substring; logout is token revocation,
+        // not a credential brute-force surface.
+        $routeCode = <<<'PHP'
+<?php
+
+Route::post('/auth/logout', [AuthController::class, 'logout']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/api.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_skips_auth_me_endpoint(): void
+    {
+        $routeCode = <<<'PHP'
+<?php
+
+Route::get('/auth/me', [AuthController::class, 'me']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/api.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_skips_auth_signout_endpoint(): void
+    {
+        $routeCode = <<<'PHP'
+<?php
+
+Route::post('/auth/signout', [AuthController::class, 'signout']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/api.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_still_flags_auth_login_despite_denylist(): void
+    {
+        // 'login' is an explicit credential keyword, so the denylist must not
+        // suppress it even though it sits under the /auth prefix.
+        $routeCode = <<<'PHP'
+<?php
+
+Route::post('/auth/login', [AuthController::class, 'login']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/api.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('/auth/login', $result);
+    }
+
+    public function test_still_flags_token_refresh_endpoint(): void
+    {
+        // 'refresh' is intentionally NOT on the denylist: a token-refresh endpoint
+        // accepts a secret and mints tokens, so throttling it is warranted.
+        $routeCode = <<<'PHP'
+<?php
+
+Route::post('/token/refresh', [TokenController::class, 'refresh']);
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/api.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('token/refresh', $result);
+    }
+
+    public function test_issue_309_repro_global_throttle_api_clears_all(): void
+    {
+        // Exact reproduction from issue #309: a global throttle:api (via
+        // throttleApi()) covers every API route, and logout/me are not
+        // credential surfaces — so there should be no findings.
+        $bootstrapCode = <<<'PHP'
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->throttleApi();
+    })
+    ->create();
+PHP;
+
+        $routeCode = <<<'PHP'
+<?php
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('auth/logout', [StaffLoginController::class, 'logout']);
+    Route::get('auth/me', MeController::class);
+});
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'bootstrap/app.php' => $bootstrapCode,
+            'routes/api.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['bootstrap', 'routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_issue_309_repro_without_global_throttle_flags_only_login(): void
+    {
+        // No global throttle and an unthrottled auth:sanctum group: logout/me are
+        // skipped as non-credential endpoints, but the genuine login route is
+        // still flagged. Exactly one finding.
+        $routeCode = <<<'PHP'
+<?php
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('auth/logout', [StaffLoginController::class, 'logout']);
+    Route::get('auth/me', MeController::class);
+    Route::post('login', [StaffLoginController::class, 'login']);
+});
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'routes/api.php' => $routeCode,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['routes']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertIssueCount(1, $result);
+        $this->assertHasIssueContaining('login', $result);
     }
 
     public function test_handles_invalid_php_in_route_file(): void

--- a/tests/Unit/Support/BootstrapRouteParserTest.php
+++ b/tests/Unit/Support/BootstrapRouteParserTest.php
@@ -1118,6 +1118,114 @@ PHP;
         }
     }
 
+    public function test_throttled_group_ranges_returns_empty_for_missing_file(): void
+    {
+        $parser = new BootstrapRouteParser('/nonexistent', $this->parser);
+
+        $this->assertSame([], $parser->getThrottledGroupLineRanges('/nonexistent/routes/api.php'));
+    }
+
+    public function test_throttled_group_ranges_returns_empty_when_ast_is_empty(): void
+    {
+        // A file with only an opening tag parses to an empty statement list.
+        $tempDir = $this->createTempDir(['routes/api.php' => '<?php']);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+
+            $this->assertSame([], $parser->getThrottledGroupLineRanges($tempDir.'/routes/api.php'));
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_throttled_group_ranges_detects_array_list_middleware_throttle(): void
+    {
+        // Array-config form where 'middleware' is itself a list of strings.
+        $routes = <<<'PHP'
+<?php
+
+Route::group(['middleware' => ['auth:sanctum', 'throttle:api']], function () {
+    Route::post('/login', [LoginController::class, 'login']);
+});
+PHP;
+        $tempDir = $this->createTempDir(['routes/api.php' => $routes]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $ranges = $parser->getThrottledGroupLineRanges($tempDir.'/routes/api.php');
+
+            $this->assertCount(1, $ranges);
+            $this->assertSame(3, $ranges[0]['start']);
+            $this->assertSame(5, $ranges[0]['end']);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_throttled_group_ranges_ignores_array_list_middleware_without_throttle(): void
+    {
+        // Array-config 'middleware' list that carries no throttle entry.
+        $routes = <<<'PHP'
+<?php
+
+Route::group(['middleware' => ['auth:sanctum', 'verified']], function () {
+    Route::post('/login', [LoginController::class, 'login']);
+});
+PHP;
+        $tempDir = $this->createTempDir(['routes/api.php' => $routes]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+
+            $this->assertSame([], $parser->getThrottledGroupLineRanges($tempDir.'/routes/api.php'));
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_throttled_group_ranges_ignores_group_without_closure(): void
+    {
+        // Route::group with no closure argument yields no range.
+        $routes = <<<'PHP'
+<?php
+
+Route::group(['prefix' => 'admin']);
+PHP;
+        $tempDir = $this->createTempDir(['routes/web.php' => $routes]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+
+            $this->assertSame([], $parser->getThrottledGroupLineRanges($tempDir.'/routes/web.php'));
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
+    public function test_throttled_group_ranges_returns_closure_span_for_fluent_group(): void
+    {
+        $routes = <<<'PHP'
+<?php
+
+Route::middleware('throttle:5,1')->group(function () {
+    Route::post('/login', [LoginController::class, 'login']);
+});
+PHP;
+        $tempDir = $this->createTempDir(['routes/web.php' => $routes]);
+
+        try {
+            $parser = new BootstrapRouteParser($tempDir, $this->parser);
+            $ranges = $parser->getThrottledGroupLineRanges($tempDir.'/routes/web.php');
+
+            $this->assertCount(1, $ranges);
+            $this->assertSame(3, $ranges[0]['start']);
+            $this->assertSame(5, $ranges[0]['end']);
+        } finally {
+            $this->removeDir($tempDir);
+        }
+    }
+
     /**
      * @param  array<string>  $paths
      */


### PR DESCRIPTION
## Summary

Fixes #309 — three related gaps in the `login-throttling` analyzer that combined into false-positive High findings on modern Laravel 11+/Sanctum APIs.

## Changes

- **Global `throttleApi()` detection** — `hasThrottleInLaravel11Middleware()` now recognises the canonical no-arg `$middleware->throttleApi()` helper (api group only). `throttleWithRedis()` is explicitly excluded — it swaps the throttle driver, it does not enable throttling.
- **Fluent group throttle via AST** — replaced the brace-depth `$inWebGroup` heuristic with AST-derived throttled-group line ranges (`BootstrapRouteParser::getThrottledGroupLineRanges()`), reusing the existing `chainContainsThrottleMiddleware()` walk. Handles the fluent `Route::middleware([...])->group()` and array forms, and is nesting-, multiline- and path-argument-safe.
- **Non-credential denylist** — `auth/logout`, `auth/me`, `auth/signout` (previously matched only on the broad `auth` substring) are no longer flagged. Guarded so any URI containing a real credential keyword (`login|signin|authenticate|token`) is never suppressed; token-`refresh` deliberately stays flaggable.

## Tests

De-vacuumed the misleading `test_passes_with_throttle_in_laravel_11_bootstrap` (its routes file was empty, so it proved nothing) and added 14 tests covering `throttleApi()` detection (+ custom limiter, + redis guard), fluent/nested/path-arg group coverage, denylist skips and guards, and the exact issue #309 reproduction with and without a global throttle.

## Verification

- Full suite: **4513 tests, 0 failures**
- PHPStan Level 9: **0 errors** on changed source
- Pint: **passed**
