### PR TITLE
fix: exclude single-line script tag attributes from JS-injection scanning

### DIFF
--- a/src/Analyzers/Security/XssAnalyzer.php
+++ b/src/Analyzers/Security/XssAnalyzer.php
@@ -200,12 +200,23 @@ class XssAnalyzer extends AbstractFileAnalyzer
                 $hasOpeningTag = preg_match('/<script[^>]*>/', $line);
                 $hasClosingTag = str_contains($line, '</script>');
 
+                // Text used by the JS-injection heuristic below (~line 291+). Defaults to the
+                // raw line; narrowed to the script body only for the single-line
+                // <script ...>...</script> case so the opening tag's own HTML attributes
+                // (e.g. a CSP nonce) are never mistaken for JavaScript source.
+                $scriptCheckText = $line;
+
                 $exitScriptAfterLine = false;
                 if ($hasOpeningTag && $hasClosingTag) {
                     // Single-line <script>...</script> - treat content as inside script
                     // (will be checked in the inScriptTag section)
                     $inScriptTag = true;
                     $exitScriptAfterLine = true;
+
+                    // Strip everything through the opening tag's own closing '>' so the
+                    // check below sees only the script body, not the <script ...> tag's
+                    // own attribute values.
+                    $scriptCheckText = preg_replace('/^.*?<script[^>]*>/', '', $line) ?? $line;
                 } elseif ($hasOpeningTag) {
                     // Opening tag without closing - enter script block
                     $inScriptTag = true;
@@ -287,14 +298,17 @@ class XssAnalyzer extends AbstractFileAnalyzer
                 $attributeIssues = $this->checkHtmlAttributeContext($line, $file, $lineNumber);
                 $issues = array_merge($issues, $attributeIssues);
 
-                // Check for dangerous JavaScript output when inside script tags
-                $isBladeOutput = preg_match('/\{\{.*?\}\}|\{!!.*?!!\}/', $line);
-                $isRawBlade = preg_match('/\{!!.*?!!\}/', $line);
-                $isTainted = $this->mightContainUserInput($line);
-                $isEncoded = preg_match('/@json\s*\(|json_encode\s*\(|Js::from\s*\(/', $line);
-                $isJsString = preg_match('/([=\(,]\s*[\'"]\s*\{\{.*?\}\}\s*[\'"])/', $line);
+                // Check for dangerous JavaScript output when inside script tags.
+                // Uses $scriptCheckText (script body only for the single-line case) rather
+                // than $line, so a single-line <script ...> tag's own HTML attributes are
+                // never treated as JavaScript source.
+                $isBladeOutput = preg_match('/\{\{.*?\}\}|\{!!.*?!!\}/', $scriptCheckText);
+                $isRawBlade = preg_match('/\{!!.*?!!\}/', $scriptCheckText);
+                $isTainted = $this->mightContainUserInput($scriptCheckText);
+                $isEncoded = preg_match('/@json\s*\(|json_encode\s*\(|Js::from\s*\(/', $scriptCheckText);
+                $isJsString = preg_match('/([=\(,]\s*[\'"]\s*\{\{.*?\}\}\s*[\'"])/', $scriptCheckText);
                 if ($inScriptTag && ! $rawBladeMatched && $isBladeOutput && $isTainted && ! $isEncoded
-                    && ! $this->allBladeExpressionsAreLiteralOutputs($line)) {
+                    && ! $this->allBladeExpressionsAreLiteralOutputs($scriptCheckText)) {
                     // Check for unescaped Blade output or superglobals in JavaScript
                     $severity = $isRawBlade || $isJsString
                         ? Severity::Critical

--- a/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Security/XssAnalyzerTest.php
@@ -1199,6 +1199,10 @@ BLADE;
 
         $this->assertFailed($result);
         $this->assertHasIssueContaining('src attribute', $result);
+        // Locks in the fix: only the legitimate "src attribute" issue should remain, the
+        // spurious "JavaScript string context" issue (from the <script ...> tag's own
+        // attributes being scanned as JS body) must not reappear.
+        $this->assertIssueCount(1, $result);
     }
 
     public function test_detects_unescaped_output_in_data_attributes(): void
@@ -1755,5 +1759,46 @@ BLADE;
 
         // urlencode makes user input safe in src attribute
         $this->assertPassed($result);
+    }
+
+    public function test_does_not_flag_nonce_attribute_on_single_line_script_tag(): void
+    {
+        $bladeCode = <<<'BLADE'
+<script src="/assets/app.js" nonce="{{ request()->attributes->get('csp_nonce', '') }}"></script>
+BLADE;
+
+        $tempDir = $this->createTempDirectory(['nonce-script.blade.php' => $bladeCode]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // The nonce is a request *attribute* (set by first-party middleware), not user
+        // input, and it lives in the <script> tag's own HTML attribute, never executed
+        // as JavaScript. This must not be flagged as JS-context injection.
+        $this->assertPassed($result);
+    }
+
+    public function test_still_flags_user_input_in_single_line_script_body_with_attributes(): void
+    {
+        $bladeCode = <<<'BLADE'
+<script src="/assets/app.js">var x = {{ request('x') }};</script>
+BLADE;
+
+        $tempDir = $this->createTempDirectory(['tainted-body-with-attrs.blade.php' => $bladeCode]);
+
+        $analyzer = $this->createAnalyzer();
+        $analyzer->setBasePath($tempDir);
+        $analyzer->setPaths(['.']);
+
+        $result = $analyzer->analyze();
+
+        // A tainted script *body* must still be flagged even when the tag carries its own
+        // (safe) attributes, confirms the fix scopes to "after the tag's own '>'", not to
+        // "the whole tag line is exempt."
+        $this->assertFailed($result);
+        $this->assertHasIssueContaining('JavaScript', $result);
     }
 }


### PR DESCRIPTION
## Summary
- Single-line `<script attrs>body</script>` tags had their own opening-tag attributes (e.g. a `nonce` containing a Blade expression) scanned by the JS-injection heuristic as if they were JavaScript body content, causing a false "User input injected into JavaScript string context" finding
- Multi-line script tags were already unaffected, since the opening tag's attribute line is skipped by the scanner; this aligns single-line handling with that same body-only scoping
- A genuinely tainted script body is still flagged even when the tag carries its own attributes