### PR TITLE
fix: exempt addGlobalScope/resolveRelationUsing closures in service-container-resolution

### DIFF
--- a/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
+++ b/src/Analyzers/BestPractices/ServiceContainerResolutionAnalyzer.php
@@ -67,10 +67,11 @@ use ShieldCI\Support\EloquentModelDetector;
  * - Eloquent Scope classes: A global scope (implements Illuminate\Database\Eloquent\Scope) is
  *   instantiated with `new` by user code (addGlobalScope(new FooScope)), so constructor DI is
  *   impossible, and apply(Builder, Model) is a framework-fixed signature. All resolution suppressed.
- * - Model-event closures: Closures registered to Eloquent events (static::creating(), updating(),
- *   saving(), etc.) are invoked by the event dispatcher with the model instance, never via DI. This
- *   covers model traits/concerns (e.g. a boot{Trait}() method) which extend nothing and so aren't
- *   caught by Eloquent-model detection. Resolution inside any model-event call subtree is suppressed.
+ * - Model-event & scope/relation closures: Closures registered to Eloquent events (static::creating(),
+ *   updating(), saving(), etc.) or to static closure registrations (addGlobalScope(), addGlobalScopes(),
+ *   resolveRelationUsing()) are invoked by Eloquent with the model/builder, never via DI. This covers
+ *   model traits/concerns (e.g. a boot{Trait}() method) which extend nothing and so aren't caught by
+ *   Eloquent-model detection. Resolution inside any such call subtree is suppressed; bindings stay flagged.
  * - Middleware: Detected by the App\Http\Middleware\ namespace OR a handle(Request, Closure)
  *   signature, not only the *Middleware class-name suffix. Verb-named middleware (HandleInertiaRequests,
  *   EnsureSubscribed) resolve per request, so all resolution is suppressed.
@@ -877,11 +878,12 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
     private bool $currentMethodIsStatic = false;
 
     /**
-     * Depth inside an Eloquent model-event registration call (static::creating(),
-     * updating(), etc.). Closures passed to these events are invoked by the event
-     * dispatcher with the model instance, never via DI, so resolution within the
-     * call subtree is suppressed. Covers model traits/concerns whose boot{Trait}()
-     * methods register events but extend nothing.
+     * Depth inside an Eloquent closure-registration call — a model-event registration
+     * (static::creating(), updating(), etc.) or a scope/relation registration
+     * (addGlobalScope(), resolveRelationUsing(), see ELOQUENT_CLOSURE_REGISTRATIONS).
+     * Closures passed to these are invoked by Eloquent with the model/builder, never via
+     * DI, so resolution within the call subtree is suppressed. Covers model traits/concerns
+     * whose boot{Trait}() methods register these but extend nothing.
      */
     private int $modelEventDepth = 0;
 
@@ -896,6 +898,18 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
         'saving', 'saved', 'deleting', 'deleted', 'trashed',
         'forceDeleting', 'forceDeleted', 'restoring', 'restored',
         'replicating', 'booting', 'booted',
+    ];
+
+    /**
+     * Eloquent static closure registrations (HasGlobalScopes::addGlobalScope / addGlobalScopes,
+     * HasRelationships::resolveRelationUsing). Each takes a Closure that Eloquent later invokes
+     * with the Builder/Model — there is no DI injection point, exactly like a model-event closure —
+     * so resolution inside the closure is suppressed. Bindings stay flagged.
+     *
+     * @var array<string>
+     */
+    private const ELOQUENT_CLOSURE_REGISTRATIONS = [
+        'addGlobalScope', 'addGlobalScopes', 'resolveRelationUsing',
     ];
 
     /**
@@ -992,11 +1006,11 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        // Track Eloquent model-event registration (static::creating(fn () => ...), etc.).
-        // Closures passed to these are invoked with the model instance, never via DI.
-        // Must run before the suppression guards below so the depth stays balanced with
-        // the unconditional decrement in leaveNode().
-        if ($this->isModelEventCall($node)) {
+        // Track Eloquent closure registration (static::creating(fn () => ...), addGlobalScope(),
+        // resolveRelationUsing(), etc.). Closures passed to these are invoked by Eloquent with the
+        // model/builder, never via DI. Must run before the suppression guards below so the depth
+        // stays balanced with the unconditional decrement in leaveNode().
+        if ($this->isDiExemptClosureRegistration($node)) {
             $this->modelEventDepth++;
         }
 
@@ -1382,8 +1396,8 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
             $this->closureDepth--;
         }
 
-        // Track Eloquent model-event call exit
-        if ($this->isModelEventCall($node)) {
+        // Track Eloquent closure-registration call exit
+        if ($this->isDiExemptClosureRegistration($node)) {
             $this->modelEventDepth--;
         }
 
@@ -1512,17 +1526,19 @@ class ServiceContainerVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * Check if a node is an Eloquent model-event registration call.
+     * Check if a node is a static call whose closure argument Eloquent invokes without DI.
      *
-     * Keys on static calls (static::creating(), self::saving(), Model::deleting(), ...) whose
-     * method name is a known Eloquent event. Event registration is always static, so this avoids
-     * false matches on arbitrary instance method calls that happen to share an event name.
+     * Covers model-event registrations (static::creating(), self::saving(), Model::deleting(), ...)
+     * and the static closure registrations in ELOQUENT_CLOSURE_REGISTRATIONS (addGlobalScope(),
+     * resolveRelationUsing(), ...). All of these are registered via static calls, so keying on
+     * StaticCall avoids false matches on arbitrary instance method calls that share a name.
      */
