### PR TITLE
fix: grade missing env variables by config default presence

### DIFF
--- a/src/Analyzers/Reliability/EnvVariableAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvVariableAnalyzer.php
@@ -8,21 +8,30 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
-use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\AnalyzesEnvFiles;
 use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
  * Checks that all environment variables from .env.example are defined in .env.
  *
+ * Grading is default-aware: a variable that is absent from .env but whose
+ * env() call in config/ supplies a real default is the lean-.env style
+ * working as intended (config owns defaults, .env owns overrides), so it is
+ * reported through result metadata instead of a High issue. Variables with
+ * no config default (bare env('KEY') or an explicit null default) stay High:
+ * the app reads null when they are unset.
+ *
  * Checks for:
  * - .env file exists
- * - All variables from .env.example are present in .env
- * - No missing required configuration
+ * - Variables from .env.example without a config default are present in .env
+ * - Optional (report_defaulted): variables relying on config defaults
+ * - Optional (report_redundant): .env values restating the config default
  */
 class EnvVariableAnalyzer extends AbstractFileAnalyzer
 {
+    use AnalyzesEnvFiles;
     use DetectsDeploymentPlatform;
 
     public static bool $runInCI = false;
@@ -142,13 +151,62 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
             $missingVars[$key] = $value;
         }
 
-        // All variables are present (either active or commented)
-        if (empty($missingVars) && empty($commentedOnlyVars)) {
+        $reportDefaulted = (bool) config('shieldci.analyzers.reliability.env-variables-complete.report_defaulted', false);
+        $reportRedundant = (bool) config('shieldci.analyzers.reliability.env-variables-complete.report_redundant', false);
+
+        $usages = ($missingVars !== [] || $reportRedundant)
+            ? $this->collectConfigEnvKeyUsages()
+            : [];
+
+        // Split missing variables by whether config supplies a real default
+        $defaultedVars = [];
+        $stillMissing = [];
+
+        foreach ($missingVars as $key => $value) {
+            if (isset($usages[$key]) && $usages[$key]['hasDefault']) {
+                $defaultedVars[$key] = $value;
+            } else {
+                $stillMissing[$key] = $value;
+            }
+        }
+
+        $redundantVars = [];
+
+        if ($reportRedundant) {
+            foreach ($actualResult['values'] as $key => $value) {
+                $default = $usages[$key]['default'] ?? null;
+
+                if ($default !== null && $default === $value) {
+                    $redundantVars[] = $key;
+                }
+            }
+        }
+
+        $resultMetadata = [];
+
+        if ($defaultedVars !== []) {
+            $resultMetadata = [
+                'defaulted_count' => count($defaultedVars),
+                'defaulted_variables' => array_keys($defaultedVars),
+            ];
+        }
+
+        $hasInfoIssues = ($reportDefaulted && $defaultedVars !== []) || $redundantVars !== [];
+
+        // All variables are present, either directly or through config defaults
+        if ($stillMissing === [] && $commentedOnlyVars === [] && ! $hasInfoIssues) {
+            if ($defaultedVars !== []) {
+                return $this->passed(
+                    sprintf('All required environment variables are set (%d using config defaults)', count($defaultedVars)),
+                    $resultMetadata
+                );
+            }
+
             return $this->passed('All environment variables from .env.example are defined and enabled in .env');
         }
 
         // Only commented variables, no truly missing ones
-        if (empty($missingVars) && ! empty($commentedOnlyVars)) {
+        if ($stillMissing === [] && $commentedOnlyVars !== [] && ! $hasInfoIssues) {
             return $this->warning(
                 sprintf('Found %d commented environment variable(s)', count($commentedOnlyVars)),
                 [$this->createIssue(
@@ -161,26 +219,29 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
                         'commented_variables' => array_keys($commentedOnlyVars),
                         'code' => 'commented-variables',
                     ]
-                )]
+                )],
+                $resultMetadata
             );
         }
 
-        // Build issues for missing and/or commented variables
+        // Build issues for missing, commented, and opt-in informational groups
         $issues = [];
 
