### PR TITLE
feat: flag config env() keys undocumented in .env.example

### DIFF
--- a/src/Analyzers/Reliability/EnvExampleAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvExampleAnalyzer.php
@@ -8,24 +8,204 @@ use ShieldCI\AnalyzersCore\Abstracts\AbstractFileAnalyzer;
 use ShieldCI\AnalyzersCore\Contracts\ResultInterface;
 use ShieldCI\AnalyzersCore\Enums\Category;
 use ShieldCI\AnalyzersCore\Enums\Severity;
-use ShieldCI\AnalyzersCore\Support\FileParser;
 use ShieldCI\AnalyzersCore\ValueObjects\AnalyzerMetadata;
+use ShieldCI\AnalyzersCore\ValueObjects\Issue;
 use ShieldCI\AnalyzersCore\ValueObjects\Location;
+use ShieldCI\Concerns\AnalyzesEnvFiles;
 use ShieldCI\Concerns\DetectsDeploymentPlatform;
 
 /**
- * Checks that all environment variables from .env are documented in .env.example.
+ * Checks that .env.example documents the environment variables the
+ * application can use.
+ *
+ * Two directions feed the same documentation goal:
+ * - every variable set in .env must appear in .env.example, and
+ * - every env() key read by the app's own config/ files must appear in
+ *   .env.example (actively or commented out).
+ *
+ * Framework- and vendor-owned keys are exempt from the config direction:
+ * keys read by any installed package's own vendor config are recognized by
+ * provenance, and stock laravel/laravel skeleton keys by a built-in list.
  *
  * Checks for:
  * - All variables from .env are present in .env.example
+ * - env() keys read in config files are documented in .env.example
  * - Ensures .env.example serves as proper documentation
  * - Helps with team onboarding and deployment
  */
 class EnvExampleAnalyzer extends AbstractFileAnalyzer
 {
+    use AnalyzesEnvFiles;
     use DetectsDeploymentPlatform;
 
     public static bool $runInCI = false;
+
+    /**
+     * Every config env() key across laravel/laravel skeleton branches
+     * 9.x-13.x. Framework-owned keys are not the application's
+     * documentation debt, and on Laravel 9/10 the framework ships no
+     * vendor config stubs for the provenance check to find.
+     *
+     * Regenerate by fetching each skeleton config file from GitHub,
+     * flattening newlines (multi-line env() calls are real), and taking
+     * the sorted unique key set of:
+     * grep -oE "env\([[:space:]]*'[A-Za-z0-9_]+'"
+     */
+    private const BUILTIN_IGNORED_KEYS = [
+        'ABLY_KEY',
+        'APP_DEBUG',
+        'APP_ENV',
+        'APP_FAKER_LOCALE',
+        'APP_FALLBACK_LOCALE',
+        'APP_KEY',
+        'APP_LOCALE',
+        'APP_MAINTENANCE_DRIVER',
+        'APP_MAINTENANCE_STORE',
+        'APP_NAME',
+        'APP_PREVIOUS_KEYS',
+        'APP_URL',
+        'ASSET_URL',
+        'AUTH_GUARD',
+        'AUTH_MODEL',
+        'AUTH_PASSWORD_BROKER',
+        'AUTH_PASSWORD_RESET_TOKEN_TABLE',
+        'AUTH_PASSWORD_TIMEOUT',
+        'AWS_ACCESS_KEY_ID',
+        'AWS_BUCKET',
+        'AWS_DEFAULT_REGION',
+        'AWS_ENDPOINT',
+        'AWS_SECRET_ACCESS_KEY',
+        'AWS_URL',
+        'AWS_USE_PATH_STYLE_ENDPOINT',
+        'BCRYPT_ROUNDS',
+        'BEANSTALKD_QUEUE',
+        'BEANSTALKD_QUEUE_HOST',
+        'BEANSTALKD_QUEUE_RETRY_AFTER',
+        'BROADCAST_DRIVER',
+        'CACHE_DRIVER',
+        'CACHE_PREFIX',
+        'CACHE_STORAGE_DISK',
+        'CACHE_STORAGE_PATH',
+        'CACHE_STORE',
+        'DATABASE_URL',
+        'DB_CACHE_CONNECTION',
+        'DB_CACHE_LOCK_CONNECTION',
+        'DB_CACHE_LOCK_TABLE',
+        'DB_CACHE_TABLE',
+        'DB_CHARSET',
+        'DB_COLLATION',
+        'DB_CONNECTION',
+        'DB_DATABASE',
+        'DB_ENCRYPT',
+        'DB_FOREIGN_KEYS',
+        'DB_HOST',
+        'DB_PASSWORD',
+        'DB_PORT',
+        'DB_QUEUE',
+        'DB_QUEUE_CONNECTION',
+        'DB_QUEUE_RETRY_AFTER',
+        'DB_QUEUE_TABLE',
+        'DB_SOCKET',
+        'DB_SSLMODE',
+        'DB_TRUST_SERVER_CERTIFICATE',
+        'DB_URL',
+        'DB_USERNAME',
+        'DYNAMODB_CACHE_TABLE',
+        'DYNAMODB_ENDPOINT',
+        'FILESYSTEM_DISK',
+        'LOG_CHANNEL',
+        'LOG_DAILY_DAYS',
+        'LOG_DEPRECATIONS_CHANNEL',
+        'LOG_DEPRECATIONS_TRACE',
+        'LOG_LEVEL',
+        'LOG_PAPERTRAIL_HANDLER',
+        'LOG_SLACK_EMOJI',
+        'LOG_SLACK_USERNAME',
+        'LOG_SLACK_WEBHOOK_URL',
+        'LOG_STACK',
+        'LOG_STDERR_FORMATTER',
+        'LOG_SYSLOG_FACILITY',
+        'MAILGUN_DOMAIN',
+        'MAILGUN_ENDPOINT',
+        'MAILGUN_SECRET',
+        'MAIL_EHLO_DOMAIN',
+        'MAIL_ENCRYPTION',
+        'MAIL_FROM_ADDRESS',
+        'MAIL_FROM_NAME',
+        'MAIL_HOST',
+        'MAIL_LOG_CHANNEL',
+        'MAIL_MAILER',
+        'MAIL_PASSWORD',
+        'MAIL_PORT',
+        'MAIL_SCHEME',
+        'MAIL_SENDMAIL_PATH',
+        'MAIL_URL',
+        'MAIL_USERNAME',
+        'MEMCACHED_HOST',
+        'MEMCACHED_PASSWORD',
+        'MEMCACHED_PERSISTENT_ID',
+        'MEMCACHED_PORT',
+        'MEMCACHED_USERNAME',
+        'MYSQL_ATTR_SSL_CA',
+        'PAPERTRAIL_PORT',
+        'PAPERTRAIL_URL',
+        'POSTMARK_API_KEY',
+        'POSTMARK_MESSAGE_STREAM_ID',
+        'POSTMARK_TOKEN',
+        'PUSHER_APP_CLUSTER',
+        'PUSHER_APP_ID',
+        'PUSHER_APP_KEY',
+        'PUSHER_APP_SECRET',
+        'PUSHER_HOST',
+        'PUSHER_PORT',
+        'PUSHER_SCHEME',
+        'QUEUE_CONNECTION',
+        'QUEUE_FAILED_DRIVER',
+        'REDIS_BACKOFF_ALGORITHM',
+        'REDIS_BACKOFF_BASE',
+        'REDIS_BACKOFF_CAP',
+        'REDIS_CACHE_CONNECTION',
+        'REDIS_CACHE_DB',
+        'REDIS_CACHE_LOCK_CONNECTION',
+        'REDIS_CLIENT',
+        'REDIS_CLUSTER',
+        'REDIS_DB',
+        'REDIS_HOST',
+        'REDIS_MAX_RETRIES',
+        'REDIS_PASSWORD',
+        'REDIS_PERSISTENT',
+        'REDIS_PORT',
+        'REDIS_PREFIX',
+        'REDIS_QUEUE',
+        'REDIS_QUEUE_CONNECTION',
+        'REDIS_QUEUE_RETRY_AFTER',
+        'REDIS_URL',
+        'REDIS_USERNAME',
+        'RESEND_API_KEY',
+        'RESEND_KEY',
+        'SANCTUM_STATEFUL_DOMAINS',
+        'SANCTUM_TOKEN_PREFIX',
+        'SESSION_CONNECTION',
+        'SESSION_COOKIE',
+        'SESSION_DOMAIN',
+        'SESSION_DRIVER',
+        'SESSION_ENCRYPT',
+        'SESSION_EXPIRE_ON_CLOSE',
+        'SESSION_HTTP_ONLY',
+        'SESSION_LIFETIME',
+        'SESSION_PARTITIONED_COOKIE',
+        'SESSION_PATH',
+        'SESSION_SAME_SITE',
+        'SESSION_SECURE_COOKIE',
+        'SESSION_STORE',
+        'SESSION_TABLE',
+        'SLACK_BOT_USER_DEFAULT_CHANNEL',
+        'SLACK_BOT_USER_OAUTH_TOKEN',
+        'SQS_PREFIX',
+        'SQS_QUEUE',
+        'SQS_SUFFIX',
+        'VIEW_COMPILED_PATH',
+    ];
 
     public function shouldRun(): bool
     {
@@ -46,7 +226,7 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
         return new AnalyzerMetadata(
             id: 'env-example-documented',
             name: 'Environment Example Documentation Analyzer',
-            description: 'Ensures all environment variables used in .env are documented in .env.example',
+            description: 'Ensures all environment variables used in .env and read by config files are documented in .env.example',
             category: Category::Reliability,
             severity: Severity::Low,
             tags: ['environment', 'configuration', 'documentation', 'team-collaboration'],
@@ -60,8 +240,9 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
         $envPath = $this->getEnvPath($basePath);
         $envExamplePath = $this->getEnvExamplePath($basePath);
 
-        // Check if .env exists
-        if (! file_exists($envPath)) {
+        // With neither file present there is nothing to verify in either
+        // direction; matches the pre-config-direction behavior.
+        if (! file_exists($envPath) && ! file_exists($envExamplePath)) {
             return $this->warning('.env file not found - cannot verify documentation');
         }
 
@@ -79,20 +260,36 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
             );
         }
 
-        // Parse both files
-        $envVars = $this->parseEnvFile($envPath);
-        $exampleVars = $this->parseEnvFile($envExamplePath);
+        $exampleResult = $this->parseEnvFileWithErrors($envExamplePath);
+        $exampleVars = $exampleResult['error'] === null ? $exampleResult['variables'] : [];
+        $exampleCommented = $this->parseCommentedVariablesWithErrors($envExamplePath)['variables'];
+
+        // Config direction: env() keys read in config/ but not documented.
+        // Runs regardless of .env presence — it only needs code and .env.example.
+        $configIssues = $this->buildUndocumentedConfigKeyIssues($exampleVars, $exampleCommented);
+
+        // The .env direction needs an actual .env file
+        if (! file_exists($envPath)) {
+            if ($configIssues === []) {
+                return $this->warning('.env file not found - cannot verify documentation');
+            }
+
+            return $this->resultBySeverity(
+                sprintf('Found %d undocumented environment variable(s)', count($configIssues)),
+                $configIssues
+            );
+        }
+
+        $envResult = $this->parseEnvFileWithErrors($envPath);
+        $envVars = $envResult['error'] === null ? $envResult['variables'] : [];
 
         // Find undocumented variables (in .env but not in .env.example)
         $undocumentedVars = array_diff_key($envVars, $exampleVars);
 
-        if (empty($undocumentedVars)) {
-            return $this->passed('All environment variables are documented in .env.example');
-        }
+        $issues = $configIssues;
 
-        return $this->resultBySeverity(
-            sprintf('Found %d undocumented environment variable(s)', count($undocumentedVars)),
-            [$this->createIssueWithSnippet(
+        if (! empty($undocumentedVars)) {
+            $issues[] = $this->createIssueWithSnippet(
                 message: 'Undocumented environment variables',
                 filePath: $envExamplePath,
                 lineNumber: null,
@@ -105,8 +302,103 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
                     'undocumented_variables' => array_keys($undocumentedVars),
                     'code' => 'undocumented-variables',
                 ]
-            )]
+            );
+        }
+
+        if ($issues === []) {
+            return $this->passed('All environment variables are documented in .env.example');
+        }
+
+        $totalCount = count($configIssues) + count($undocumentedVars);
+
+        return $this->resultBySeverity(
+            sprintf('Found %d undocumented environment variable(s)', $totalCount),
+            $issues
         );
+    }
+
+    /**
+     * Build one Medium issue per env() key read in config/ that .env.example
+     * does not document (actively or commented) and no exemption covers.
+     *
+     * @param  array<string, string>  $exampleVars
+     * @param  array<string, string>  $exampleCommented
+     * @return array<int, Issue>
+     */
+    private function buildUndocumentedConfigKeyIssues(array $exampleVars, array $exampleCommented): array
+    {
+        $usages = $this->collectConfigEnvKeyUsages();
+
+        if ($usages === []) {
+            return [];
+        }
+
+        $vendorKeys = $this->collectVendorConfigEnvKeys();
+        $ignoredKeys = $this->loadIgnoredKeys();
+
+        $issues = [];
+
+        foreach ($usages as $key => $usage) {
+            if (isset($exampleVars[$key]) || isset($exampleCommented[$key]) || isset($vendorKeys[$key])) {
+                continue;
+            }
+
+            if ($this->isIgnoredKey($key, $ignoredKeys)) {
+                continue;
+            }
+
+            $issues[] = $this->createIssueWithSnippet(
+                message: sprintf("Environment variable '%s' is read in config files but not documented in .env.example", $key),
+                filePath: $usage['file'],
+                lineNumber: $usage['line'],
+                severity: Severity::Medium,
+                recommendation: $this->buildUndocumentedConfigKeyRecommendation($key),
+                metadata: [
+                    'key' => $key,
+                    'has_config_default' => $usage['hasDefault'],
+                    'code' => 'undocumented-config-key',
+                ]
+            );
+        }
+
+        return $issues;
+    }
+
+    /**
+     * Merge the built-in framework key list with per-project ignores.
+     *
+     * @return array<int, string>
+     */
+    private function loadIgnoredKeys(): array
+    {
+        $configured = config('shieldci.analyzers.reliability.env-example-documented.ignored_keys', []);
+
+        if (! is_array($configured)) {
+            $configured = [];
+        }
+
+        return array_values(array_unique(array_merge(
+            self::BUILTIN_IGNORED_KEYS,
+            array_filter($configured, 'is_string')
+        )));
+    }
+
+    /**
+     * @param  array<int, string>  $ignoredKeys
+     */
+    private function isIgnoredKey(string $key, array $ignoredKeys): bool
+    {
+        foreach ($ignoredKeys as $pattern) {
+            if ($pattern === $key) {
+                return true;
+            }
+
+            if (str_contains($pattern, '*') && fnmatch($pattern, $key)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -164,47 +456,16 @@ RECOMMENDATION,
     }
 
     /**
-     * Parse environment file and return key-value pairs.
-     *
-     * @return array<string, string>
+     * Build recommendation message for a config-read key missing from .env.example.
      */
-    private function parseEnvFile(string $filePath): array
+    private function buildUndocumentedConfigKeyRecommendation(string $key): string
     {
-        if (! file_exists($filePath) || ! is_readable($filePath)) {
-            return [];
-        }
-
-        try {
-            $lines = FileParser::getLines($filePath);
-        } catch (\Throwable $e) {
-            return [];
-        }
-
-        if (empty($lines)) {
-            return [];
-        }
-
-        $variables = [];
-
-        foreach ($lines as $line) {
-            if (! is_string($line)) {
-                continue;
-            }
-
-            $line = trim($line);
-
-            // Skip empty lines and comments
-            if ($line === '' || str_starts_with($line, '#')) {
-                continue;
-            }
-
-            // Parse KEY=VALUE format
-            if (preg_match('/^([A-Z_][A-Z0-9_]*)\s*=/', $line, $matches)) {
-                $key = $matches[1];
-                $variables[$key] = $line;
-            }
-        }
-
-        return $variables;
+        return sprintf(
+            <<<'RECOMMENDATION'
+The %s environment variable is read by a config file but does not appear in .env.example.
+Add it to .env.example (actively or commented out) so other developers can see it is available for configuration.
+RECOMMENDATION,
+            $key,
+        );
     }
 }

--- a/src/Concerns/AnalyzesEnvFiles.php
+++ b/src/Concerns/AnalyzesEnvFiles.php
@@ -20,6 +20,8 @@ trait AnalyzesEnvFiles
 {
     use InspectsCode;
 
+    abstract protected function getBasePath(): string;
+
     /**
      * Parse environment file and return key-value pairs with error tracking.
      *
@@ -152,6 +154,49 @@ trait AnalyzesEnvFiles
         }
 
         return $usages;
+    }
+
+    /**
+     * Harvest the env() key names read by installed packages' own config
+     * files (vendor/{vendor}/{package}/config/*.php, which on Laravel 11+
+     * also covers vendor/laravel/framework/config).
+     *
+     * A published vendor config's keys are vendor-owned: they are not the
+     * application's documentation debt, so completeness checks should never
+     * flag them. Keys the app ADDS to a published copy are absent from the
+     * vendor original and stay visible.
+     *
+     * Uses a regex rather than the AST: only key names are needed here, and
+     * PCRE \s spans newlines so multi-line env() calls are matched.
+     *
+     * @return array<string, true>
+     */
+    protected function collectVendorConfigEnvKeys(): array
+    {
+        $basePath = $this->getBasePath();
+
+        if ($basePath === '') {
+            return [];
+        }
+
+        $keys = [];
+        $files = glob($basePath.'/vendor/*/*/config/*.php') ?: [];
+
+        foreach ($files as $file) {
+            $contents = @file_get_contents($file);
+
+            if ($contents === false) {
+                continue;
+            }
+
+            if (preg_match_all("/env\\(\\s*'([A-Za-z0-9_]+)'/", $contents, $matches) > 0) {
+                foreach ($matches[1] as $key) {
+                    $keys[$key] = true;
+                }
+            }
+        }
+
+        return $keys;
     }
 
     /**

--- a/tests/Unit/Analyzers/Reliability/EnvExampleAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/EnvExampleAnalyzerTest.php
@@ -583,4 +583,251 @@ app_name=lowercase';
 
         $this->assertFalse($analyzer->shouldRun());
     }
+
+    // =========================================================================
+    // Config → .env.example Completeness Tests
+    // =========================================================================
+
+    public function test_flags_config_key_undocumented_in_env_example(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'APP_NAME=Laravel',
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        $this->assertSame(
+            "Environment variable 'WIDGET_MAX_SEATS' is read in config files but not documented in .env.example",
+            $issues[0]->message
+        );
+        $this->assertSame('medium', $issues[0]->severity->value);
+        $this->assertSame('undocumented-config-key', $issues[0]->metadata['code']);
+        $this->assertSame('WIDGET_MAX_SEATS', $issues[0]->metadata['key']);
+        $this->assertTrue($issues[0]->metadata['has_config_default']);
+        $this->assertNotNull($issues[0]->location);
+        $this->assertStringContainsString('config/widget.php', $issues[0]->location->file);
+        $this->assertGreaterThan(0, $issues[0]->location->line);
+    }
+
+    public function test_passes_when_config_key_documented_active(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nWIDGET_MAX_SEATS=1000",
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_passes_when_config_key_documented_as_commented(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\n# WIDGET_MAX_SEATS=1000",
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+    }
+
+    public function test_builtin_skeleton_keys_are_not_flagged(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "CACHE_DRIVER=file\nQUEUE_CONNECTION=sync\nSESSION_DRIVER=file\nSESSION_LIFETIME=120\nMEMCACHED_HOST=127.0.0.1",
+            '.env' => "CACHE_DRIVER=file\nQUEUE_CONNECTION=sync\nSESSION_DRIVER=file\nSESSION_LIFETIME=120\nMEMCACHED_HOST=127.0.0.1",
+            'config/cache.php' => "<?php\n\nreturn ['default' => env('CACHE_DRIVER', 'file'), 'prefix' => env('CACHE_PREFIX', 'laravel'), 'memcached' => ['host' => env('MEMCACHED_HOST', '127.0.0.1'), 'port' => env('MEMCACHED_PORT', 11211), 'username' => env('MEMCACHED_USERNAME'), 'password' => env('MEMCACHED_PASSWORD')]];",
+            'config/queue.php' => "<?php\n\nreturn ['default' => env('QUEUE_CONNECTION', 'sync'), 'sqs' => ['prefix' => env('SQS_PREFIX'), 'queue' => env('SQS_QUEUE', 'default'), 'suffix' => env('SQS_SUFFIX')]];",
+            'config/session.php' => "<?php\n\nreturn ['driver' => env('SESSION_DRIVER', 'file'), 'lifetime' => env('SESSION_LIFETIME', 120), 'cookie' => env(\n    'SESSION_COOKIE',\n    'laravel-session'\n)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertEmpty($result->getIssues());
+    }
+
+    public function test_project_ignored_keys_suppress_findings(): void
+    {
+        config(['shieldci.analyzers.reliability.env-example-documented.ignored_keys' => [
+            'WIDGET_MAX_SEATS',
+            'ACME_*',
+            42,
+        ]]);
+
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'APP_NAME=Laravel',
+            '.env' => 'APP_NAME=MyApp',
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000), 'timeout' => env('ACME_TIMEOUT', 30), 'label' => env('WIDGET_LABEL', 'widgets')];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('WIDGET_LABEL', $issues[0]->metadata['key']);
+    }
+
+    public function test_vendor_shipped_config_keys_are_not_flagged(): void
+    {
+        $vendorConfig = "<?php\n\nreturn ['timeout' => env(\n    'ACME_WIDGET_TIMEOUT',\n    30\n)];";
+
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'APP_NAME=Laravel',
+            '.env' => 'APP_NAME=MyApp',
+            'vendor/acme/widget/config/widget.php' => $vendorConfig,
+            'config/widget.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT', 30)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertEmpty($result->getIssues());
+    }
+
+    public function test_unreadable_vendor_config_falls_back_to_flagging(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'APP_NAME=Laravel',
+            '.env' => 'APP_NAME=MyApp',
+            'vendor/acme/widget/config/widget.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT', 30)];",
+            'config/widget.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT', 30)];",
+        ]);
+
+        $vendorConfigPath = $tempDir.'/vendor/acme/widget/config/widget.php';
+        chmod($vendorConfigPath, 0000);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        // Restore permissions for cleanup
+        chmod($vendorConfigPath, 0644);
+
+        $this->assertWarning($result);
+        $this->assertSame('ACME_WIDGET_TIMEOUT', $result->getIssues()[0]->metadata['key']);
+    }
+
+    public function test_app_added_key_in_published_config_is_flagged(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'APP_NAME=Laravel',
+            '.env' => 'APP_NAME=MyApp',
+            'vendor/acme/widget/config/widget.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT', 30)];",
+            'config/widget.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT', 30), 'custom' => env('ACME_WIDGET_CUSTOM', 5)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('ACME_WIDGET_CUSTOM', $issues[0]->metadata['key']);
+    }
+
+    public function test_config_direction_runs_when_env_missing(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'APP_NAME=Laravel',
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issues = $result->getIssues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('undocumented-config-key', $issues[0]->metadata['code']);
+    }
+
+    public function test_env_missing_with_clean_config_keeps_existing_warning(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => "APP_NAME=Laravel\nWIDGET_MAX_SEATS=1000",
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $this->assertEmpty($result->getIssues());
+        $this->assertStringContainsString('.env file not found', $result->getMessage());
+    }
+
+    public function test_both_directions_report_combined_issues(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'APP_NAME=Laravel',
+            '.env' => "APP_NAME=MyApp\nACME_UNDOCUMENTED=1",
+            'config/widget.php' => "<?php\n\nreturn ['seats' => env('WIDGET_MAX_SEATS', 1000)];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $issues = $result->getIssues();
+        $this->assertCount(2, $issues);
+
+        $codes = array_map(static fn ($issue) => $issue->metadata['code'], $issues);
+        $this->assertContains('undocumented-config-key', $codes);
+        $this->assertContains('undocumented-variables', $codes);
+    }
+
+    public function test_bare_config_key_reports_has_config_default_false(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'APP_NAME=Laravel',
+            '.env' => 'APP_NAME=MyApp',
+            'config/services.php' => "<?php\n\nreturn ['key' => env('ACME_SECRET_KEY')];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertWarning($result);
+        $this->assertFalse($result->getIssues()[0]->metadata['has_config_default']);
+    }
 }

--- a/tests/Unit/Concerns/AnalyzesEnvFilesTest.php
+++ b/tests/Unit/Concerns/AnalyzesEnvFilesTest.php
@@ -29,6 +29,13 @@ class AnalyzesEnvFilesTest extends TestCase
         $this->assertNull($result['error']);
         $this->assertSame([], $result['variables']);
     }
+
+    public function test_vendor_key_harvest_returns_empty_without_base_path(): void
+    {
+        $harness = new ConcreteAnalyzesEnvFiles;
+
+        $this->assertSame([], $harness->publicCollectVendorConfigEnvKeys());
+    }
 }
 
 class ConcreteAnalyzesEnvFiles
@@ -49,6 +56,19 @@ class ConcreteAnalyzesEnvFiles
     public function publicParseCommentedVariablesWithErrors(string $filePath): array
     {
         return $this->parseCommentedVariablesWithErrors($filePath);
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    public function publicCollectVendorConfigEnvKeys(): array
+    {
+        return $this->collectVendorConfigEnvKeys();
+    }
+
+    protected function getBasePath(): string
+    {
+        return '';
     }
 
     /**


### PR DESCRIPTION
Stacked on #317.

Adds the missing direction to `env-example-documented`: every `env()` key read by the app's own `config/` files must appear in `.env.example` (actively or commented). One Medium issue per key, anchored at the config `file:line` of first use so findings baseline individually. Result stays a warning, never red.

Noise control, three layers:
- **Vendor provenance (dynamic)**: keys read by any installed package's own `vendor/*/*/config/*.php` are vendor-owned and never flagged — covers every package that publishes a config, without curation. Keys the app adds to a published copy remain visible.
- **Built-in skeleton list (static)**: all 153 config `env()` keys across laravel/laravel 9.x–13.x (derived, exact keys — no prefix wildcards, so project keys sharing a prefix stay flaggable). Needed because `laravel/framework` only ships vendor config stubs from 11.x.
- **Per-project** `ignored_keys` (exact or `fnmatch` wildcards).

A fresh Laravel skeleton on any supported version reports zero findings out of the box.