-    private function isModelEventCall(Node $node): bool
+    private function isDiExemptClosureRegistration(Node $node): bool
     {
         return $node instanceof Expr\StaticCall
             && $node->name instanceof Node\Identifier
-            && in_array($node->name->toString(), self::MODEL_EVENTS, true);
+            && (in_array($node->name->toString(), self::MODEL_EVENTS, true)
+                || in_array($node->name->toString(), self::ELOQUENT_CLOSURE_REGISTRATIONS, true));
     }
 
     /**

--- a/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
+++ b/tests/Unit/Analyzers/BestPractices/ServiceContainerResolutionAnalyzerTest.php
@@ -3159,6 +3159,111 @@ PHP;
         $this->assertPassed($result);
     }
 
+    public function test_container_resolution_in_add_global_scope_closure_in_trait_is_suppressed(): void
+    {
+        // A trait boot method registers a global scope via static::addGlobalScope(). Eloquent
+        // invokes the closure with the Builder — there is no constructor or method injection
+        // point — so container access inside it is unavoidable, exactly like a model-event
+        // closure. This is the standard multi-tenant scoping pattern.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait BelongsToBuilding
+{
+    protected static function bootBelongsToBuilding(): void
+    {
+        static::addGlobalScope('building', function (Builder $builder) {
+            $builder->where('building_id', app('current_building_id'));
+        });
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/Concerns/BelongsToBuilding.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_container_resolution_in_resolve_relation_using_closure_is_suppressed(): void
+    {
+        // resolveRelationUsing() stores a Closure Eloquent later invokes with the model to
+        // build a dynamic relation — no DI injection point, so container access is unavoidable.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models\Concerns;
+
+trait HasDynamicOrders
+{
+    public static function bootHasDynamicOrders(): void
+    {
+        static::resolveRelationUsing('orders', function ($model) {
+            return app(OrderResolver::class)->for($model);
+        });
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/Concerns/HasDynamicOrders.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_binding_in_add_global_scope_closure_is_still_flagged(): void
+    {
+        // The DI-impossible exemption suppresses resolution, but container *bindings*
+        // (bind/singleton) are always wrong outside a service provider and stay flagged.
+        $code = <<<'PHP'
+<?php
+
+namespace App\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait BindsInScope
+{
+    protected static function bootBindsInScope(): void
+    {
+        static::addGlobalScope('bad', function (Builder $builder) {
+            app()->singleton('foo', fn () => new \stdClass());
+        });
+    }
+}
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            'app/Models/Concerns/BindsInScope.php' => $code,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['app']);
+
+        $result = $analyzer->analyze();
+
+        $this->assertHasIssueContaining('singleton', $result);
+    }
+
     public function test_trait_non_event_resolution_is_flagged_with_trait_location(): void
     {
         // Resolution outside a model-event closure is still flagged, but the trait is now


### PR DESCRIPTION
## Summary

Fixes #310. `service-container-resolution` flagged `app()` / `resolve()` inside a closure registered via `static::addGlobalScope('name', fn (Builder $b) => ...)` in a trait `boot{Trait}()` method — a false positive. Eloquent invokes such a closure with the Builder (or Model, for `resolveRelationUsing`); there is no constructor or method injection point, making it a DI-impossible context exactly like a model-event closure, which the analyzer already exempts. This is the standard multi-tenant global-scope pattern, so the false positive is common.

## Root cause

The visitor suppresses resolution inside DI-impossible closures via a `modelEventDepth` counter, incremented only for `Expr\StaticCall`s whose method name is in `MODEL_EVENTS`. `addGlobalScope` (and siblings) are not in that list, so their closure bodies were analysed as generic closures and flagged.

Verified against Laravel's source that `addGlobalScope`, `addGlobalScopes`, and `resolveRelationUsing` are all `public static` and store a `Closure(Builder|Model)` invoked later without DI — identical property to model events.

## Changes

- Add `ELOQUENT_CLOSURE_REGISTRATIONS` const (`addGlobalScope`, `addGlobalScopes`, `resolveRelationUsing`).
- Generalize `isModelEventCall` → `isDiExemptClosureRegistration`, matching either `MODEL_EVENTS` or `ELOQUENT_CLOSURE_REGISTRATIONS`; update both call sites and the docblocks.
- Reuses the existing `modelEventDepth` guard, so **container bindings** (`bind`/`singleton`) inside these closures stay flagged.

## Tests

- `addGlobalScope` closure in a trait boot method → suppressed (the issue's repro).
- `resolveRelationUsing` closure → suppressed.
- Binding (`app()->singleton()`) inside an `addGlobalScope` closure → still flagged (guard preservation).

## Verification

- New tests: red before the fix (2 failed), green after (3/3).
- Full analyzer test class: 98/98.
- Full suite: 4522/4522, 0 failures.
- PHPStan Level 9 (changed file): 0 errors.
- Pint: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)