-        $issues[] = $this->createIssue(
-            message: 'Missing environment variables',
-            location: new Location($this->getRelativePath($envPath)),
-            severity: Severity::High,
-            recommendation: $this->buildMissingVariablesRecommendation($missingVars),
-            metadata: [
-                'missing_count' => count($missingVars),
-                'missing_variables' => array_keys($missingVars),
-                'code' => 'missing-variables',
-            ]
-        );
+        if ($stillMissing !== []) {
+            $issues[] = $this->createIssue(
+                message: 'Missing environment variables',
+                location: new Location($this->getRelativePath($envPath)),
+                severity: Severity::High,
+                recommendation: $this->buildMissingVariablesRecommendation($stillMissing),
+                metadata: [
+                    'missing_count' => count($stillMissing),
+                    'missing_variables' => array_keys($stillMissing),
+                    'code' => 'missing-variables',
+                ]
+            );
+        }
 
-        if (! empty($commentedOnlyVars)) {
+        if ($commentedOnlyVars !== []) {
             $issues[] = $this->createIssue(
                 message: 'Environment variables are commented out',
                 location: new Location($this->getRelativePath($envPath)),
@@ -194,11 +255,42 @@ class EnvVariableAnalyzer extends AbstractFileAnalyzer
             );
         }
 
-        $totalCount = count($missingVars) + count($commentedOnlyVars);
+        if ($reportDefaulted && $defaultedVars !== []) {
+            $issues[] = $this->createIssue(
+                message: 'Environment variables relying on config defaults',
+                location: new Location($this->getRelativePath($envPath)),
+                severity: Severity::Info,
+                recommendation: $this->buildDefaultedVariablesRecommendation($defaultedVars),
+                metadata: [
+                    'defaulted_count' => count($defaultedVars),
+                    'defaulted_variables' => array_keys($defaultedVars),
+                    'code' => 'defaulted-variables',
+                ]
+            );
+        }
+
+        if ($redundantVars !== []) {
+            $issues[] = $this->createIssue(
+                message: 'Environment variables restating config defaults',
+                location: new Location($this->getRelativePath($envPath)),
+                severity: Severity::Info,
+                recommendation: $this->buildRedundantVariablesRecommendation($redundantVars),
+                metadata: [
+                    'redundant_count' => count($redundantVars),
+                    'redundant_variables' => $redundantVars,
+                    'code' => 'redundant-override',
+                ]
+            );
+        }
+
+        $totalCount = count($stillMissing) + count($commentedOnlyVars)
+            + ($reportDefaulted ? count($defaultedVars) : 0)
+            + count($redundantVars);
 
         return $this->resultBySeverity(
             sprintf('Found %d environment variable issue(s)', $totalCount),
-            $issues
+            $issues,
+            $resultMetadata
         );
     }
 
@@ -286,101 +378,38 @@ RECOMMENDATION,
     }
 
     /**
-     * Parse environment file and return key-value pairs with error tracking.
+     * Build recommendation message for variables relying on config defaults.
      *
-     * @return array{variables: array<string, string>, error: string|null}
+     * @param  array<string, string>  $defaultedVars
      */
-    private function parseEnvFileWithErrors(string $filePath): array
+    private function buildDefaultedVariablesRecommendation(array $defaultedVars): string
     {
-        if (! file_exists($filePath)) {
-            return ['variables' => [], 'error' => 'File does not exist'];
-        }
+        $variablesList = implode(', ', array_keys($defaultedVars));
 
-        if (! is_readable($filePath)) {
-            return ['variables' => [], 'error' => 'File is not readable'];
-        }
-
-        try {
-            $lines = FileParser::getLines($filePath);
-        } catch (\Throwable $e) {
-            return ['variables' => [], 'error' => $e->getMessage()];
-        }
-
-        if (empty($lines)) {
-            // Empty file is valid, not an error
-            return ['variables' => [], 'error' => null];
-        }
-
-        $variables = [];
-
-        foreach ($lines as $line) {
-            if (! is_string($line)) {
-                continue;
-            }
-
-            $line = trim($line);
-
-            // Skip empty lines and comments
-            if ($line === '' || str_starts_with($line, '#')) {
-                continue;
-            }
-
-            // Parse KEY=VALUE format
-            if (preg_match('/^([A-Z_][A-Z0-9_]*)\s*=/', $line, $matches)) {
-                $key = $matches[1];
-                $variables[$key] = $line;
-            }
-        }
-
-        return ['variables' => $variables, 'error' => null];
+        return sprintf(
+            <<<'RECOMMENDATION'
+The following environment variables are not set in .env and use the defaults defined in config files: %s
+This is the lean .env style working as intended; set a variable in .env only when this environment needs to override its config default.
+RECOMMENDATION,
+            $variablesList,
+        );
     }
 
     /**
-     * Parse environment file and return commented-out variables with error tracking.
+     * Build recommendation message for redundant environment variable overrides.
      *
-     * Note: Parsing errors for commented variables are non-critical and ignored.
-     *
-     * @return array{variables: array<string, string>, error: string|null}
+     * @param  array<int, string>  $redundantVars
      */
