### PR TITLE
fix: exempt bare env() keys read in vendor-named config files

### DIFF
--- a/src/Analyzers/Reliability/EnvExampleAnalyzer.php
+++ b/src/Analyzers/Reliability/EnvExampleAnalyzer.php
@@ -28,8 +28,11 @@ use ShieldCI\Concerns\DetectsDeploymentPlatform;
  * it stays voluntary; a bare env('KEY') or explicit null default reads null
  * when unset, making the key a required input worth documenting. Bare keys
  * that any installed package's own vendor config also reads are
- * vendor-owned and exempt; the direction is skipped on Laravel 9/10, which
- * ship no framework config stubs for that comparison.
+ * vendor-owned and exempt, as are bare keys read in an app config file
+ * whose basename matches a vendor config file (stock-file territory, where
+ * skeleton and vendor stubs drift apart key by key); the direction is
+ * skipped on Laravel 9/10, which ship no framework config stubs for those
+ * comparisons.
  *
  * Checks for:
  * - All variables from .env are present in .env.example
@@ -179,6 +182,7 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
         }
 
         $vendorKeys = $this->collectVendorConfigEnvKeys();
+        $vendorFileNames = $this->collectVendorConfigFileNames();
         $ignoredKeys = $this->loadIgnoredKeys();
 
         $issues = [];
@@ -191,6 +195,16 @@ class EnvExampleAnalyzer extends AbstractFileAnalyzer
             }
 
             if (isset($exampleVars[$key]) || isset($exampleCommented[$key]) || isset($vendorKeys[$key])) {
+                continue;
+            }
+
+            // A key read in a config file sharing a vendor config's basename
+            // (services.php, mail.php, filesystems.php, ...) is stock-file
+            // territory: skeleton files drift from vendor stubs key by key,
+            // and optional per-service settings there are legitimately null.
+            // Custom keys in such files are still caught by the .env
+            // direction once they are set.
+            if (isset($vendorFileNames[basename($usage['file'])])) {
                 continue;
             }
 