-    private function parseCommentedVariablesWithErrors(string $filePath): array
+    private function buildRedundantVariablesRecommendation(array $redundantVars): string
     {
-        if (! file_exists($filePath) || ! is_readable($filePath)) {
-            // Not an error - file might not exist yet or have permission issues already reported
-            return ['variables' => [], 'error' => null];
-        }
+        $variablesList = implode(', ', $redundantVars);
 
-        try {
-            $lines = FileParser::getLines($filePath);
-        } catch (\Throwable $e) {
-            // Not an error - if we can't read the file for commented vars, it's already reported elsewhere
-            return ['variables' => [], 'error' => null];
-        }
-
-        if (empty($lines)) {
-            return ['variables' => [], 'error' => null];
-        }
-
-        $commentedVars = [];
-
-        foreach ($lines as $line) {
-            if (! is_string($line)) {
-                continue;
-            }
-
-            $line = trim($line);
-
-            // Skip empty lines
-            if ($line === '') {
-                continue;
-            }
-
-            // Look for commented variable definitions: # KEY=VALUE or #KEY=VALUE
-            if (preg_match('/^#\s*([A-Z_][A-Z0-9_]*)\s*=/', $line, $matches)) {
-                $key = $matches[1];
-                $commentedVars[$key] = $line;
-            }
-        }
-
-        return ['variables' => $commentedVars, 'error' => null];
+        return sprintf(
+            <<<'RECOMMENDATION'
+The following environment variables restate the default already defined in config files: %s
+Removing them from .env lets future config default changes take effect without editing every environment.
+RECOMMENDATION,
+            $variablesList,
+        );
     }
 }

--- a/src/Concerns/AnalyzesEnvFiles.php
+++ b/src/Concerns/AnalyzesEnvFiles.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Concerns;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use ShieldCI\AnalyzersCore\Support\FileParser;
+
+/**
+ * Shared helpers for analyzers that reason about .env files and the env()
+ * keys read by the application's config/ directory.
+ *
+ * Env::get() calls in config files are deliberately not scanned: a key read
+ * only via Env::get() counts as "never seen in config", which keeps missing
+ * variables graded conservatively (High) rather than risking a false green.
+ */
+trait AnalyzesEnvFiles
+{
+    use InspectsCode;
+
+    /**
+     * Parse environment file and return key-value pairs with error tracking.
+     *
+     * `variables` maps each key to its raw line; `values` maps each key to
+     * its trimmed, unquoted value.
+     *
+     * @return array{variables: array<string, string>, values: array<string, string>, error: string|null}
+     */
+    protected function parseEnvFileWithErrors(string $filePath): array
+    {
+        if (! file_exists($filePath)) {
+            return ['variables' => [], 'values' => [], 'error' => 'File does not exist'];
+        }
+
+        if (! is_readable($filePath)) {
+            return ['variables' => [], 'values' => [], 'error' => 'File is not readable'];
+        }
+
+        try {
+            $lines = FileParser::getLines($filePath);
+        } catch (\Throwable $e) {
+            return ['variables' => [], 'values' => [], 'error' => $e->getMessage()];
+        }
+
+        if (empty($lines)) {
+            // Empty file is valid, not an error
+            return ['variables' => [], 'values' => [], 'error' => null];
+        }
+
+        $variables = [];
+        $values = [];
+
+        foreach ($lines as $line) {
+            if (! is_string($line)) {
+                continue;
+            }
+
+            $line = trim($line);
+
+            // Skip empty lines and comments
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            // Parse KEY=VALUE format
+            if (preg_match('/^([A-Z_][A-Z0-9_]*)\s*=/', $line, $matches)) {
+                $key = $matches[1];
+                $variables[$key] = $line;
+                $values[$key] = $this->extractEnvValue($line);
+            }
+        }
+
+        return ['variables' => $variables, 'values' => $values, 'error' => null];
+    }
+
+    /**
+     * Parse environment file and return commented-out variables with error tracking.
+     *
+     * Note: Parsing errors for commented variables are non-critical and ignored.
+     *
+     * @return array{variables: array<string, string>, error: string|null}
+     */
+    protected function parseCommentedVariablesWithErrors(string $filePath): array
+    {
+        if (! file_exists($filePath) || ! is_readable($filePath)) {
+            // Not an error - file might not exist yet or have permission issues already reported
+            return ['variables' => [], 'error' => null];
+        }
+
+        try {
+            $lines = FileParser::getLines($filePath);
+        } catch (\Throwable $e) {
+            // Not an error - if we can't read the file for commented vars, it's already reported elsewhere
+            return ['variables' => [], 'error' => null];
+        }
+
+        if (empty($lines)) {
+            return ['variables' => [], 'error' => null];
+        }
+
+        $commentedVars = [];
+
+        foreach ($lines as $line) {
+            if (! is_string($line)) {
+                continue;
+            }
+
+            $line = trim($line);
+
+            // Skip empty lines
+            if ($line === '') {
+                continue;
+            }
+
+            // Look for commented variable definitions: # KEY=VALUE or #KEY=VALUE
+            if (preg_match('/^#\s*([A-Z_][A-Z0-9_]*)\s*=/', $line, $matches)) {
+                $key = $matches[1];
+                $commentedVars[$key] = $line;
+            }
+        }
+
+        return ['variables' => $commentedVars, 'error' => null];
+    }
+
+    /**
+     * Scan the application's config/ directory for env() calls and fold them
+     * into per-key usage info.
+     *
+     * `hasDefault` is true only when every call for the key supplies a real
+     * default (a bare env('KEY') or an explicit null default means the app
+     * reads null when the variable is unset). `default` carries the scalar
+     * default's .env textual form when it is statically known and consistent
+     * across calls; null when unknown.
+     *
+     * @return array<string, array{hasDefault: bool, default: string|null, file: string, line: int}>
+     */
+    protected function collectConfigEnvKeyUsages(): array
+    {
+        $usages = [];
+
+        foreach ($this->findFunctionCalls('env', ['config'], []) as $call) {
+            $key = $call['args'][0] ?? null;
+
+            if (! is_string($key) || $key === '') {
+                continue; // dynamic or non-literal key
+            }
+
+            [$hasDefault, $default] = $this->classifyEnvDefault($call['node'], $call['args']);
+
+            if (! isset($usages[$key])) {
+                $usages[$key] = [
+                    'hasDefault' => $hasDefault,
+                    'default' => $default,
+                    'file' => $call['file'],
+                    'line' => $call['node']->getStartLine(),
+                ];
+
+                continue;
+            }
+
+            // Any bare/null-default call wins; the first occurrence keeps the location.
+            $usages[$key]['hasDefault'] = $usages[$key]['hasDefault'] && $hasDefault;
+
+            if (! $hasDefault || $usages[$key]['default'] !== $default) {
+                $usages[$key]['default'] = null;
+            }
+        }
+
+        return $usages;
+    }
+
+    /**
+     * Classify the default argument of an env() call.
+     *
+     * Works from the raw AST node because InspectsCode extracts both a
+     * ConstFetch null and the string literal 'null' to the same value, and
+     * those must grade differently (no default vs. a real string default).
+     *
+     * @param  array<int, mixed>  $args
+     * @return array{0: bool, 1: string|null}
+     */
+    private function classifyEnvDefault(FuncCall $node, array $args): array
+    {
+        if (! array_key_exists(1, $args)) {
+            return [false, null]; // bare env('KEY')
+        }
+
+        $rawArg = $node->args[1] ?? null;
+
+        if ($rawArg instanceof Node\Arg && $rawArg->value instanceof Node\Expr\ConstFetch) {
+            $name = strtolower($rawArg->value->name->toString());
+
+            if ($name === 'null') {
+                return [false, null]; // env('KEY', null) behaves like a bare call
+            }
+
+            // true/false match their .env textual form; other constants are unknown values.
+            return [true, in_array($name, ['true', 'false'], true) ? $name : null];
+        }
+
+        $value = $args[1];
+
+        if (is_string($value)) {
+            return [true, $value];
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return [true, (string) $value];
+        }
+
+        return [true, null]; // complex expression: a default exists, its value is unknown
+    }
+
+    /**
+     * Extract the value portion of a KEY=VALUE line, trimmed and with
+     * matching surrounding quotes stripped.
+     */
+    private function extractEnvValue(string $line): string
+    {
+        $value = trim(substr($line, (int) strpos($line, '=') + 1));
+
+        if (strlen($value) >= 2) {
+            $first = $value[0];
+
+            if (($first === '"' || $first === "'") && str_ends_with($value, $first)) {
+                $value = substr($value, 1, -1);
+            }
+        }
+
+        return $value;
+    }
+}