--- a/src/Concerns/AnalyzesEnvFiles.php
+++ b/src/Concerns/AnalyzesEnvFiles.php
@@ -200,6 +200,34 @@ trait AnalyzesEnvFiles
     }
 
     /**
+     * Collect the basenames of installed packages' config files
+     * (vendor/{vendor}/{package}/config/*.php, framework stubs included).
+     *
+     * A key read in an app config file sharing a vendor config's basename
+     * lives in stock-file territory, where skeleton and vendor stubs drift
+     * apart key by key (a skeleton services.php reads keys no framework
+     * stub does), so name-level provenance is the drift-proof signal.
+     *
+     * @return array<string, true>
+     */
+    protected function collectVendorConfigFileNames(): array
+    {
+        $basePath = $this->getBasePath();
+
+        if ($basePath === '') {
+            return [];
+        }
+
+        $names = [];
+
+        foreach (glob($basePath.'/vendor/*/*/config/*.php') ?: [] as $file) {
+            $names[basename($file)] = true;
+        }
+
+        return $names;
+    }
+
+    /**
      * Classify the default argument of an env() call.
      *
      * Works from the raw AST node because InspectsCode extracts both a

--- a/tests/Unit/Analyzers/Reliability/EnvExampleAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Reliability/EnvExampleAnalyzerTest.php
@@ -595,7 +595,7 @@ app_name=lowercase';
         $tempDir = $this->createTempDirectory([
             '.env.example' => 'APP_NAME=Laravel',
             '.env' => 'APP_NAME=MyApp',
-            'config/services.php' => "<?php\n\nreturn ['acme' => ['key' => env('ACME_API_KEY')]];",
+            'config/acme.php' => "<?php\n\nreturn ['acme' => ['key' => env('ACME_API_KEY')]];",
             'vendor/laravel/framework/config/app.php' => self::FRAMEWORK_STUB,
         ]);
 
@@ -615,7 +615,7 @@ app_name=lowercase';
         $this->assertSame('undocumented-config-key', $issues[0]->metadata['code']);
         $this->assertSame('ACME_API_KEY', $issues[0]->metadata['key']);
         $this->assertNotNull($issues[0]->location);
-        $this->assertStringContainsString('config/services.php', $issues[0]->location->file);
+        $this->assertStringContainsString('config/acme.php', $issues[0]->location->file);
         $this->assertGreaterThan(0, $issues[0]->location->line);
     }
 
@@ -642,7 +642,7 @@ app_name=lowercase';
         $tempDir = $this->createTempDirectory([
             '.env.example' => 'APP_NAME=Laravel',
             '.env' => 'APP_NAME=MyApp',
-            'config/services.php' => "<?php\n\nreturn ['key' => env('ACME_SECRET_KEY', null)];",
+            'config/acme.php' => "<?php\n\nreturn ['key' => env('ACME_SECRET_KEY', null)];",
             'vendor/laravel/framework/config/app.php' => self::FRAMEWORK_STUB,
         ]);
 
@@ -677,7 +677,7 @@ app_name=lowercase';
         $tempDir = $this->createTempDirectory([
             '.env.example' => "APP_NAME=Laravel\nACME_API_KEY=",
             '.env' => 'APP_NAME=MyApp',
-            'config/services.php' => "<?php\n\nreturn ['key' => env('ACME_API_KEY')];",
+            'config/acme.php' => "<?php\n\nreturn ['key' => env('ACME_API_KEY')];",
             'vendor/laravel/framework/config/app.php' => self::FRAMEWORK_STUB,
         ]);
 
@@ -694,7 +694,7 @@ app_name=lowercase';
         $tempDir = $this->createTempDirectory([
             '.env.example' => "APP_NAME=Laravel\n# ACME_API_KEY=",
             '.env' => 'APP_NAME=MyApp',
-            'config/services.php' => "<?php\n\nreturn ['key' => env('ACME_API_KEY')];",
+            'config/acme.php' => "<?php\n\nreturn ['key' => env('ACME_API_KEY')];",
             'vendor/laravel/framework/config/app.php' => self::FRAMEWORK_STUB,
         ]);
 
@@ -731,7 +731,7 @@ app_name=lowercase';
         $tempDir = $this->createTempDirectory([
             '.env.example' => 'APP_NAME=Laravel',
             '.env' => 'APP_NAME=MyApp',
-            'config/services.php' => "<?php\n\nreturn ['key' => env('ACME_API_KEY')];",
+            'config/acme.php' => "<?php\n\nreturn ['key' => env('ACME_API_KEY')];",
         ]);
 
         $analyzer = $this->createAnalyzer();
@@ -775,7 +775,7 @@ app_name=lowercase';
             '.env.example' => 'APP_NAME=Laravel',
             '.env' => 'APP_NAME=MyApp',
             'vendor/acme/widget/config/widget.php' => "<?php\n\nreturn ['timeout' => env(\n    'ACME_WIDGET_TIMEOUT'\n)];",
-            'config/widget.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT')];",
+            'config/custom.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT')];",
             'vendor/laravel/framework/config/app.php' => self::FRAMEWORK_STUB,
         ]);
 
@@ -794,7 +794,7 @@ app_name=lowercase';
             '.env.example' => 'APP_NAME=Laravel',
             '.env' => 'APP_NAME=MyApp',
             'vendor/acme/widget/config/widget.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT')];",
-            'config/widget.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT')];",
+            'config/custom.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT')];",
             'vendor/laravel/framework/config/app.php' => self::FRAMEWORK_STUB,
         ]);
 
@@ -813,13 +813,31 @@ app_name=lowercase';
         $this->assertSame('ACME_WIDGET_TIMEOUT', $result->getIssues()[0]->metadata['key']);
     }
 
-    public function test_app_added_bare_key_in_published_config_is_flagged(): void
+    public function test_bare_key_in_vendor_named_config_file_is_not_flagged(): void
     {
         $tempDir = $this->createTempDirectory([
             '.env.example' => 'APP_NAME=Laravel',
             '.env' => 'APP_NAME=MyApp',
-            'vendor/acme/widget/config/widget.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT')];",
-            'config/widget.php' => "<?php\n\nreturn ['timeout' => env('ACME_WIDGET_TIMEOUT'), 'custom' => env('ACME_WIDGET_CUSTOM')];",
+            'config/services.php' => "<?php\n\nreturn ['mailer' => ['key' => env('ACME_MAIL_KEY')]];",
+            'vendor/laravel/framework/config/services.php' => "<?php\n\nreturn ['mailer' => ['key' => env('OTHER_MAIL_KEY')]];",
+        ]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+
+        $result = $analyzer->analyze();
+
+        $this->assertPassed($result);
+        $this->assertEmpty($result->getIssues());
+    }
+
+    public function test_custom_disk_keys_in_vendor_named_filesystems_config_are_not_flagged(): void
+    {
+        $tempDir = $this->createTempDirectory([
+            '.env.example' => 'APP_NAME=Laravel',
+            '.env' => 'APP_NAME=MyApp',
+            'config/filesystems.php' => "<?php\n\nreturn ['disks' => ['acme' => ['url' => env('ACME_DISK_URL'), 'endpoint' => env('ACME_DISK_ENDPOINT')]]];",
+            'vendor/laravel/framework/config/filesystems.php' => "<?php\n\nreturn ['disks' => ['local' => ['serve' => env('FILESYSTEM_SERVE', true)]]];",
             'vendor/laravel/framework/config/app.php' => self::FRAMEWORK_STUB,
         ]);
 
@@ -828,17 +846,15 @@ app_name=lowercase';
 
         $result = $analyzer->analyze();
 
-        $this->assertWarning($result);
-        $issues = $result->getIssues();
-        $this->assertCount(1, $issues);
-        $this->assertSame('ACME_WIDGET_CUSTOM', $issues[0]->metadata['key']);
+        $this->assertPassed($result);
+        $this->assertEmpty($result->getIssues());
     }
 
     public function test_config_direction_runs_when_env_missing(): void
     {
         $tempDir = $this->createTempDirectory([
             '.env.example' => 'APP_NAME=Laravel',
-            'config/services.php' => "<?php\n\nreturn ['key' => env('ACME_API_KEY')];",
+            'config/acme.php' => "<?php\n\nreturn ['key' => env('ACME_API_KEY')];",
             'vendor/laravel/framework/config/app.php' => self::FRAMEWORK_STUB,
         ]);
 
@@ -876,7 +892,7 @@ app_name=lowercase';
         $tempDir = $this->createTempDirectory([
             '.env.example' => 'APP_NAME=Laravel',
             '.env' => "APP_NAME=MyApp\nACME_UNDOCUMENTED=1",
-            'config/services.php' => "<?php\n\nreturn ['key' => env('ACME_API_KEY')];",
+            'config/acme.php' => "<?php\n\nreturn ['key' => env('ACME_API_KEY')];",
             'vendor/laravel/framework/config/app.php' => self::FRAMEWORK_STUB,
         ]);
 

--- a/tests/Unit/Concerns/AnalyzesEnvFilesTest.php
+++ b/tests/Unit/Concerns/AnalyzesEnvFilesTest.php
@@ -36,6 +36,13 @@ class AnalyzesEnvFilesTest extends TestCase
 
         $this->assertSame([], $harness->publicCollectVendorConfigEnvKeys());
     }
+
+    public function test_vendor_file_name_harvest_returns_empty_without_base_path(): void
+    {
+        $harness = new ConcreteAnalyzesEnvFiles;
+
+        $this->assertSame([], $harness->publicCollectVendorConfigFileNames());
+    }
 }
 
 class ConcreteAnalyzesEnvFiles
@@ -64,6 +71,14 @@ class ConcreteAnalyzesEnvFiles
     public function publicCollectVendorConfigEnvKeys(): array
     {
         return $this->collectVendorConfigEnvKeys();
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    public function publicCollectVendorConfigFileNames(): array
+    {
+        return $this->collectVendorConfigFileNames();
     }
 
     protected function getBasePath(): string


### PR DESCRIPTION
Fixes the `POSTMARK_API_KEY` class of findings: Laravel's skeleton config files drift from the framework's vendor stubs key by key (skeleton `services.php` reads `POSTMARK_API_KEY`; the stub still reads `POSTMARK_TOKEN`), so key-level vendor provenance cannot cover stock files, and every fresh Laravel 12/13 app was flagged for mailer creds it may never use.

A bare key read in an app config file whose basename matches any installed vendor config file (`services.php`, `mail.php`, `filesystems.php`, ...) is now exempt. Stock-file territory hosts optional per-service settings that are legitimately null when unused, including custom additions like extra S3 disk `url`/`endpoint` keys; those stay covered by the `.env` direction once set. Custom-named config files remain fully checked.