--- a/src/Concerns/AnalyzesEnvFiles.php
+++ b/src/Concerns/AnalyzesEnvFiles.php
@@ -38,11 +38,7 @@ trait AnalyzesEnvFiles
             return ['variables' => [], 'values' => [], 'error' => 'File is not readable'];
         }
 
-        try {
-            $lines = FileParser::getLines($filePath);
-        } catch (\Throwable $e) {
-            return ['variables' => [], 'values' => [], 'error' => $e->getMessage()];
-        }
+        $lines = FileParser::getLines($filePath);
 
         if (empty($lines)) {
             // Empty file is valid, not an error
@@ -53,10 +49,6 @@ trait AnalyzesEnvFiles
         $values = [];
 
         foreach ($lines as $line) {
-            if (! is_string($line)) {
-                continue;
-            }
-
             $line = trim($line);
 
             // Skip empty lines and comments
@@ -89,12 +81,7 @@ trait AnalyzesEnvFiles
             return ['variables' => [], 'error' => null];
         }
 
-        try {
-            $lines = FileParser::getLines($filePath);
-        } catch (\Throwable $e) {
-            // Not an error - if we can't read the file for commented vars, it's already reported elsewhere
-            return ['variables' => [], 'error' => null];
-        }
+        $lines = FileParser::getLines($filePath);
 
         if (empty($lines)) {
             return ['variables' => [], 'error' => null];
@@ -103,10 +90,6 @@ trait AnalyzesEnvFiles
         $commentedVars = [];
 
         foreach ($lines as $line) {
-            if (! is_string($line)) {
-                continue;
-            }
-
             $line = trim($line);
 
             // Skip empty lines

--- a/tests/Unit/Analyzers/Reliability/EnvVariableAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/EnvVariableAnalyzerTest.php
@@ -803,4 +803,283 @@ REQUIRED_VAR=',
 
         $this->assertFalse($analyzer->shouldRun());
     }
+
+    // =========================================================================
+    // Default-Aware Grading Tests (lean .env style)
+    // =========================================================================
+
+    public function test_passes_when_missing_variables_have_config_defaults(): void
+    {
+        $configContent = <<<'PHP'
+<?php
+
+return [
+    'max_seats' => env('WIDGET_MAX_SEATS', 1000),
+    'nested' => [
+        'poll_interval' => env('WIDGET_POLL_INTERVAL', 5000),
+    ],
+    'timeout' => env(
+        'WIDGET_TIMEOUT',
+        30
+    ),
+];
+PHP;
+
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nWIDGET_MAX_SEATS=1000\nWIDGET_POLL_INTERVAL=5000\nWIDGET_TIMEOUT=30",
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => $configContent,
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertStringContainsString('config defaults', $result->getMessage());
+
+        $metadata = $result->getMetadata();
+        $this->assertSame(3, $metadata['defaulted_count']);
+        $this->assertEqualsCanonicalizing(
+            ['WIDGET_MAX_SEATS', 'WIDGET_POLL_INTERVAL', 'WIDGET_TIMEOUT'],
+            $metadata['defaulted_variables']
+        );
+    }
+
+    public function test_reports_defaulted_variables_as_info_when_flag_enabled(): void
+    {
+        config(['shieldci.analyzers.reliability.env-variables-complete.report_defaulted' => true]);
+
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nWIDGET_MAX_SEATS=1000",
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => "<?php\n\nreturn ['max_seats' => env('WIDGET_MAX_SEATS', 1000)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('info', $issues[0]->severity->value);
+        $this->assertSame('defaulted-variables', $issues[0]->metadata['code']);
+        $this->assertContains('WIDGET_MAX_SEATS', $issues[0]->metadata['defaulted_variables']);
+    }
+
+    public function test_bare_env_call_in_config_stays_high(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nACME_SECRET_KEY=",
+            '.env' => 'APP_NAME=MyApp',
+            'config/services.php' => "<?php\n\nreturn ['acme' => ['key' => env('ACME_SECRET_KEY')]];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('Missing environment variables', $issues[0]->message);
+        $this->assertSame('missing-variables', $issues[0]->metadata['code']);
+        $this->assertContains('ACME_SECRET_KEY', $issues[0]->metadata['missing_variables']);
+    }
+
+    public function test_null_default_in_config_stays_high(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nACME_SECRET_KEY=",
+            '.env' => 'APP_NAME=MyApp',
+            'config/services.php' => "<?php\n\nreturn ['key' => env('ACME_SECRET_KEY', null)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertSame('missing-variables', $result->getIssues()[0]->metadata['code']);
+    }
+
+    public function test_empty_string_default_counts_as_default(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nWIDGET_LABEL=",
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => "<?php\n\nreturn ['label' => env('WIDGET_LABEL', '')];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertContains('WIDGET_LABEL', $result->getMetadata()['defaulted_variables']);
+    }
+
+    public function test_mixed_defaulted_and_bare_missing_variables_partition(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nACME_SECRET_KEY=\nWIDGET_MAX_SEATS=1000",
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000), 'key' => env('ACME_SECRET_KEY')];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        $this->assertSame(1, $issues[0]->metadata['missing_count']);
+        $this->assertSame(['ACME_SECRET_KEY'], $issues[0]->metadata['missing_variables']);
+        $this->assertSame(['WIDGET_MAX_SEATS'], $result->getMetadata()['defaulted_variables']);
+    }
+
+    public function test_missing_variable_not_referenced_in_config_stays_high(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nVITE_ACME_KEY=",
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => "<?php\n\nreturn ['name' => env('APP_NAME', 'Laravel')];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertContains('VITE_ACME_KEY', $result->getIssues()[0]->metadata['missing_variables']);
+    }
+
+    public function test_bare_call_in_one_file_overrides_default_in_another(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nACME_SECRET_KEY=",
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => "<?php\n\nreturn ['key' => env('ACME_SECRET_KEY', 'fallback')];",
+            'config/services.php' => "<?php\n\nreturn ['key' => env('ACME_SECRET_KEY')];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertFailed($result);
+        $this->assertContains('ACME_SECRET_KEY', $result->getIssues()[0]->metadata['missing_variables']);
+    }
+
+    public function test_dynamic_env_key_in_config_is_ignored(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nWIDGET_MAX_SEATS=1000",
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000), 'other' => env(\$dynamicKey)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertContains('WIDGET_MAX_SEATS', $result->getMetadata()['defaulted_variables']);
+    }
+
+    // =========================================================================
+    // Redundant Override Tests (opt-in flag)
+    // =========================================================================
+
+    public function test_redundant_override_not_reported_by_default(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'WIDGET_MAX_SEATS=1000',
+            '.env' => 'WIDGET_MAX_SEATS=1000',
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertEmpty($result->getIssues());
+    }
+
+    public function test_redundant_override_reported_when_flag_enabled(): void
+    {
+        config(['shieldci.analyzers.reliability.env-variables-complete.report_redundant' => true]);
+
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "WIDGET_MAX_SEATS=1000\nWIDGET_LABEL=widgets",
+            '.env' => "WIDGET_MAX_SEATS=1000\nWIDGET_LABEL=\"widgets\"",
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000), 'label' => env('WIDGET_LABEL', 'widgets')];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('info', $issues[0]->severity->value);
+        $this->assertSame('redundant-override', $issues[0]->metadata['code']);
+        $this->assertEqualsCanonicalizing(
+            ['WIDGET_MAX_SEATS', 'WIDGET_LABEL'],
+            $issues[0]->metadata['redundant_variables']
+        );
+    }
+
+    public function test_redundant_override_matches_boolean_default_text(): void
+    {
+        config(['shieldci.analyzers.reliability.env-variables-complete.report_redundant' => true]);
+
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'WIDGET_ENABLED=false',
+            '.env' => 'WIDGET_ENABLED=false',
+            'config/widget.php' => "<?php\n\nreturn ['enabled' => env('WIDGET_ENABLED', false)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $this->assertSame('redundant-override', $result->getIssues()[0]->metadata['code']);
+    }
+
+    public function test_redundant_override_ignores_non_literal_defaults_and_differing_values(): void
+    {
+        config(['shieldci.analyzers.reliability.env-variables-complete.report_redundant' => true]);
+
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "WIDGET_PATH=/tmp/widgets\nWIDGET_MAX_SEATS=1000",
+            '.env' => "WIDGET_PATH=/tmp/widgets\nWIDGET_MAX_SEATS=2000",
+            'config/widget.php' => "<?php\n\nreturn ['path' => env('WIDGET_PATH', storage_path('widgets')), 'seats' => env('WIDGET_MAX_SEATS', 1000)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertEmpty($result->getIssues());
+    }
 }

--- a/tests/Unit/Concerns/AnalyzesEnvFilesTest.php
+++ b/tests/Unit/Concerns/AnalyzesEnvFilesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShieldCI\Tests\Unit\Concerns;
+
+use ShieldCI\Concerns\AnalyzesEnvFiles;
+use ShieldCI\Tests\TestCase;
+
+class AnalyzesEnvFilesTest extends TestCase
+{
+    public function test_parse_env_file_reports_nonexistent_file(): void
+    {
+        $harness = new ConcreteAnalyzesEnvFiles;
+
+        $result = $harness->publicParseEnvFileWithErrors('/nonexistent/path/.env');
+
+        $this->assertSame('File does not exist', $result['error']);
+        $this->assertSame([], $result['variables']);
+        $this->assertSame([], $result['values']);
+    }
+
+    public function test_parse_commented_variables_tolerates_nonexistent_file(): void
+    {
+        $harness = new ConcreteAnalyzesEnvFiles;
+
+        $result = $harness->publicParseCommentedVariablesWithErrors('/nonexistent/path/.env');
+
+        $this->assertNull($result['error']);
+        $this->assertSame([], $result['variables']);
+    }
+}
+
+class ConcreteAnalyzesEnvFiles
+{
+    use AnalyzesEnvFiles;
+
+    /**
+     * @return array{variables: array<string, string>, values: array<string, string>, error: string|null}
+     */
+    public function publicParseEnvFileWithErrors(string $filePath): array
+    {
+        return $this->parseEnvFileWithErrors($filePath);
+    }
+
+    /**
+     * @return array{variables: array<string, string>, error: string|null}
+     */
+    public function publicParseCommentedVariablesWithErrors(string $filePath): array
+    {
+        return $this->parseCommentedVariablesWithErrors($filePath);
+    }
+
+    /**
+     * @param  array<int, string>  $paths
+     */
+    protected function setPaths(array $paths): void {}
+
+    /**
+     * @return array<int, string>
+     */
+    protected function getPhpFiles(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Missing-from-`.env` variables are now graded by whether config supplies a real default:

- `env('KEY', $default)` in `config/` with a real default → no High issue; keys listed in result metadata (`defaulted_variables`). Opt-in `report_defaulted` flag elevates them to one Info issue.
- Bare `env('KEY')`, explicit `null` default, or keys never read in config (incl. `VITE_*`) → unchanged High `Missing environment variables` (message byte-identical, so existing baselines survive).
- New opt-in `report_redundant` flag (default off): reports `.env` values that restate the config default as Info — restated defaults silently pin stale values when the config default later changes.

Extracts the duplicated `.env` parser into a shared `AnalyzesEnvFiles` concern (built on `InspectsCode` for the `config/` AST scan — nested and multi-line `env()` calls included).

Rationale: a lean `.env` (overrides + secrets only) is framework-sanctioned — `env()`'s second argument is the official default mechanism, and config-owned defaults keep environments from forking. Enforcing full `.env.example ⊆ .env` parity made that style permanently red.
